### PR TITLE
perf: enable WAL mode and increase busy timeout

### DIFF
--- a/twag/db.py
+++ b/twag/db.py
@@ -497,8 +497,10 @@ def get_connection(db_path: Path | None = None) -> Iterator[sqlite3.Connection]:
     if db_path is None:
         db_path = get_database_path()
 
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path, timeout=30)
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=30000")
     try:
         yield conn
     finally:


### PR DESCRIPTION
- enable Write-Ahead Logging to improve concurrency
- set busy_timeout to 30s to reduce database locked errors
- ensure connection timeout matches pragma settings