### PR TITLE
perf: optimize feed latest sort and quote reprocessing

### DIFF
--- a/twag/cli.py
+++ b/twag/cli.py
@@ -726,6 +726,7 @@ def process(
                 WHERE processed_at IS NOT NULL
                   AND has_quote = 1
                   AND quote_tweet_id IS NOT NULL
+                  AND quote_reprocessed_at IS NULL
                   AND date(created_at) = ?
                   AND relevance_score >= ?
                 ORDER BY created_at DESC


### PR DESCRIPTION
## Summary
- Add `idx_tweets_processed_created` index so "latest" sort uses an index scan instead of loading all processed tweets into memory and sorting
- Restructure feed query to paginate tweets in a subquery before LEFT JOINing reactions, avoiding full-table aggregation before LIMIT
- Add `quote_reprocessed_at` column so quoted tweets are only reprocessed once per day instead of on every `twag process` run

## Test plan
- [x] `uv run ruff check` passes
- [x] `uv run pytest -q -k "feed or tweet or db or process"` passes (84 tests)
- [ ] Run `twag process` twice — second run should skip quote reprocessing
- [ ] Verify "latest" sort in the web feed is noticeably faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)