### PR TITLE
[codex] improve processing parallelism and add CI benchmark harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --group dev
-      - run: uv run ruff check twag/ tests/
-      - run: uv run ruff format --check twag/ tests/
+      - run: uv run ruff check twag/ tests/ scripts/
+      - run: uv run ruff format --check twag/ tests/ scripts/
 
   test:
     runs-on: ubuntu-latest
@@ -41,3 +41,6 @@ jobs:
       - name: Run tests with coverage
         if: matrix.python-version == '3.12'
         run: uv run pytest --cov --cov-report=term-missing
+      - name: Run parallel timing harness
+        if: matrix.python-version == '3.12'
+        run: uv run python scripts/benchmark_parallelism.py

--- a/scripts/benchmark_parallelism.py
+++ b/scripts/benchmark_parallelism.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Deterministic timing harness for tweet processing parallelization."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import twag.processor as processor_mod
+from twag.db import get_connection, init_db, insert_tweet
+from twag.scorer import TriageResult
+
+
+def _seed_db(db_path: Path, tweet_count: int) -> None:
+    init_db(db_path)
+    with get_connection(db_path) as conn:
+        for idx in range(tweet_count):
+            inserted = insert_tweet(
+                conn,
+                tweet_id=f"bench-{idx:04d}",
+                author_handle=f"acct{idx:04d}",
+                content=f"Benchmark content {idx} " + ("x" * 700),
+                created_at=datetime.now(timezone.utc),
+                source="benchmark",
+            )
+            if not inserted:
+                raise RuntimeError(f"Failed to seed tweet bench-{idx:04d}")
+        conn.commit()
+
+
+def _run_triage_case(
+    db_path: Path,
+    *,
+    batch_size: int,
+    triage_workers: int,
+    text_workers: int,
+    triage_latency_s: float,
+    summary_latency_s: float,
+) -> float:
+    original_load_config = processor_mod.load_config
+    original_triage_batch = processor_mod.triage_tweets_batch
+    original_summarize_tweet = processor_mod.summarize_tweet
+
+    def _fake_load_config() -> dict:
+        return {
+            "llm": {
+                "max_concurrency_text": text_workers,
+                "max_concurrency_triage": triage_workers,
+                "max_concurrency_vision": 1,
+                "vision_model": None,
+                "vision_provider": None,
+            },
+            "scoring": {
+                "min_score_for_analysis": 99,
+                "min_score_for_article_processing": 99,
+            },
+        }
+
+    def _fake_triage_tweets_batch(batch, model=None, provider=None):
+        time.sleep(triage_latency_s)
+        return [
+            TriageResult(
+                tweet_id=item["id"],
+                score=6.0,
+                categories=["news"],
+                summary="benchmark",
+            )
+            for item in batch
+        ]
+
+    def _fake_summarize_tweet(tweet_text, handle, model=None, provider=None):
+        time.sleep(summary_latency_s)
+        return f"summary for @{handle}"
+
+    processor_mod.load_config = _fake_load_config
+    processor_mod.triage_tweets_batch = _fake_triage_tweets_batch
+    processor_mod.summarize_tweet = _fake_summarize_tweet
+
+    try:
+        with get_connection(db_path) as conn:
+            rows = conn.execute("SELECT * FROM tweets ORDER BY id ASC").fetchall()
+            start = time.perf_counter()
+            results = processor_mod._triage_rows(
+                conn,
+                tweet_rows=rows,
+                batch_size=batch_size,
+                triage_model=None,
+                enrich_model=None,
+                high_threshold=7.0,
+                tier1_handles=set(),
+                update_stats=False,
+                allow_summarize=True,
+                media_min_score=None,
+            )
+            elapsed = time.perf_counter() - start
+            if len(results) != len(rows):
+                raise RuntimeError(f"Expected {len(rows)} triage results, got {len(results)}")
+            return elapsed
+    finally:
+        processor_mod.load_config = original_load_config
+        processor_mod.triage_tweets_batch = original_triage_batch
+        processor_mod.summarize_tweet = original_summarize_tweet
+
+
+def _measure(
+    *,
+    tweet_count: int,
+    batch_size: int,
+    low_triage_workers: int,
+    high_triage_workers: int,
+    text_workers: int,
+    triage_latency_s: float,
+    summary_latency_s: float,
+) -> tuple[float, float]:
+    with TemporaryDirectory(prefix="twag-bench-") as tmp_dir:
+        base_db = Path(tmp_dir) / "base.db"
+        fast_db = Path(tmp_dir) / "fast.db"
+        _seed_db(base_db, tweet_count)
+        _seed_db(fast_db, tweet_count)
+
+        baseline = _run_triage_case(
+            base_db,
+            batch_size=batch_size,
+            triage_workers=low_triage_workers,
+            text_workers=text_workers,
+            triage_latency_s=triage_latency_s,
+            summary_latency_s=summary_latency_s,
+        )
+        optimized = _run_triage_case(
+            fast_db,
+            batch_size=batch_size,
+            triage_workers=high_triage_workers,
+            text_workers=text_workers,
+            triage_latency_s=triage_latency_s,
+            summary_latency_s=summary_latency_s,
+        )
+        return baseline, optimized
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark twag processing parallelization.")
+    parser.add_argument("--tweet-count", type=int, default=32, help="Number of synthetic tweets to process.")
+    parser.add_argument("--batch-size", type=int, default=4, help="Batch size for triage.")
+    parser.add_argument("--text-workers", type=int, default=2, help="Text worker count for both runs.")
+    parser.add_argument("--low-triage-workers", type=int, default=1, help="Triage workers in baseline case.")
+    parser.add_argument("--high-triage-workers", type=int, default=4, help="Triage workers in optimized case.")
+    parser.add_argument("--triage-latency-ms", type=float, default=60.0, help="Mock triage latency per batch.")
+    parser.add_argument("--summary-latency-ms", type=float, default=5.0, help="Mock summary latency per tweet.")
+    parser.add_argument("--min-speedup", type=float, default=1.35, help="Minimum required baseline/optimized ratio.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    triage_latency_s = args.triage_latency_ms / 1000.0
+    summary_latency_s = args.summary_latency_ms / 1000.0
+
+    if args.low_triage_workers >= args.high_triage_workers:
+        raise SystemExit("--high-triage-workers must be greater than --low-triage-workers")
+
+    baseline_s, optimized_s = _measure(
+        tweet_count=args.tweet_count,
+        batch_size=args.batch_size,
+        low_triage_workers=args.low_triage_workers,
+        high_triage_workers=args.high_triage_workers,
+        text_workers=args.text_workers,
+        triage_latency_s=triage_latency_s,
+        summary_latency_s=summary_latency_s,
+    )
+    speedup = baseline_s / optimized_s if optimized_s > 0 else 0.0
+
+    print(
+        "benchmark_parallelism:"
+        f" tweets={args.tweet_count}"
+        f" batch_size={args.batch_size}"
+        f" baseline_s={baseline_s:.4f}"
+        f" optimized_s={optimized_s:.4f}"
+        f" speedup={speedup:.3f}x"
+        f" min_required={args.min_speedup:.3f}x"
+    )
+
+    if speedup < args.min_speedup:
+        print("FAIL: measured speedup is below threshold")
+        return 1
+
+    print("PASS: measured speedup meets threshold")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_processor_parallelization.py
+++ b/tests/test_processor_parallelization.py
@@ -1,0 +1,179 @@
+"""Tests for processor parallelization and enrichment throughput helpers."""
+
+import threading
+import time
+from datetime import datetime, timezone
+
+import twag.processor as processor_mod
+from twag.db import get_connection, init_db, insert_tweet, update_tweet_processing
+from twag.scorer import EnrichmentResult, TriageResult
+
+
+def test_triage_overlap_with_summaries_using_dedicated_pool(monkeypatch, tmp_path) -> None:
+    """Summary tasks should run before all triage batches fully complete."""
+    db_path = tmp_path / "triage_parallel.db"
+    init_db(db_path)
+
+    with get_connection(db_path) as conn:
+        for idx in range(1, 3):
+            inserted = insert_tweet(
+                conn,
+                tweet_id=f"tweet-{idx}",
+                author_handle=f"acct{idx}",
+                content=f"Long content {idx} " + ("x" * 700),
+                created_at=datetime.now(timezone.utc),
+                source="test",
+            )
+            assert inserted is True
+        conn.commit()
+
+        rows = conn.execute("SELECT * FROM tweets ORDER BY id ASC").fetchall()
+
+        monkeypatch.setattr(
+            processor_mod,
+            "load_config",
+            lambda: {
+                "llm": {
+                    "max_concurrency_text": 1,
+                    "max_concurrency_triage": 1,
+                    "max_concurrency_vision": 1,
+                    "vision_model": None,
+                    "vision_provider": None,
+                },
+                "scoring": {
+                    "min_score_for_analysis": 99,
+                    "min_score_for_article_processing": 99,
+                },
+            },
+        )
+
+        events: dict[str, float] = {}
+        summary_starts: list[float] = []
+        lock = threading.Lock()
+
+        def _fake_triage_tweets_batch(batch, model=None, provider=None):
+            tweet_id = batch[0]["id"]
+            batch_no = 1 if tweet_id == "tweet-1" else 2
+            with lock:
+                events[f"triage_{batch_no}_start"] = time.perf_counter()
+            time.sleep(0.04 if batch_no == 1 else 0.18)
+            with lock:
+                events[f"triage_{batch_no}_end"] = time.perf_counter()
+            return [
+                TriageResult(
+                    tweet_id=item["id"],
+                    score=6.0,
+                    categories=["news"],
+                    summary="scored",
+                )
+                for item in batch
+            ]
+
+        def _fake_summarize_tweet(tweet_text, handle, model=None, provider=None):
+            with lock:
+                summary_starts.append(time.perf_counter())
+            time.sleep(0.03)
+            return f"summary for @{handle}"
+
+        monkeypatch.setattr(processor_mod, "triage_tweets_batch", _fake_triage_tweets_batch)
+        monkeypatch.setattr(processor_mod, "summarize_tweet", _fake_summarize_tweet)
+
+        results = processor_mod._triage_rows(
+            conn,
+            tweet_rows=rows,
+            batch_size=1,
+            triage_model=None,
+            enrich_model=None,
+            high_threshold=7.0,
+            tier1_handles=set(),
+            update_stats=False,
+            allow_summarize=True,
+            media_min_score=None,
+        )
+
+        assert len(results) == 2
+        assert summary_starts
+        assert "triage_2_end" in events
+        assert summary_starts[0] < events["triage_2_end"]
+
+
+def test_enrich_high_signal_prefers_local_quote_row(monkeypatch, tmp_path) -> None:
+    """Enrichment should use quoted tweet content from local DB when available."""
+    db_path = tmp_path / "enrich_local_quote.db"
+    init_db(db_path)
+
+    with get_connection(db_path) as conn:
+        inserted_quote = insert_tweet(
+            conn,
+            tweet_id="quote-1",
+            author_handle="quotedacct",
+            content="Quoted local context",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+        )
+        assert inserted_quote is True
+
+        inserted_main = insert_tweet(
+            conn,
+            tweet_id="main-1",
+            author_handle="mainacct",
+            content="Main tweet content",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+            has_quote=True,
+            quote_tweet_id="quote-1",
+        )
+        assert inserted_main is True
+
+        update_tweet_processing(
+            conn,
+            tweet_id="main-1",
+            relevance_score=9.0,
+            categories=["news"],
+            summary="summary",
+            signal_tier="high_signal",
+            tickers=[],
+        )
+        conn.commit()
+
+    monkeypatch.setattr(processor_mod, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(
+        processor_mod,
+        "load_config",
+        lambda: {
+            "scoring": {"high_signal_threshold": 7},
+            "llm": {"max_concurrency_text": 1},
+        },
+    )
+    monkeypatch.setattr(
+        processor_mod,
+        "read_tweet",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("read_tweet should not be called")),
+    )
+
+    seen: dict[str, str] = {}
+
+    def _fake_enrich_tweet(
+        tweet_text: str,
+        handle: str,
+        author_category: str,
+        quoted_tweet: str,
+        article_summary: str,
+        image_description: str,
+        model=None,
+    ) -> EnrichmentResult:
+        seen["quoted_tweet"] = quoted_tweet
+        return EnrichmentResult(
+            signal_tier="high_signal",
+            insight="insight",
+            implications="implications",
+            narratives=[],
+            tickers=[],
+        )
+
+    monkeypatch.setattr(processor_mod, "enrich_tweet", _fake_enrich_tweet)
+
+    results = processor_mod.enrich_high_signal(limit=5, enrich_model="dummy-model")
+
+    assert len(results) == 1
+    assert seen["quoted_tweet"] == "@quotedacct: Quoted local context"

--- a/twag/config.py
+++ b/twag/config.py
@@ -17,6 +17,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "enrichment_provider": "anthropic",
         "vision_model": "gemini-3-flash-preview",
         "vision_provider": "gemini",
+        "max_concurrency_triage": 4,
         "max_concurrency_text": 8,
         "max_concurrency_vision": 4,
         "retry_max_attempts": 4,


### PR DESCRIPTION
## Summary
This PR improves end-to-end tweet processing throughput, especially in flows that combine batch triage with downstream summarization and enrichment work. It also adds a deterministic benchmark harness that runs in CI to catch future regressions in this concurrency behavior.

## User Impact
Before this change, triage batch tasks and downstream text tasks shared the same executor, so triage submissions could occupy worker slots and delay summarization/enrichment jobs. In practice this made processing feel slower under load even when configured text concurrency was high.

With this change:
- Triage throughput and text-enrichment throughput no longer contend for the same executor.
- Enrichment avoids unnecessary network quote fetches when quoted rows already exist locally.
- CI now has an explicit regression gate for the parallelization behavior.

## Root Cause
The processing path in `twag/processor.py` used a single text thread pool for both:
- `triage_tweets_batch` tasks, and
- `summarize_tweet` / `summarize_x_article` / `enrich_tweet` tasks.

That coupling created head-of-line blocking: queued triage work could starve downstream text tasks. In addition, `enrich_high_signal` fetched each account category individually and used network quote reads even when quote content was already in SQLite.

## Fix
1. Decoupled triage concurrency from text enrichment concurrency.
   - Added `llm.max_concurrency_triage` config (`twag/config.py`).
   - Added a dedicated triage executor in `_triage_rows` (`twag/processor.py`).
   - Kept DB writes on the main thread.
2. Hardened worker-count config handling.
   - Added `_normalized_worker_count` helper for robust positive worker parsing.
3. Reduced enrichment overhead.
   - `enrich_high_signal` now prefers local quoted rows (`get_tweet_by_id`) before fallback `read_tweet` network calls.
   - Batched account category lookup into one query across candidate handles.
4. Added deterministic benchmark harness.
   - New script: `scripts/benchmark_parallelism.py`.
   - Compares low-triage-worker baseline vs high-triage-worker case with mocked deterministic latencies.
   - Fails if measured speedup drops below threshold.
5. Wired benchmark into CI.
   - Added benchmark step for Python 3.12 in `.github/workflows/ci.yml`.
   - Expanded ruff lint/format checks to include `scripts/`.

## Tests and Validation
### New tests
- `tests/test_processor_parallelization.py`
  - Verifies summaries can start before all triage batches complete (parallel overlap behavior).
  - Verifies enrichment uses local quote rows without unnecessary `read_tweet` calls.

### Commands run locally
- `uv run ruff format twag/config.py twag/processor.py tests/test_processor_parallelization.py scripts/benchmark_parallelism.py`
- `uv run ruff check twag/config.py twag/processor.py tests/test_processor_parallelization.py scripts/benchmark_parallelism.py`
- `uv run ruff check twag/ tests/ scripts/`
- `uv run ruff format --check twag/ tests/ scripts/`
- `uv run pytest -q tests/test_processor_parallelization.py tests/test_article_processing.py tests/test_cli_process_status.py tests/test_cli_analyze_status.py`
- `uv run python scripts/benchmark_parallelism.py`

### Benchmark sample output
- `baseline_s=0.5259`
- `optimized_s=0.1778`
- `speedup=2.958x`
- `min_required=1.350x`

## Risk Assessment
- Low-to-moderate risk: concurrency configuration behavior changed in processing.
- Mitigation: preserved fallback single-thread paths, added focused regression tests, and added deterministic CI benchmark gate.
