### PR TITLE
Security hardening for public release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ htmlcov/
 # Local config (keep default config.json in repo)
 config.local.json
 
+# Environment files (API keys, secrets)
+.env
+.env.*
+
 # Frontend
 twag/web/frontend/node_modules/
 twag/web/frontend/dist/

--- a/README.md
+++ b/README.md
@@ -272,6 +272,16 @@ Notes:
 - In dev mode, Vite runs on `http://localhost:8080`.
 - API target defaults to `http://localhost:5173` unless you change `--port`.
 
+## Security
+
+**`twag web` is designed for local/trusted-network use only.** The API endpoints are unauthenticated. Do not expose the server to the public internet without adding your own authentication layer.
+
+The default bind address is `0.0.0.0` (all interfaces). To restrict to local-only access, use:
+
+```bash
+twag web --host 127.0.0.1
+```
+
 ## Scoring Tiers
 
 - `high_signal`: strongest actionable content


### PR DESCRIPTION
## Summary
- **Path traversal fix**: SPA catch-all now uses `.resolve()` + `.is_relative_to()` to prevent directory traversal attacks
- **Shell injection fix**: Context command variable substitution uses `shlex.quote()`, and command execution switched from `create_subprocess_shell` to `create_subprocess_exec`
- **CORS middleware**: Restricted to `localhost`/`127.0.0.1` origins only
- **`.gitignore`**: Added `.env` / `.env.*` to prevent accidental secret commits
- **README**: Added Security section documenting local-use expectations

## Test plan
- [x] `uv run ruff format` + `uv run ruff check` pass
- [x] `uv run pytest tests/` passes
- [x] `git grep` scan for hardcoded secrets — clean
- [ ] Manual: verify SPA still serves correctly after path traversal fix
- [ ] Manual: verify context commands still execute with shlex escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)