### PR TITLE
chore: ignore nightshift plan artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ Thumbs.db
 tmp/*
 !tmp/.gitkeep
 .clawdhub/
+
+# Nightshift plan artifacts (keep out of version control)
+.nightshift-plan


### PR DESCRIPTION
## Summary
- Add `.nightshift-plan` to `.gitignore` to keep nightshift plan artifacts out of version control

## Test plan
- [x] Verify `.nightshift-plan` files are no longer tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)