### PR TITLE
chore: add commit-msg and pre-commit git hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,4 +164,7 @@ If command behavior changes, update `README.md` and `SKILL.md` in the same PR.
 - Keep commits focused and atomic
 - Run formatting/lint/tests before committing
 - Don't commit temporary artifacts unless explicitly requested
-- Write descriptive commit messages
+- Use **Conventional Commits** format: `<type>[(<scope>)][!]: <subject>`
+- Allowed type prefixes: `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`, `ci`, `build`, `security`
+- A `commit-msg` git hook enforces this automatically (symlinked from `scripts/hooks/`)
+- A `pre-commit` git hook runs `ruff format --check` and `ruff check` on staged Python files

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# commit-msg hook — enforce Conventional Commits format
+# Symlinked from .git/hooks/commit-msg
+
+set -euo pipefail
+
+MSG_FILE="$1"
+MSG=$(head -1 "$MSG_FILE")
+
+# Skip merge, revert, fixup, and squash commits
+SKIP_PATTERN='^(Merge |Revert |fixup! |squash! )'
+if [[ "$MSG" =~ $SKIP_PATTERN ]]; then
+    exit 0
+fi
+
+# Allowed Conventional Commit types
+TYPES="feat|fix|docs|chore|refactor|perf|test|ci|build|security"
+
+# Pattern: type[(scope)][!]: subject
+# - type is required, from TYPES list
+# - scope is optional, in parentheses
+# - ! for breaking changes is optional
+# - colon + space + non-empty subject is required
+PATTERN="^($TYPES)(\([a-zA-Z0-9_-]+\))?!?: .+"
+
+if ! [[ "$MSG" =~ $PATTERN ]]; then
+    echo "ERROR: Commit message does not follow Conventional Commits format."
+    echo ""
+    echo "  Expected: <type>[(<scope>)][!]: <subject>"
+    echo ""
+    echo "  Allowed types: feat, fix, docs, chore, refactor, perf, test, ci, build, security"
+    echo ""
+    echo "  Examples:"
+    echo "    feat: add user authentication"
+    echo "    fix(parser): handle empty input"
+    echo "    docs: update API reference"
+    echo "    chore!: drop Python 3.9 support"
+    echo ""
+    echo "  Your message: $MSG"
+    exit 1
+fi

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# pre-commit hook — run linters on staged files
+# Symlinked from .git/hooks/pre-commit
+
+set -euo pipefail
+
+# Collect staged Python files
+STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM -- '*.py' || true)
+
+if [ -z "$STAGED_PY" ]; then
+    exit 0
+fi
+
+pids=()
+names=("ruff format" "ruff check")
+failed=0
+
+# shellcheck disable=SC2086
+uv run ruff format --check $STAGED_PY &
+pids+=($!)
+
+# shellcheck disable=SC2086
+uv run ruff check $STAGED_PY &
+pids+=($!)
+
+for i in "${!pids[@]}"; do
+    if ! wait "${pids[$i]}"; then
+        echo "FAILED: ${names[$i]}"
+        failed=1
+    fi
+done
+
+if [ "$failed" -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/hooks/commit-msg` to enforce Conventional Commits format on all commit messages (the `.git/hooks/commit-msg` symlink already existed but the target was missing)
- Add `scripts/hooks/pre-commit` to run `ruff format --check` and `ruff check` on staged Python files (its symlink also already existed)
- Update CLAUDE.md Commit Hygiene section to document the expected format and allowed type prefixes

## Test plan
- [x] Verified commit-msg hook accepts all valid conventional commit formats (feat, fix, docs, chore, refactor, perf, test, ci, build, security)
- [x] Verified scoped types like `fix(parser):` and breaking changes like `chore!:` are accepted
- [x] Verified non-conforming messages are rejected with a helpful error
- [x] Verified merge, revert, fixup, and squash commits are skipped
- [x] Verified the hook itself passes (this commit went through it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local git hooks and developer documentation; they can only block commits locally if misconfigured.
> 
> **Overview**
> Adds repo-managed git hooks under `scripts/hooks/` to **enforce Conventional Commits** via `commit-msg` and to **run `ruff format --check` + `ruff check` on staged `.py` files** via `pre-commit`.
> 
> Updates `CLAUDE.md` to document the required commit message format, allowed types, and that these hooks are expected to be symlinked into `.git/hooks/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dc762c1967529191db717dd98c9eb7e0b2af3f6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/home/clifton/code/twag
task-type: commit-normalize
task-title: Commit Message Normalizer
iterations: 1
duration: 5m54s
nightshift:metadata -->
