### PR TITLE
Unify analyze and digest long-form article section formatting

### DIFF
--- a/tests/test_article_sections.py
+++ b/tests/test_article_sections.py
@@ -1,0 +1,75 @@
+"""Unit tests for shared article section parsing helpers."""
+
+import json
+
+from twag.article_sections import format_confidence, normalize_horizon, parse_action_items, parse_primary_points
+
+
+def test_parse_primary_points_filters_invalid_entries():
+    payload = json.dumps(
+        [
+            {
+                "point": "Google capex is entering a new regime.",
+                "reasoning": "Demand backlog supports accelerated deployment.",
+                "evidence": "$240B backlog and strong cloud growth.",
+            },
+            {"point": "", "reasoning": "invalid"},
+            {"reasoning": "missing point"},
+            "not-a-dict",
+        ]
+    )
+
+    points = parse_primary_points(payload)
+
+    assert points == [
+        {
+            "point": "Google capex is entering a new regime.",
+            "reasoning": "Demand backlog supports accelerated deployment.",
+            "evidence": "$240B backlog and strong cloud growth.",
+        }
+    ]
+
+
+def test_parse_action_items_normalizes_horizon_confidence_and_tickers():
+    payload = json.dumps(
+        [
+            {
+                "action": "Track quarterly GCP growth and backlog trends.",
+                "trigger": "Growth below 30% plus backlog stall.",
+                "horizon": "medium_term",
+                "confidence": 0.65,
+                "tickers": ["GOOGL", " MSFT ", "", "AMZN"],
+            },
+            {"action": "", "trigger": "invalid"},
+            {"trigger": "missing action"},
+        ]
+    )
+
+    actions = parse_action_items(payload)
+
+    assert actions == [
+        {
+            "action": "Track quarterly GCP growth and backlog trends.",
+            "trigger": "Growth below 30% plus backlog stall.",
+            "horizon": "medium term",
+            "confidence": "0.65",
+            "tickers": "GOOGL, MSFT, AMZN",
+        }
+    ]
+
+
+def test_parse_action_items_handles_missing_or_bad_json():
+    assert parse_action_items(None) == []
+    assert parse_action_items("") == []
+    assert parse_action_items("not-json") == []
+    assert parse_action_items(json.dumps({"action": "wrong shape"})) == []
+
+
+def test_normalize_horizon_and_confidence_helpers():
+    assert normalize_horizon("near_term") == "near term"
+    assert normalize_horizon("  ") == ""
+    assert format_confidence(0.7) == "0.7"
+    assert format_confidence(0.65) == "0.65"
+    assert format_confidence(True) == "true"
+    assert format_confidence(" high ") == "high"
+    assert format_confidence(None) == ""

--- a/tests/test_renderer_article_sections.py
+++ b/tests/test_renderer_article_sections.py
@@ -1,0 +1,107 @@
+"""Tests for digest rendering of structured article sections."""
+
+from datetime import datetime, timezone
+
+from twag.db import (
+    get_connection,
+    init_db,
+    insert_tweet,
+    update_tweet_article,
+    update_tweet_processing,
+)
+from twag.renderer import render_digest
+
+
+def test_render_digest_uses_labeled_article_sections(monkeypatch, tmp_path):
+    db_path = tmp_path / "twag_renderer_article_sections.db"
+    init_db(db_path)
+
+    now = datetime.now(timezone.utc)
+    digest_date = now.strftime("%Y-%m-%d")
+
+    with get_connection(db_path) as conn:
+        inserted = insert_tweet(
+            conn,
+            tweet_id="31001",
+            author_handle="undrvalue",
+            content="Google's $180B AI capex guidance is a regime shift.",
+            created_at=now,
+            source="test",
+            has_link=True,
+            is_x_article=True,
+            article_title="Google's $180 Billion Bet",
+            article_preview="Preview",
+            article_text="Long body",
+        )
+        assert inserted is True
+
+        update_tweet_processing(
+            conn,
+            tweet_id="31001",
+            relevance_score=9.0,
+            categories=["capex", "tech_business", "ai_advancement"],
+            summary=(
+                "Deep dive into Google's record $180B 2026 capex guidance and "
+                "the compute-to-ROI playbook across cloud and ads."
+            ),
+            signal_tier="high_signal",
+            tickers=["GOOGL", "MSFT", "META"],
+        )
+        update_tweet_article(
+            conn,
+            tweet_id="31001",
+            article_summary_short=(
+                "Google's $180B 2026 capex guidance is historically large, but "
+                "backlog visibility and ad monetization data suggest demand-driven deployment."
+            ),
+            primary_points=[
+                {
+                    "point": "Capex magnitude is unprecedented for a single company.",
+                    "reasoning": "Real-dollar levels rival peak dotcom telecom infrastructure spend.",
+                    "evidence": "Guide implies nearly 2x versus the prior year run-rate.",
+                },
+                {"point": "", "reasoning": "invalid and should be ignored", "evidence": "n/a"},
+            ],
+            actionable_items=[
+                {
+                    "action": "Monitor GCP growth and backlog durability each quarter.",
+                    "trigger": "Cloud growth drops below 30% while backlog growth stalls.",
+                    "horizon": "medium_term",
+                    "confidence": 0.7,
+                    "tickers": ["GOOGL", "AMZN", "MSFT"],
+                },
+                {"action": "", "trigger": "invalid and should be ignored"},
+            ],
+            top_visual={
+                "url": "https://pbs.twimg.com/media/HAXmiH6acAEiywu.jpg",
+                "kind": "chart",
+                "why_important": "Core chart showing the acceleration profile into 2026.",
+                "key_takeaway": "Capex trend inflects sharply after 2023 and spikes in 2026.",
+            },
+            set_top_visual=True,
+            processed_at=now.isoformat(),
+        )
+        conn.commit()
+
+    monkeypatch.setattr("twag.renderer.get_connection", lambda: get_connection(db_path))
+    output_path = tmp_path / "digest.md"
+    content = render_digest(date=digest_date, min_score=5.0, output_path=output_path)
+
+    assert "🧾 **Article Summary:**" in content
+    assert "📌 **Primary Points:**" in content
+    assert "- **1. Capex magnitude is unprecedented for a single company.**" in content
+    assert "- **Why:** Real-dollar levels rival peak dotcom telecom infrastructure spend." in content
+    assert "- **Evidence:** Guide implies nearly 2x versus the prior year run-rate." in content
+    assert "✅ **Actionable Items:**" in content
+    assert "- **1. Monitor GCP growth and backlog durability each quarter.**" in content
+    assert "- **Trigger:** Cloud growth drops below 30% while backlog growth stalls." in content
+    assert "- **Horizon:** medium term" in content
+    assert "- **Confidence:** 0.7" in content
+    assert "- **Tickers:** GOOGL, AMZN, MSFT" in content
+    assert "(trigger:" not in content
+    assert "invalid and should be ignored" not in content
+    assert "🖼️ **Visuals:**" in content
+    assert "- **1. chart (top)**" in content
+    assert "- **Key takeaway:** Capex trend inflects sharply after 2023 and spikes in 2026." in content
+    assert "- **Why:** Core chart showing the acceleration profile into 2026." in content
+    assert "- **URL:** https://pbs.twimg.com/media/HAXmiH6acAEiywu.jpg" in content

