### PR TITLE
docs: fix documentation drift across 4 files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,15 +20,20 @@ FETCH → PROCESS → DIGEST
 **Core packages:**
 - `twag/models/` — Pydantic data models (tweet, scoring, media, links, config, API)
 - `twag/auth.py` — Shared credential and env-file parsing
-- `twag/db/` — SQLite database layer (schema, connections, CRUD, search, maintenance)
+- `twag/config.py` — Runtime config (paths, defaults, following file)
+- `twag/db/` — SQLite database layer (schema, connections, CRUD, search, maintenance, accounts, narratives, reactions, time utils)
 - `twag/fetcher/` — bird CLI integration + tweet parsing/extraction
 - `twag/scorer/` — LLM scoring, prompts, and client management
 - `twag/processor/` — Pipeline orchestration (storage, dependencies, triage, pipeline)
 - `twag/cli/` — Rich-enhanced Click CLI commands
+- `twag/notifier.py` — Telegram alert delivery
 - `twag/renderer.py` — Markdown digest generation
+- `twag/tables.py` — Rich table formatting for CLI output
+- `twag/media.py` — Media handling utilities
 - `twag/link_utils.py` — URL expansion and embed classification
 - `twag/article_visuals.py` — Visual selection for X Articles
-- `twag/web/` — FastAPI backend
+- `twag/article_sections.py` — Article section extraction
+- `twag/web/` — FastAPI backend (app, tweet_utils, routes: tweets, context, prompts, reactions)
 - `twag/web/frontend/` — React feed UI
 
 ## Key Files

--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ twag search "market" --min-score 7          # High-signal only
 - Boolean: `inflation AND fed`, `fed NOT fomc`
 - Prefix: `infla*` (wildcard)
 
+### Analyze Commands
+
+```bash
+twag analyze 1234567890123456789              # Analyze by ID
+twag analyze https://x.com/user/status/123    # Analyze by URL
+twag analyze 1234567890123456789 --reprocess  # Force re-analyze
+twag analyze 1234567890123456789 -m gemini-2.0-flash  # Override model
+```
+
 ### Digest Commands
 
 ```bash
@@ -257,9 +266,12 @@ twag export --days 7            # Export recent data
 ```bash
 twag db path                    # Show database location
 twag db shell                   # Open SQLite shell
+twag db init                    # Initialize/reset database
 twag db rebuild-fts             # Rebuild search index
-twag db dump                    # Backup database
+twag db dump                    # Backup database (auto-named file)
+twag db dump --stdout           # Backup to stdout
 twag db restore backup.sql      # Restore from backup
+twag db restore backup.sql --force  # Restore without confirmation
 ```
 
 ### Web Interface
@@ -301,14 +313,15 @@ Tweets are scored 0-10:
 
 | Score | Signal Level | Behavior |
 |-------|--------------|----------|
-| 8-10 | High signal | Telegram alert (if configured) |
-| 6-7 | Market relevant | Included in digests |
-| 4-5 | News/context | Searchable, not in digests |
-| 0-3 | Noise | Stored but filtered out |
+| 8-10 | Alert | Telegram alert (if configured) |
+| 7 | High signal | Enriched, included in digests |
+| 5-6 | Market relevant | Included in digests |
+| 3-4 | News/context | Searchable, not in digests |
+| 0-2 | Noise | Stored but filtered out |
 
 ### Categories
 
-`fed_policy`, `inflation`, `job_market`, `macro_data`, `earnings`, `equities`, `rates_fx`, `credit`, `banks`, `consumer_spending`, `commodities`, `energy`, `geopolitical`, `tech_business`, `ai_advancement`, `crypto`
+`fed_policy`, `inflation`, `job_market`, `macro_data`, `earnings`, `equities`, `rates_fx`, `credit`, `banks`, `consumer_spending`, `capex`, `commodities`, `energy`, `metals_mining`, `geopolitical`, `sanctions`, `tech_business`, `ai_advancement`, `crypto`, `noise`
 
 ## Automation
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -196,9 +196,11 @@ twag accounts list -t 1       # Tier-1 only
 twag accounts add @handle     # Add account
 twag accounts add @handle -t 1  # Add as tier-1
 twag accounts promote @handle # Promote to tier-1
+twag accounts demote @handle  # Demote to tier-2
 twag accounts mute @handle    # Mute account
 twag accounts boost @handle --amount 10
 twag accounts decay           # Apply daily decay
+twag accounts import          # Import from following.txt
 ```
 
 ### Stats & Maintenance
