### PR TITLE
fix: enable and fix PIE, RET505, TC003 lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ line-length = 120
 exclude = ["twag/_version.py"]
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF"]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF", "PIE", "RET505", "TC003"]
 ignore = [
     "E501",    # line too long (handled by formatter)
     "SIM105",  # contextlib.suppress — less readable for multi-line try blocks

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -140,9 +140,8 @@ def main():
     if all_passed:
         print("All tests passed!")
         return 0
-    else:
-        print("Some tests failed!")
-        return 1
+    print("Some tests failed!")
+    return 1
 
 
 if __name__ == "__main__":

--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -31,7 +31,6 @@ from .analyze import _print_status_analysis as _print_status_analysis
 @click.version_option(version=__version__)
 def cli():
     """Twitter aggregator for market-relevant signals."""
-    pass
 
 
 # Register commands

--- a/twag/cli/accounts.py
+++ b/twag/cli/accounts.py
@@ -21,7 +21,6 @@ from ._console import console
 @click.group()
 def accounts():
     """Manage tracked accounts."""
-    pass
 
 
 @accounts.command("list")

--- a/twag/cli/config_cmd.py
+++ b/twag/cli/config_cmd.py
@@ -12,7 +12,6 @@ from ._console import console
 @click.group()
 def config():
     """Manage configuration."""
-    pass
 
 
 @config.command("show")

--- a/twag/cli/db_cmd.py
+++ b/twag/cli/db_cmd.py
@@ -14,7 +14,6 @@ from ._console import console
 @click.group()
 def db():
     """Database operations."""
-    pass
 
 
 @db.command("path")

--- a/twag/cli/narratives.py
+++ b/twag/cli/narratives.py
@@ -10,7 +10,6 @@ from ._console import console
 @click.group()
 def narratives():
     """Manage emerging narratives."""
-    pass
 
 
 @narratives.command("list")

--- a/twag/db/prompts.py
+++ b/twag/db/prompts.py
@@ -193,15 +193,15 @@ def upsert_prompt(
             (template, new_version, datetime.now(timezone.utc).isoformat(), updated_by, name),
         )
         return new_version
-    else:
-        conn.execute(
-            """
-            INSERT INTO prompts (name, template, version, updated_at, updated_by)
-            VALUES (?, ?, 1, ?, ?)
-            """,
-            (name, template, datetime.now(timezone.utc).isoformat(), updated_by),
-        )
-        return 1
+
+    conn.execute(
+        """
+        INSERT INTO prompts (name, template, version, updated_at, updated_by)
+        VALUES (?, ?, 1, ?, ?)
+        """,
+        (name, template, datetime.now(timezone.utc).isoformat(), updated_by),
+    )
+    return 1
 
 
 def get_prompt_history(conn: sqlite3.Connection, name: str, limit: int = 10) -> list[dict[str, Any]]:

--- a/twag/db/tweets.py
+++ b/twag/db/tweets.py
@@ -283,7 +283,7 @@ def _looks_truncated_text(text: str | None) -> bool:
     if not text:
         return False
     stripped = text.rstrip()
-    return bool(stripped) and (stripped.endswith("\u2026") or stripped.endswith("..."))
+    return bool(stripped) and stripped.endswith(("\u2026", "..."))
 
 
 def _merge_duplicate_retweet_metadata(

--- a/twag/models/db_models.py
+++ b/twag/models/db_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime  # noqa: TC003 — Pydantic needs this at runtime
 from typing import Any
 
 from pydantic import BaseModel

--- a/twag/models/tweet.py
+++ b/twag/models/tweet.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime  # noqa: TC003 — Pydantic needs this at runtime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -23,8 +23,7 @@ def is_quiet_hours() -> bool:
     # Handle overnight quiet hours (e.g., 23:00 to 08:00)
     if start > end:
         return hour >= start or hour < end
-    else:
-        return start <= hour < end
+    return start <= hour < end
 
 
 def get_recent_alert_count() -> int:

--- a/twag/processor/dependencies.py
+++ b/twag/processor/dependencies.py
@@ -7,10 +7,12 @@ import logging
 import sqlite3
 import time
 from collections import deque
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from ..db import (
     get_tweet_by_id,

--- a/twag/processor/pipeline.py
+++ b/twag/processor/pipeline.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import logging
-import sqlite3
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
+    from collections.abc import Callable
 
 from ..config import load_config
 from ..db import (

--- a/twag/processor/storage.py
+++ b/twag/processor/storage.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from ..config import load_config
 from ..db import (

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import json
 import re
-import sqlite3
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import sqlite3
+    from collections.abc import Callable
 
 from ..config import load_config
 from ..db import (

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -32,7 +32,7 @@ def _looks_truncated_text(text: str | None) -> bool:
     if not text:
         return False
     stripped = text.rstrip()
-    return bool(stripped) and (stripped.endswith("\u2026") or stripped.endswith("..."))
+    return bool(stripped) and stripped.endswith(("\u2026", "..."))
 
 
 def _build_quote_embed(


### PR DESCRIPTION
## Summary
- Add `PIE`, `RET505`, and `TC003` to the ruff lint rule set in `pyproject.toml`
- Fix all 18 violations across 16 files:
  - **PIE790** (5): Remove unnecessary `pass` in Click command groups
  - **PIE810** (2): Merge separate `endswith()` calls into tuple form
  - **RET505** (3): Remove unnecessary `else` after `return` statements
  - **TC003** (8): Move type-only stdlib imports (`Callable`, `sqlite3`) into `TYPE_CHECKING` blocks; Pydantic model files excluded via `noqa` since they need runtime type resolution

## Test plan
- [x] `ruff check .` passes with zero violations (including the new rules)
- [x] `ruff format --check .` passes (87 files formatted)
- [x] All 168 tests pass

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)