### PR TITLE
Unify dependency processing for quote, reply, and thread tweets

### DIFF
--- a/tests/test_cli_analyze_status.py
+++ b/tests/test_cli_analyze_status.py
@@ -18,6 +18,8 @@ def _sample_tweet() -> Tweet:
         created_at=None,
         has_quote=False,
         quote_tweet_id=None,
+        in_reply_to_tweet_id=None,
+        conversation_id=None,
         has_media=False,
         media_items=[],
         has_link=True,

--- a/tests/test_cli_fetch_status.py
+++ b/tests/test_cli_fetch_status.py
@@ -15,6 +15,8 @@ def _sample_tweet() -> Tweet:
         created_at=None,
         has_quote=False,
         quote_tweet_id=None,
+        in_reply_to_tweet_id=None,
+        conversation_id=None,
         has_media=False,
         media_items=[],
         has_link=True,

--- a/tests/test_cli_process_status.py
+++ b/tests/test_cli_process_status.py
@@ -57,7 +57,7 @@ def test_process_status_id_fast_path(monkeypatch):
     assert result.exit_code == 0
     assert "Processing status 2019488673935552978..." in result.output
     assert "No unprocessed tweets found." in result.output
-    assert "Skipping quote reprocessing for single-status mode." in result.output
+    assert "Skipping dependency reprocessing for single-status mode." in result.output
     assert calls["limit"] == 250
     assert isinstance(calls["rows"], list)
     assert len(calls["rows"]) == 1

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -184,6 +184,20 @@ class TestTweetFromBirdJson:
         assert tweet.has_quote is True
         assert tweet.quote_tweet_id == "789"
 
+    def test_parse_with_reply_and_conversation_ids(self):
+        """Parse reply parent and conversation metadata."""
+        data = {
+            "id": "123",
+            "author": {"username": "replier"},
+            "text": "Replying in thread",
+            "in_reply_to_status_id_str": "111",
+            "conversation_id_str": "999",
+        }
+        tweet = Tweet.from_bird_json(data)
+
+        assert tweet.in_reply_to_tweet_id == "111"
+        assert tweet.conversation_id == "999"
+
     def test_parse_with_media(self, media_tweet_data):
         """Parse tweet with media attachments."""
         tweet = Tweet.from_bird_json(media_tweet_data)
@@ -652,6 +666,8 @@ class TestFetchFunctions:
             created_at=None,
             has_quote=False,
             quote_tweet_id=None,
+            in_reply_to_tweet_id=None,
+            conversation_id=None,
             has_media=False,
             media_items=[],
             has_link=False,

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, timezone
 
 import twag.processor as processor_mod
-from twag.db import get_connection, get_tweet_by_id, init_db, insert_tweet
+from twag.db import get_connection, get_tweet_by_id, init_db, insert_tweet, update_tweet_processing
 
 
 def test_process_unprocessed_expands_links_and_persists_before_triage(monkeypatch, tmp_path) -> None:
@@ -137,3 +137,215 @@ def test_process_unprocessed_skips_already_expanded_links(monkeypatch, tmp_path)
         row = get_tweet_by_id(conn, "1002")
         assert row is not None
         assert row["links_expanded_at"] == expanded_at
