### PR TITLE
Move URL expansion to twag process with parallelization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,13 +51,17 @@ Core modules:
 
 ### Link normalization (digest + web)
 
-Implemented in `twag/link_utils.py` and consumed in CLI/web renderers.
+Implemented in `twag/link_utils.py`.
+
+URL short-link expansion (`t.co` -> final URL) runs during `twag process` and is
+persisted to `tweets.links_json` with `links_expanded_at`. Digest rendering and
+web API routes are read-only consumers of stored expanded links.
 
 Rules:
 
 - Remove self links (tweet links pointing to the current tweet)
 - Convert twitter/x links to other tweets into inline quote link metadata
-- Expand non-twitter short URLs (best effort) and render as external links
+- Expand non-twitter short URLs (best effort) during processing and render as external links
 - Prune trailing unresolved `t.co` links that are likely self/media pointers:
   - for media tweets, and
   - for mixed-link tweets where another link in the same post resolved externally

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,139 @@
+"""Tests for process-time URL expansion behavior."""
+
+import json
+from datetime import datetime, timezone
+
+import twag.processor as processor_mod
+from twag.db import get_connection, get_tweet_by_id, init_db, insert_tweet
+
+
+def test_process_unprocessed_expands_links_and_persists_before_triage(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "twag_process_expand_links.db"
+    init_db(db_path)
+
+    with get_connection(db_path) as conn:
+        inserted = insert_tweet(
+            conn,
+            tweet_id="1001",
+            author_handle="root_user",
+            content="Interesting thread https://t.co/ext",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+            has_link=True,
+            links=[{"url": "https://t.co/ext", "expanded_url": "https://t.co/ext"}],
+        )
+        assert inserted is True
+        conn.commit()
+
+    monkeypatch.setattr(processor_mod, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(
+        processor_mod,
+        "load_config",
+        lambda: {
+            "scoring": {
+                "batch_size": 10,
+                "high_signal_threshold": 7,
+                "min_score_for_media": 3,
+            },
+            "fetch": {"quote_depth": 0, "quote_delay": 0.0},
+            "processing": {"max_concurrency_url_expansion": 4},
+        },
+    )
+
+    calls: list[list[dict]] = []
+
+    def _fake_expand_links(links: list[dict]) -> list[dict]:
+        calls.append(links)
+        return [
+            {
+                "url": "https://t.co/ext",
+                "expanded_url": "https://github.com/example/project",
+                "display_url": "github.com/example/project",
+            }
+        ]
+
+    captured_rows: list[dict] = []
+
+    def _fake_triage_rows(_conn, **kwargs):
+        tweet_rows = kwargs["tweet_rows"]
+        captured_rows.extend(tweet_rows)
+        return []
+
+    monkeypatch.setattr(processor_mod, "expand_links_in_place", _fake_expand_links)
+    monkeypatch.setattr(processor_mod, "_triage_rows", _fake_triage_rows)
+
+    results = processor_mod.process_unprocessed(limit=10)
+
+    assert results == []
+    assert len(calls) == 1
+    assert len(captured_rows) == 1
+
+    triage_row = captured_rows[0]
+    triage_links = json.loads(triage_row["links_json"])
+    assert triage_links[0]["expanded_url"] == "https://github.com/example/project"
+    assert triage_row["links_expanded_at"] is not None
+
+    with get_connection(db_path) as conn:
+        row = get_tweet_by_id(conn, "1001")
+        assert row is not None
+        parsed = json.loads(row["links_json"])
+        assert parsed[0]["expanded_url"] == "https://github.com/example/project"
+        assert row["links_expanded_at"] is not None
+
+
+def test_process_unprocessed_skips_already_expanded_links(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "twag_process_skip_expanded_links.db"
+    init_db(db_path)
+
+    with get_connection(db_path) as conn:
+        inserted = insert_tweet(
+            conn,
+            tweet_id="1002",
+            author_handle="root_user",
+            content="Already expanded https://github.com/example/project",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+            has_link=True,
+            links=[
+                {
+                    "url": "https://t.co/ext",
+                    "expanded_url": "https://github.com/example/project",
+                    "display_url": "github.com/example/project",
+                }
+            ],
+        )
+        assert inserted is True
+        expanded_at = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            "UPDATE tweets SET links_expanded_at = ? WHERE id = ?",
+            (expanded_at, "1002"),
+        )
+        conn.commit()
+
+    monkeypatch.setattr(processor_mod, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(
+        processor_mod,
+        "load_config",
+        lambda: {
+            "scoring": {
+                "batch_size": 10,
+                "high_signal_threshold": 7,
+                "min_score_for_media": 3,
+            },
+            "fetch": {"quote_depth": 0, "quote_delay": 0.0},
+            "processing": {"max_concurrency_url_expansion": 4},
+        },
+    )
+    monkeypatch.setattr(
+        processor_mod,
+        "expand_links_in_place",
+        lambda _links: (_ for _ in ()).throw(AssertionError("expand_links_in_place should not run")),
+    )
+    monkeypatch.setattr(processor_mod, "_triage_rows", lambda _conn, **_kwargs: [])
+
+    processor_mod.process_unprocessed(limit=10)
+
+    with get_connection(db_path) as conn:
+        row = get_tweet_by_id(conn, "1002")
+        assert row is not None
+        assert row["links_expanded_at"] == expanded_at

--- a/twag/config.py
+++ b/twag/config.py
@@ -53,6 +53,9 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "quote_depth": 3,  # max recursive depth for quoted tweets
         "quote_delay": 1.0,  # seconds between recursive quoted tweet fetches
     },
+    "processing": {
+        "max_concurrency_url_expansion": 15,
+    },
     "paths": {
         # These can be overridden in config.json
         # If not set, XDG defaults are used

--- a/twag/renderer.py
+++ b/twag/renderer.py
@@ -157,6 +157,7 @@ def _render_tweet(conn: sqlite3.Connection, tweet: sqlite3.Row, compact: bool = 
         text=tweet["content"],
         links=links,
         has_media=bool(_value(tweet, "has_media", False)),
+        already_expanded=True,
     )
     inline_tweet_links = normalized_links.inline_tweet_links
     external_links = normalized_links.external_links

--- a/twag/web/tweet_utils.py
+++ b/twag/web/tweet_utils.py
@@ -52,7 +52,13 @@ def normalize_links_for_display(
     links: list[dict] | None,
     has_media: bool = False,
 ) -> LinkNormalizationResult:
-    return normalize_tweet_links(tweet_id=tweet_id, text=text, links=links, has_media=has_media)
+    return normalize_tweet_links(
+        tweet_id=tweet_id,
+        text=text,
+        links=links,
+        has_media=has_media,
+        already_expanded=True,
+    )
 
 
 def parse_tweet_id_from_url(url: str | None) -> str | None:


### PR DESCRIPTION
## Summary
This PR moves short-URL expansion from render/request time into `twag process`, persists expanded link entities in `tweets.links_json`, and makes digest/web link normalization read-only.

## Why
Previously, link expansion could run during digest generation and on API requests, which caused:
- avoidable request/render latency,
- repeated expansion work across requests/renders,
- volatile cache behavior across process restarts.

This change ensures expansion is done once during processing and reused everywhere else.

## What changed
- Added DB persistence for expansion status:
  - `tweets.links_expanded_at` column in schema + migration.
  - `update_tweet_links_expanded(...)` DB helper to write `links_json` + timestamp together.
- Added link expansion utility:
  - `expand_links_in_place(...)` in `twag/link_utils.py`.
- Added `already_expanded` guard to link normalization:
  - `_normalize_structured_links(..., already_expanded=False)`
  - `normalize_tweet_links(..., already_expanded=False)`
- Added parallel URL expansion phase in `process_unprocessed(...)`:
  - runs after quote expansion and before triage,
  - expands rows with `has_link=1`, `links_json` present, `links_expanded_at IS NULL`,
  - uses thread pool workers for network I/O,
  - keeps DB writes on main thread,
  - commits and re-fetches rows so triage uses updated links.
- Added config:
  - `processing.max_concurrency_url_expansion` default `15`.
- Made downstream consumers read-only:
  - digest renderer passes `already_expanded=True`,
  - web tweet utilities pass `already_expanded=True`.
- Updated documentation:
  - `CLAUDE.md` link normalization section now documents process-time expansion behavior.

## Behavioral notes
- Existing unexpanded tweets remain `links_expanded_at = NULL` and are expanded on next `twag process` run.
- Expansion failures still set `links_expanded_at`; existing fallback behavior keeps unresolved URLs.
- If duplicate tweet merge adds richer/new link entities, `links_expanded_at` is reset to `NULL` so expansion reruns.

## Validation
- `uv run ruff check twag/ tests/ scripts/`
- `uv run pytest -q tests/test_link_utils.py tests/test_processor.py tests/test_renderer_links.py tests/test_web_tweets_api.py tests/test_processor_parallelization.py`

All checks passed.
