### PR TITLE
fix: retry bird CLI on 429 rate limit

### DIFF
--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -800,29 +800,13 @@ class TestReadTweet:
         assert "read" in args
         assert "https://x.com/user/status/12345" in args
 
-    def test_read_tweet_falls_back_from_truncated_json_full(self, mock_run_bird):
-        """Fallback to --json when --json-full cannot be parsed, preserving recovered media."""
-        truncated_full = (
-            '{"id":"123","author":{"username":"single"},"text":"Single tweet","_raw":{"article":{"article_results":'
-            '{"result":{"media_entities":[{"media_info":{"original_img_url":"https:\\/\\/pbs.twimg.com\\/media\\/'
-            'HAXmiH6acAEiywu.jpg"}}]}}}}'
-        )
-        fallback_json = {
-            "id": "123",
-            "author": {"username": "single"},
-            "text": "Single tweet",
-            "article": {"title": "Deep Dive", "previewText": "Preview"},
-        }
-        mock_run_bird.side_effect = [
-            (truncated_full, "", 0),
-            (json.dumps(fallback_json), "", 0),
-        ]
+    def test_read_tweet_unparseable_returns_none(self, mock_run_bird):
+        """Return None when --json-full output cannot be parsed into a tweet."""
+        mock_run_bird.return_value = ("not valid json", "", 0)
 
         tweet = read_tweet("123")
 
-        assert tweet is not None
-        assert tweet.is_x_article is True
-        assert any(item["url"] == "https://pbs.twimg.com/media/HAXmiH6acAEiywu.jpg" for item in tweet.media_items)
+        assert tweet is None
 
 
 # ============================================================================

--- a/twag/config.py
+++ b/twag/config.py
@@ -65,6 +65,9 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "auth_token_env": "AUTH_TOKEN",
         "ct0_env": "CT0",
         "min_interval_seconds": 1.0,
+        "retry_max_attempts": 4,
+        "retry_base_seconds": 15.0,
+        "retry_max_seconds": 120.0,
     },
 }
 


### PR DESCRIPTION
## Summary
- Adds exponential backoff retry (up to 4 attempts, 15–120s with jitter) when bird CLI returns a 429 rate-limit error
- Extracts `_run_bird_once` helper and adds `_is_rate_limited` detection
- Simplifies `read_tweet` by removing the json-full→json fallback and media recovery path (no longer needed after tempfile stdout fix in #20)
- Adds `retry_max_attempts`, `retry_base_seconds`, `retry_max_seconds` to bird config defaults

## Test plan
- [x] Updated `test_read_tweet_unparseable_returns_none` to match simplified behavior
- [x] Verify retry behavior with a rate-limited bird CLI session
- [x] Confirm existing fetch/process pipelines work without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)