### PR TITLE
chore: switch default enrichment model to gemini 3.1 pro

### DIFF
--- a/twag/config.py
+++ b/twag/config.py
@@ -13,8 +13,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "llm": {
         "triage_model": "gemini-3-flash-preview",
         "triage_provider": "gemini",
-        "enrichment_model": "claude-opus-4-5-20251101",
-        "enrichment_provider": "anthropic",
+        "enrichment_model": "gemini-3.1-pro-preview",
+        "enrichment_provider": "gemini",
         "vision_model": "gemini-3-flash-preview",
         "vision_provider": "gemini",
         "max_concurrency_triage": 6,

--- a/twag/models/config.py
+++ b/twag/models/config.py
@@ -10,8 +10,8 @@ class LLMConfig(BaseModel):
 
     triage_model: str = "gemini-3-flash-preview"
     triage_provider: str = "gemini"
-    enrichment_model: str = "claude-opus-4-5-20251101"
-    enrichment_provider: str = "anthropic"
+    enrichment_model: str = "gemini-3.1-pro-preview"
+    enrichment_provider: str = "gemini"
     enrichment_reasoning: str | None = None
     vision_model: str = "gemini-3-flash-preview"
     vision_provider: str = "gemini"


### PR DESCRIPTION
- update enrichment_model and enrichment_provider in config.py and models/config.py
- move from anthropic/claude-opus to gemini/gemini-3.1-pro-preview as default