@@ -215,9 +217,12 @@ twag export --days 7          # Export recent
 ```bash
 twag db path                  # Show location
 twag db shell                 # SQLite shell
+twag db init                  # Initialize/reset database
 twag db rebuild-fts           # Rebuild search index
 twag db dump                  # Backup
+twag db dump --stdout         # Backup to stdout
 twag db restore backup.sql    # Restore
+twag db restore backup.sql --force  # Restore without confirmation
 ```
 
 ### Web UI
@@ -240,14 +245,15 @@ twag config set key value     # Update setting
 
 | Score | Level | Behavior |
 |-------|-------|----------|
-| 8-10 | High signal | Telegram alert |
-| 6-7 | Market relevant | In digests |
-| 4-5 | News/context | Searchable |
-| 0-3 | Noise | Filtered out |
+| 8-10 | Alert | Telegram alert |
+| 7 | High signal | Enriched, in digests |
+| 5-6 | Market relevant | In digests |
+| 3-4 | News/context | Searchable |
+| 0-2 | Noise | Filtered out |
 
 ## Categories
 
-`fed_policy`, `inflation`, `job_market`, `macro_data`, `earnings`, `equities`, `rates_fx`, `credit`, `banks`, `consumer_spending`, `commodities`, `energy`, `geopolitical`, `tech_business`, `ai_advancement`, `crypto`
+`fed_policy`, `inflation`, `job_market`, `macro_data`, `earnings`, `equities`, `rates_fx`, `credit`, `banks`, `consumer_spending`, `capex`, `commodities`, `energy`, `metals_mining`, `geopolitical`, `sanctions`, `tech_business`, `ai_advancement`, `crypto`, `noise`
 
 ## Environment Variables
 

--- a/TELEGRAM_DIGEST_FORMAT.md
+++ b/TELEGRAM_DIGEST_FORMAT.md
@@ -4,7 +4,7 @@
 
 ```bash
 # Read the daily digest file
-cat memory/twitter-feed/YYYY-MM-DD.md
+cat ~/.local/share/twag/digests/YYYY-MM-DD.md
 ```
 
 ## Raw Output Structure


### PR DESCRIPTION
## Summary

- Fix scoring threshold tables in README.md and SKILL.md to match actual config defaults (`min_score_for_digest=5`, `high_signal_threshold=7`, `alert_threshold=8`)
- Add 4 missing categories (`capex`, `metals_mining`, `sanctions`, `noise`) to README.md and SKILL.md
- Fix TELEGRAM_DIGEST_FORMAT.md path reference (`memory/twitter-feed/` → `~/.local/share/twag/digests/`)
- Add 6 missing modules to CLAUDE.md architecture section (`notifier.py`, `media.py`, `tables.py`, `article_sections.py`, `config.py`, expanded db/web submodules)
- Add missing Analyze Commands section to README.md CLI Reference
- Add `db init`, `db dump --stdout`, `db restore --force` to README.md and SKILL.md
- Add `accounts demote` and `accounts import` to SKILL.md

## Test plan

- [x] `uv run pytest` passes (156 tests)
- [ ] Verify scoring thresholds match `twag/models/config.py` defaults
- [ ] Verify categories match `twag/scorer/prompts.py` definitions
- [ ] Verify CLI commands match `twag/cli/` implementations

🤖 Generated with [Claude Code](https://claude.com/claude-code)