--- a/twag/article_sections.py
+++ b/twag/article_sections.py
@@ -1,0 +1,81 @@
+"""Shared parsing/normalization helpers for structured article sections."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _json_list(value: str | None) -> list[Any]:
+    if not value:
+        return []
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return []
+    return decoded if isinstance(decoded, list) else []
+
+
+def normalize_horizon(value: Any) -> str:
+    text = str(value or "").strip()
+    return text.replace("_", " ") if text else ""
+
+
+def format_confidence(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return f"{value:.2f}".rstrip("0").rstrip(".")
+    return str(value).strip()
+
+
+def parse_primary_points(value: str | None, *, limit: int | None = None) -> list[dict[str, str]]:
+    points: list[dict[str, str]] = []
+    for item in _json_list(value):
+        if not isinstance(item, dict):
+            continue
+        point = str(item.get("point") or "").strip()
+        if not point:
+            continue
+        points.append(
+            {
+                "point": point,
+                "reasoning": str(item.get("reasoning") or "").strip(),
+                "evidence": str(item.get("evidence") or "").strip(),
+            }
+        )
+        if limit is not None and len(points) >= limit:
+            break
+    return points
+
+
+def parse_action_items(value: str | None, *, limit: int | None = None) -> list[dict[str, str]]:
+    actions: list[dict[str, str]] = []
+    for item in _json_list(value):
+        if not isinstance(item, dict):
+            continue
+
+        action = str(item.get("action") or "").strip()
+        if not action:
+            continue
+
+        item_tickers = item.get("tickers")
+        ticker_text = ""
+        if isinstance(item_tickers, list):
+            cleaned = [str(t).strip() for t in item_tickers if str(t).strip()]
+            ticker_text = ", ".join(cleaned)
+
+        actions.append(
+            {
+                "action": action,
+                "trigger": str(item.get("trigger") or "").strip(),
+                "horizon": normalize_horizon(item.get("horizon")),
+                "confidence": format_confidence(item.get("confidence")),
+                "tickers": ticker_text,
+            }
+        )
+        if limit is not None and len(actions) >= limit:
+            break
+    return actions


### PR DESCRIPTION
## Summary
- unify `twag analyze` and `twag digest` article-section parsing/normalization through a new shared module
- switch both outputs to structured labeled blocks for long-form readability (`Why`, `Evidence`, `Trigger`, `Horizon`, `Confidence`, `Tickers`)
- normalize horizon/confidence formatting and filter malformed point/action entries consistently
- align visual rendering with labeled fields (`Key takeaway`, `Why`, `URL`)

## Changes
- add shared helpers: `twag/article_sections.py`
- update CLI analyze printer: `twag/cli.py`
- update digest renderer: `twag/renderer.py`
- add/expand tests:
  - `tests/test_article_sections.py`
  - `tests/test_renderer_article_sections.py`
  - `tests/test_cli_analyze_status.py`

## Validation
- `uv run ruff format twag/article_sections.py twag/cli.py twag/renderer.py tests/test_article_sections.py tests/test_cli_analyze_status.py tests/test_renderer_article_sections.py`
- `uv run ruff check twag/article_sections.py twag/cli.py twag/renderer.py tests/test_article_sections.py tests/test_cli_analyze_status.py tests/test_renderer_article_sections.py tests/test_renderer_links.py`
- `uv run pytest -q tests/test_article_sections.py tests/test_cli_analyze_status.py tests/test_renderer_article_sections.py tests/test_renderer_links.py`
