### PR TITLE
fix: allow all hosts in vite dev server

### DIFF
--- a/twag/web/frontend/vite.config.ts
+++ b/twag/web/frontend/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 8080,
+    allowedHosts: true,
     proxy: {
       "/api": {
         target: "http://localhost:5173",


### PR DESCRIPTION
- set allowedHosts to true in vite config to prevent host header validation errors when accessing via external IPs or tunnels