+
+
+def test_reprocess_today_quoted_expands_quote_row_links(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "twag_reprocess_quote_links.db"
+    init_db(db_path)
+
+    with get_connection(db_path) as conn:
+        inserted_quote = insert_tweet(
+            conn,
+            tweet_id="q1",
+            author_handle="quoted_user",
+            content="Quoted text https://t.co/ext",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+            has_link=True,
+            links=[{"url": "https://t.co/ext", "expanded_url": "https://t.co/ext"}],
+        )
+        assert inserted_quote is True
+        update_tweet_processing(
+            conn,
+            tweet_id="q1",
+            relevance_score=6.0,
+            categories=["news"],
+            summary="quoted-summary",
+            signal_tier="news",
+            tickers=[],
+        )
+
+        inserted_root = insert_tweet(
+            conn,
+            tweet_id="r1",
+            author_handle="root_user",
+            content="Root text",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+            has_quote=True,
+            quote_tweet_id="q1",
+        )
+        assert inserted_root is True
+        update_tweet_processing(
+            conn,
+            tweet_id="r1",
+            relevance_score=7.0,
+            categories=["news"],
+            summary="root-summary",
+            signal_tier="market_relevant",
+            tickers=[],
+        )
+        conn.commit()
+
+        root_row = get_tweet_by_id(conn, "r1")
+        assert root_row is not None
+
+    monkeypatch.setattr(processor_mod, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(
+        processor_mod,
+        "load_config",
+        lambda: {
+            "scoring": {
+                "batch_size": 10,
+                "high_signal_threshold": 7,
+                "min_score_for_media": 3,
+                "min_score_for_reprocess": 3,
+            },
+            "fetch": {"quote_depth": 3, "quote_delay": 0.0},
+            "processing": {"max_concurrency_url_expansion": 4},
+        },
+    )
+    monkeypatch.setattr(
+        processor_mod,
+        "expand_links_in_place",
+        lambda _links: [
+            {
+                "url": "https://t.co/ext",
+                "expanded_url": "https://github.com/example/project",
+                "display_url": "github.com/example/project",
+            }
+        ],
+    )
+    monkeypatch.setattr(processor_mod, "_triage_rows", lambda _conn, **_kwargs: [])
+
+    results = processor_mod.reprocess_today_quoted(rows=[root_row])
+    assert results == []
+
+    with get_connection(db_path) as conn:
+        quote_row = get_tweet_by_id(conn, "q1")
+        assert quote_row is not None
+        links = json.loads(quote_row["links_json"])
+        assert links[0]["expanded_url"] == "https://github.com/example/project"
+        assert quote_row["links_expanded_at"] is not None
+
+
+def test_process_unprocessed_adds_reply_parent_to_processing_stack(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "twag_process_reply_parent.db"
+    init_db(db_path)
+
+    with get_connection(db_path) as conn:
+        inserted_parent = insert_tweet(
+            conn,
+            tweet_id="p1",
+            author_handle="parent_user",
+            content="Parent in thread",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+        )
+        assert inserted_parent is True
+
+        inserted_root = insert_tweet(
+            conn,
+            tweet_id="r1",
+            author_handle="root_user",
+            content="Reply child",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+            in_reply_to_tweet_id="p1",
+            conversation_id="c1",
+        )
+        assert inserted_root is True
+        conn.commit()
+
+    monkeypatch.setattr(processor_mod, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(
+        processor_mod,
+        "load_config",
+        lambda: {
+            "scoring": {
+                "batch_size": 10,
+                "high_signal_threshold": 7,
+                "min_score_for_media": 3,
+            },
+            "fetch": {"quote_depth": 3, "quote_delay": 0.0},
+            "processing": {"max_concurrency_url_expansion": 2},
+        },
+    )
+    monkeypatch.setattr(processor_mod, "expand_links_in_place", lambda links: links)
+
+    captured_rows: list[dict] = []
+
+    def _fake_triage_rows(_conn, **kwargs):
+        captured_rows.extend(kwargs["tweet_rows"])
+        return []
+
+    monkeypatch.setattr(processor_mod, "_triage_rows", _fake_triage_rows)
+
+    results = processor_mod.process_unprocessed(limit=10)
+    assert results == []
+    ids = {row["id"] for row in captured_rows}
+    assert ids == {"r1", "p1"}
+
+
+def test_process_unprocessed_adds_thread_linked_tweet_to_processing_stack(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "twag_process_thread_link.db"
+    init_db(db_path)
+
+    with get_connection(db_path) as conn:
+        inserted_linked = insert_tweet(
+            conn,
+            tweet_id="10001",
+            author_handle="thread_user",
+            content="Earlier thread post",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+        )
+        assert inserted_linked is True
+
+        inserted_root = insert_tweet(
+            conn,
+            tweet_id="r2",
+            author_handle="root_user",
+            content="Continuation https://t.co/thread1",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+            has_link=True,
+            links=[
+                {
+                    "url": "https://t.co/thread1",
+                    "expanded_url": "https://x.com/thread_user/status/10001",
+                    "display_url": "x.com/thread_user/status/10001",
+                }
+            ],
+        )
+        assert inserted_root is True
+        conn.commit()
+
+    monkeypatch.setattr(processor_mod, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(
+        processor_mod,
+        "load_config",
+        lambda: {
+            "scoring": {
+                "batch_size": 10,
+                "high_signal_threshold": 7,
+                "min_score_for_media": 3,
+            },
+            "fetch": {"quote_depth": 3, "quote_delay": 0.0},
+            "processing": {"max_concurrency_url_expansion": 2},
+        },
+    )
+    monkeypatch.setattr(processor_mod, "expand_links_in_place", lambda links: links)
+
+    captured_rows: list[dict] = []
+
+    def _fake_triage_rows(_conn, **kwargs):
+        captured_rows.extend(kwargs["tweet_rows"])
+        return []
+
+    monkeypatch.setattr(processor_mod, "_triage_rows", _fake_triage_rows)
+
+    results = processor_mod.process_unprocessed(limit=10)
+    assert results == []
+    ids = {row["id"] for row in captured_rows}
+    assert ids == {"r2", "10001"}

--- a/twag/fetcher.py
+++ b/twag/fetcher.py
@@ -45,6 +45,8 @@ class Tweet:
     created_at: datetime | None
     has_quote: bool
     quote_tweet_id: str | None
+    in_reply_to_tweet_id: str | None
+    conversation_id: str | None
     has_media: bool
     media_items: list[dict[str, Any]]
     has_link: bool
@@ -97,6 +99,30 @@ class Tweet:
             has_quote = True
             quoted = data.get("quotedTweet") or data.get("quoted_status", {})
             quote_tweet_id = str(quoted.get("id") or quoted.get("id_str", ""))
+
+        legacy = data.get("legacy", {}) if isinstance(data.get("legacy"), dict) else {}
+        in_reply_to_tweet_id = str(
+            data.get("in_reply_to_status_id_str")
+            or data.get("in_reply_to_status_id")
+            or data.get("inReplyToStatusId")
+            or data.get("inReplyToStatusIdStr")
+            or legacy.get("in_reply_to_status_id_str")
+            or legacy.get("in_reply_to_status_id")
+            or ""
+        ).strip()
+        if not in_reply_to_tweet_id:
+            in_reply_to_tweet_id = None
+
+        conversation_id = str(
+            data.get("conversation_id_str")
+            or data.get("conversationIdStr")
+            or data.get("conversation_id")
+            or legacy.get("conversation_id_str")
+            or legacy.get("conversation_id")
+            or ""
+        ).strip()
+        if not conversation_id:
+            conversation_id = None
 
         # Media
         media_items = _extract_media_items(data)
@@ -163,6 +189,8 @@ class Tweet:
             created_at=created_at,
             has_quote=has_quote,
             quote_tweet_id=quote_tweet_id,
+            in_reply_to_tweet_id=in_reply_to_tweet_id,
+            conversation_id=conversation_id,
             has_media=has_media,
             media_items=media_items,
             has_link=has_link,


### PR DESCRIPTION
## Summary
This PR unifies dependency processing so quote tweets, reply parents, and thread-linked tweets are treated as first-class items in the same processing stack. It also fixes a migration/init edge case discovered while adding reply/thread dependency columns.

## Problem
We observed inconsistent behavior where dependency tweets (especially quote/reply context rows) could miss parts of processing such as URL expansion, which then leaked raw `t.co` links in downstream UI.

Two root issues:
1. Dependency traversal logic was quote-centric in key paths.
2. The new reply index could be referenced at schema-init time before the migration added the column on older DBs.

## What changed
### 1) Unified dependency model in processor
- Added dependency extraction from each row:
  - `quote_tweet_id`
  - `in_reply_to_tweet_id`
  - inline/thread status links parsed from `links_json`
- Replaced quote-only expansion with dependency expansion:
  - `_expand_unprocessed_with_dependencies(...)`
- Extended link expansion traversal to dependency rows (not just quote chain).
- Reprocess selection now includes reply dependencies in addition to quotes.

### 2) Reply/thread metadata in fetch + DB
- `Tweet` now captures:
  - `in_reply_to_tweet_id`
  - `conversation_id`
- `insert_tweet(...)` and duplicate merge path persist these fields.
- Added schema + migration support for those columns.

### 3) db init / migration safety fix
- Removed schema-time reply index creation that could run before migration columns existed on legacy DBs.
- Index creation remains in migration-time index setup after columns are present.

### 4) CLI wording + selection alignment
- Reprocess messaging now reflects dependency semantics (quotes/replies).
- Reprocess query now includes rows with `in_reply_to_tweet_id` as dependency candidates.

## Validation
- Formatting/lint:
  - `uv run ruff format ...` (changed files)
  - `uv run ruff check twag/ tests/ scripts/`
- Tests:
  - `uv run pytest -q tests/test_processor.py tests/test_fetcher.py tests/test_cli_fetch_status.py tests/test_cli_analyze_status.py tests/test_cli_process_status.py tests/test_link_utils.py tests/test_web_tweets_api.py tests/test_renderer_links.py tests/test_processor_parallelization.py`
- Migration smoke check:
  - `TWAG_DATA_DIR=tmp/db-init-smoke uv run twag db init`

All checks passed.

## User impact
- Dependency context is now processed consistently across quote/reply/thread-linked tweets.
- URL expansion and downstream rendering behavior is more consistent for dependency content.
- `twag db init` works correctly on legacy DB states with migrations applied in the correct order.
