### PR TITLE
fix: enable COM812 trailing comma lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ line-length = 120
 exclude = ["twag/_version.py"]
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF", "PIE", "RET505", "TC003", "PERF401", "PLR5501", "PLR1730", "FURB110", "FURB188", "PLW1510", "EXE001"]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF", "PIE", "RET505", "TC003", "PERF401", "PLR5501", "PLR1730", "FURB110", "FURB188", "PLW1510", "EXE001", "COM812"]
 ignore = [
     "E501",    # line too long (handled by formatter)
     "SIM105",  # contextlib.suppress — less readable for multi-line try blocks

--- a/scripts/benchmark_parallelism.py
+++ b/scripts/benchmark_parallelism.py
@@ -190,7 +190,7 @@ def main() -> int:
         f" baseline_s={baseline_s:.4f}"
         f" optimized_s={optimized_s:.4f}"
         f" speedup={speedup:.3f}x"
-        f" min_required={args.min_speedup:.3f}x"
+        f" min_required={args.min_speedup:.3f}x",
     )
 
     if speedup < args.min_speedup:

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -112,7 +112,7 @@ def main():
     print("\nConfigured models:")
     print(f"  Triage:     {config['llm']['triage_model']} ({config['llm'].get('triage_provider', 'anthropic')})")
     print(
-        f"  Enrichment: {config['llm']['enrichment_model']} ({config['llm'].get('enrichment_provider', 'anthropic')})"
+        f"  Enrichment: {config['llm']['enrichment_model']} ({config['llm'].get('enrichment_provider', 'anthropic')})",
     )
     print(f"  Vision:     {config['llm']['vision_model']} ({config['llm'].get('vision_provider', 'anthropic')})")
 

--- a/tests/test_article_processing.py
+++ b/tests/test_article_processing.py
@@ -53,11 +53,11 @@ def test_x_article_text_fallback_from_blocks() -> None:
                                 {"text": "Paragraph one."},
                                 {"text": "  "},
                                 {"text": "Paragraph two."},
-                            ]
+                            ],
                         },
-                    }
-                }
-            }
+                    },
+                },
+            },
         },
     }
 
@@ -288,7 +288,7 @@ def test_summarize_x_article_falls_back_to_triage_provider(monkeypatch) -> None:
                 "enrichment_provider": "anthropic",
                 "triage_model": "gemini-3-flash-preview",
                 "triage_provider": "gemini",
-            }
+            },
         },
     )
 

--- a/tests/test_article_sections.py
+++ b/tests/test_article_sections.py
@@ -16,7 +16,7 @@ def test_parse_primary_points_filters_invalid_entries():
             {"point": "", "reasoning": "invalid"},
             {"reasoning": "missing point"},
             "not-a-dict",
-        ]
+        ],
     )
 
     points = parse_primary_points(payload)
@@ -26,7 +26,7 @@ def test_parse_primary_points_filters_invalid_entries():
             "point": "Google capex is entering a new regime.",
             "reasoning": "Demand backlog supports accelerated deployment.",
             "evidence": "$240B backlog and strong cloud growth.",
-        }
+        },
     ]
 
 
@@ -42,7 +42,7 @@ def test_parse_action_items_normalizes_horizon_confidence_and_tickers():
             },
             {"action": "", "trigger": "invalid"},
             {"trigger": "missing action"},
-        ]
+        ],
     )
 
     actions = parse_action_items(payload)
@@ -54,7 +54,7 @@ def test_parse_action_items_normalizes_horizon_confidence_and_tickers():
             "horizon": "medium term",
             "confidence": "0.65",
             "tickers": "GOOGL, MSFT, AMZN",
-        }
+        },
     ]
 
 

--- a/tests/test_article_visuals.py
+++ b/tests/test_article_visuals.py
@@ -39,7 +39,7 @@ def test_build_article_visuals_infers_chart_kind_from_payload() -> None:
         {
             "url": "https://example.com/inferred-chart.jpg",
             "chart": {"description": "Revenue by quarter"},
-        }
+        },
     ]
     visuals = build_article_visuals(top_visual=None, media_items=media, max_items=3)
     assert len(visuals) == 1
@@ -80,7 +80,7 @@ def test_build_article_visuals_skips_non_data_top_visual() -> None:
             "url": "https://example.com/relevant-chart.jpg",
             "kind": "chart",
             "chart": {"insight": "Revenue acceleration by quarter"},
-        }
+        },
     ]
     visuals = build_article_visuals(top_visual=top, media_items=media, max_items=4)
 

--- a/tests/test_cli_analyze_status.py
+++ b/tests/test_cli_analyze_status.py
@@ -61,8 +61,8 @@ def _sample_row(processed_at: str | None = None) -> dict:
                     "point": "Capex acceleration is unprecedented",
                     "reasoning": "Spend is stepping higher into 2026.",
                     "evidence": "$180B guide versus prior years.",
-                }
-            ]
+                },
+            ],
         ),
         "article_action_items_json": json.dumps(
             [
@@ -72,8 +72,8 @@ def _sample_row(processed_at: str | None = None) -> dict:
                     "horizon": "2-4 quarters",
                     "confidence": "medium",
                     "tickers": ["GOOGL", "MSFT"],
-                }
-            ]
+                },
+            ],
         ),
         "article_top_visual_json": json.dumps(
             {
@@ -81,7 +81,7 @@ def _sample_row(processed_at: str | None = None) -> dict:
                 "kind": "chart",
                 "why_important": "Most relevant quantitative visual supporting the thesis.",
                 "key_takeaway": "2026 capex bar is the largest in the series.",
-            }
+            },
         ),
         "media_items": json.dumps(
             [
@@ -95,7 +95,7 @@ def _sample_row(processed_at: str | None = None) -> dict:
                     "kind": "photo",
                     "short_description": "office selfie",
                 },
-            ]
+            ],
         ),
         "processed_at": processed_at,
     }
@@ -229,8 +229,8 @@ def test_print_status_analysis_wraps_and_labels_long_fields(monkeypatch, capsys)
                 "point": "Google's $180B capex plan is historically unprecedented at single-company scale.",
                 "reasoning": "Magnitude rivals peak dotcom telecom buildout on an inflation-adjusted basis.",
                 "evidence": "Compares to Apollo and Interstate totals while staying self-funded by operations.",
-            }
-        ]
+            },
+        ],
     )
     row["article_action_items_json"] = json.dumps(
         [
@@ -240,8 +240,8 @@ def test_print_status_analysis_wraps_and_labels_long_fields(monkeypatch, capsys)
                 "horizon": "medium_term",
                 "confidence": 0.7,
                 "tickers": ["GOOGL", "MSFT", "AMZN"],
-            }
-        ]
+            },
+        ],
     )
     monkeypatch.setattr(cli_mod, "_analysis_wrap_width", lambda: 72)
 
@@ -273,13 +273,13 @@ def test_print_status_analysis_skips_invalid_points_and_actions(capsys):
         [
             {"point": "", "reasoning": "missing main point", "evidence": "ignored"},
             {"reasoning": "non-point dict"},
-        ]
+        ],
     )
     row["article_action_items_json"] = json.dumps(
         [
             {"action": "", "trigger": "missing action"},
             {"trigger": "action key missing"},
-        ]
+        ],
     )
 
     cli_mod._print_status_analysis(row)

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -366,7 +366,7 @@ def test_browse_json_article_fields(monkeypatch):
             _make_feed_tweet(
                 is_x_article=True,
                 article_summary_short="Key takeaways from the report",
-            )
+            ),
         ]
 
     monkeypatch.setattr(cli_mod, "get_connection", _fake_connection)

--- a/tests/test_db_dump_restore.py
+++ b/tests/test_db_dump_restore.py
@@ -51,7 +51,7 @@ class TestIsFilteredStatement:
     def test_insert_sqlite_master(self):
         assert _is_fts_statement(
             "INSERT INTO sqlite_master(type,name,tbl_name,rootpage,sql) "
-            "VALUES('table','tweets_fts','tweets_fts',0,'...');"
+            "VALUES('table','tweets_fts','tweets_fts',0,'...');",
         )
 
     def test_fts_table(self):

--- a/tests/test_db_retweet_backfill.py
+++ b/tests/test_db_retweet_backfill.py
@@ -45,7 +45,7 @@ def test_insert_tweet_duplicate_backfills_retweet_metadata(tmp_path):
                 original_content
             FROM tweets
             WHERE id = 'rt-1'
-            """
+            """,
         ).fetchone()
 
     assert row is not None

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -244,8 +244,8 @@ class TestTweetFromBirdJson:
                         "url": "https://t.co/abc",
                         "expanded_url": "https://x.com/other/status/999",
                         "display_url": "x.com/other/status/999",
-                    }
-                ]
+                    },
+                ],
             },
         }
         tweet = Tweet.from_bird_json(data)
@@ -256,7 +256,7 @@ class TestTweetFromBirdJson:
                 "url": "https://t.co/abc",
                 "expanded_url": "https://x.com/other/status/999",
                 "display_url": "x.com/other/status/999",
-            }
+            },
         ]
 
     def test_parse_x_article_uses_content_when_plain_text_missing(self):
@@ -401,9 +401,9 @@ class TestTweetFromBirdJson:
                                             "AI is going to become the home screen of a ludicrously high percentage of "
                                             "white collar workers in the next two years and parallel agents will be deployed "
                                             "in the battlefield of knowledge work at downright Soviet levels"
-                                        )
-                                    }
-                                }
+                                        ),
+                                    },
+                                },
                             },
                             "core": {
                                 "user_results": {
@@ -411,9 +411,9 @@ class TestTweetFromBirdJson:
                                         "core": {
                                             "screen_name": "DKThomp",
                                             "name": "Derek Thompson",
-                                        }
-                                    }
-                                }
+                                        },
+                                    },
+                                },
                             },
                             "legacy": {
                                 "full_text": (
@@ -421,11 +421,11 @@ class TestTweetFromBirdJson:
                                     "and the odds that we're actually quite under-built for the necessary levels "
                                     "of inference/usage went significantly up in that period \n\nbasically I think "
                                     "AI is going to become the home screen of a"
-                                )
+                                ),
                             },
-                        }
-                    }
-                }
+                        },
+                    },
+                },
             },
         }
 

--- a/tests/test_link_utils.py
+++ b/tests/test_link_utils.py
@@ -24,7 +24,7 @@ def test_normalize_tweet_links_expands_short_urls_without_structured_links(monke
             "url": "https://github.com/aliasvault/aliasvault",
             "display_url": "github.com/aliasvault/aliasvault",
             "domain": "github.com",
-        }
+        },
     ]
 
 
@@ -66,7 +66,7 @@ def test_normalize_tweet_links_keeps_expanded_external_and_drops_unresolved_self
             "url": "https://github.com/aliasvault/aliasvault",
             "display_url": "github.com/aliasvault/aliasvault",
             "domain": "github.com",
-        }
+        },
     ]
 
 
@@ -87,7 +87,7 @@ def test_normalize_tweet_links_drops_only_trailing_unresolved_short_link_for_med
             "url": "https://t.co/JBlilG6yJ3",
             "display_url": "t.co/JBlilG6yJ3",
             "domain": "t.co",
-        }
+        },
     ]
 
 
@@ -112,7 +112,7 @@ def test_normalize_tweet_links_drops_trailing_unresolved_short_link_when_other_l
             "url": "https://github.com/fixie-ai/ultravox",
             "display_url": "github.com/fixie-ai/ultravox",
             "domain": "github.com",
-        }
+        },
     ]
 
 
@@ -130,7 +130,7 @@ def test_expand_links_in_place_limits_short_url_expansions(monkeypatch):
             {"url": "https://t.co/one"},
             {"url": "https://t.co/two"},
             {"url": "https://t.co/three"},
-        ]
+        ],
     )
 
     assert len(seen) == 2
@@ -153,7 +153,7 @@ def test_normalize_tweet_links_already_expanded_skips_network_expansion(monkeypa
                 "url": "https://t.co/ext",
                 "expanded_url": "https://example.com/report",
                 "display_url": "example.com/report",
-            }
+            },
         ],
         already_expanded=True,
     )
@@ -164,5 +164,5 @@ def test_normalize_tweet_links_already_expanded_skips_network_expansion(monkeypa
             "url": "https://example.com/report",
             "display_url": "example.com/report",
             "domain": "example.com",
-        }
+        },
     ]

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -50,7 +50,7 @@ def test_process_unprocessed_expands_links_and_persists_before_triage(monkeypatc
                 "url": "https://t.co/ext",
                 "expanded_url": "https://github.com/example/project",
                 "display_url": "github.com/example/project",
-            }
+            },
         ]
 
     captured_rows: list[dict] = []
@@ -100,7 +100,7 @@ def test_process_unprocessed_skips_already_expanded_links(monkeypatch, tmp_path)
                     "url": "https://t.co/ext",
                     "expanded_url": "https://github.com/example/project",
                     "display_url": "github.com/example/project",
-                }
+                },
             ],
         )
         assert inserted is True
@@ -214,7 +214,7 @@ def test_reprocess_today_quoted_expands_quote_row_links(monkeypatch, tmp_path) -
                 "url": "https://t.co/ext",
                 "expanded_url": "https://github.com/example/project",
                 "display_url": "github.com/example/project",
-            }
+            },
         ],
     )
     monkeypatch.setattr(pipeline_mod, "_triage_rows", lambda _conn, **_kwargs: [])
@@ -316,7 +316,7 @@ def test_process_unprocessed_adds_thread_linked_tweet_to_processing_stack(monkey
                     "url": "https://t.co/thread1",
                     "expanded_url": "https://x.com/thread_user/status/10001",
                     "display_url": "x.com/thread_user/status/10001",
-                }
+                },
             ],
         )
         assert inserted_root is True

--- a/tests/test_renderer_links.py
+++ b/tests/test_renderer_links.py
@@ -98,7 +98,7 @@ def test_render_digest_does_not_expand_short_urls_at_render_time(monkeypatch, tm
                     "url": "https://t.co/ext",
                     "expanded_url": "https://github.com/example/project",
                     "display_url": "github.com/example/project",
-                }
+                },
             ],
         )
         assert inserted is True

--- a/tests/test_web_tweets_api.py
+++ b/tests/test_web_tweets_api.py
@@ -259,7 +259,7 @@ def test_list_tweets_normalizes_self_and_inline_links(monkeypatch, tmp_path):
             "url": "https://github.com/aliasvault/aliasvault",
             "display_url": "github.com/aliasvault/aliasvault",
             "domain": "github.com",
-        }
+        },
     ]
 
 
@@ -340,7 +340,7 @@ def test_list_tweets_drops_trailing_unresolved_short_link_when_other_link_resolv
                     "url": "https://t.co/ext",
                     "expanded_url": "https://github.com/fixie-ai/ultravox",
                     "display_url": "github.com/fixie-ai/ultravox",
-                }
+                },
             ],
             has_media=False,
         )
@@ -359,7 +359,7 @@ def test_list_tweets_drops_trailing_unresolved_short_link_when_other_link_resolv
             "url": "https://github.com/fixie-ai/ultravox",
             "display_url": "github.com/fixie-ai/ultravox",
             "domain": "github.com",
-        }
+        },
     ]
 
 
@@ -380,7 +380,7 @@ def test_list_tweets_does_not_expand_short_urls_on_request(monkeypatch, tmp_path
                     "url": "https://t.co/ext",
                     "expanded_url": "https://github.com/example/project",
                     "display_url": "github.com/example/project",
-                }
+                },
             ],
         )
         conn.commit()

--- a/twag/article_sections.py
+++ b/twag/article_sections.py
@@ -44,7 +44,7 @@ def parse_primary_points(value: str | None, *, limit: int | None = None) -> list
                 "point": point,
                 "reasoning": str(item.get("reasoning") or "").strip(),
                 "evidence": str(item.get("evidence") or "").strip(),
-            }
+            },
         )
         if limit is not None and len(points) >= limit:
             break
@@ -74,7 +74,7 @@ def parse_action_items(value: str | None, *, limit: int | None = None) -> list[d
                 "horizon": normalize_horizon(item.get("horizon")),
                 "confidence": format_confidence(item.get("confidence")),
                 "tickers": ticker_text,
-            }
+            },
         )
         if limit is not None and len(actions) >= limit:
             break

--- a/twag/article_visuals.py
+++ b/twag/article_visuals.py
@@ -7,7 +7,7 @@ from typing import Any
 
 _DATA_KINDS = {"chart", "table", "document", "screenshot"}
 _TEXTUAL_DATA_PATTERN = re.compile(
-    r"\b(chart|graph|table|capex|revenue|margin|growth|yoy|qoq|forecast|projection|run[-\s]?rate|backlog|roi|ebitda|eps)\b"
+    r"\b(chart|graph|table|capex|revenue|margin|growth|yoy|qoq|forecast|projection|run[-\s]?rate|backlog|roi|ebitda|eps)\b",
 )
 _NUMERIC_DATA_PATTERN = re.compile(r"(\$|\b\d+(\.\d+)?%|\b\d+(\.\d+)?\s?(b|m|bn|mn|trillion|billion|million)\b)")
 _NOISE_PATTERN = re.compile(r"\b(meme|reaction image|shitpost|joke|selfie|portrait)\b")
@@ -100,7 +100,7 @@ def build_article_visuals(
                         "is_top": True,
                         "why_important": why_important,
                         "key_takeaway": key_takeaway,
-                    }
+                    },
                 )
                 seen_urls.add(top_url)
 
@@ -128,7 +128,7 @@ def build_article_visuals(
                         "why_important": "",
                         "key_takeaway": takeaway,
                     },
-                )
+                ),
             )
             seen_urls.add(url)
 

--- a/twag/cli/analyze.py
+++ b/twag/cli/analyze.py
@@ -36,7 +36,7 @@ def _echo_wrapped(text: str, *, initial_indent: str = "", subsequent_indent: str
             subsequent_indent=subsequent_indent,
             break_long_words=False,
             break_on_hyphens=False,
-        )
+        ),
     )
 
 

--- a/twag/cli/db_cmd.py
+++ b/twag/cli/db_cmd.py
@@ -140,7 +140,7 @@ def db_restore(input_file: str, force: bool):
     try:
         counts = restore_sql(sql_script, db_file, backup=True)
         console.print(
-            f"Restored database: {counts['tweets']} tweets, {counts['accounts']} accounts, {counts['fts']} FTS entries"
+            f"Restored database: {counts['tweets']} tweets, {counts['accounts']} accounts, {counts['fts']} FTS entries",
         )
     except Exception as e:
         console.print(f"[red]Error restoring database: {e}[/red]")

--- a/twag/cli/fetch.py
+++ b/twag/cli/fetch.py
@@ -20,7 +20,10 @@ from ._progress import RichProgressReporter, create_progress, make_callbacks
 @click.option("--bookmarks/--no-bookmarks", default=True, help="Also fetch bookmarks")
 @click.option("--delay", type=float, default=None, help="Delay between tier-1 fetches (default: 3s)")
 @click.option(
-    "--stagger", type=int, default=None, help="Only fetch N tier-1 accounts (rotates by least-recently-fetched)"
+    "--stagger",
+    type=int,
+    default=None,
+    help="Only fetch N tier-1 accounts (rotates by least-recently-fetched)",
 )
 def fetch(
     status_id_or_url: str | None,

--- a/twag/cli/init_cmd.py
+++ b/twag/cli/init_cmd.py
@@ -198,7 +198,7 @@ def doctor():
                 "\n".join(f"  - {issue}" for issue in issues),
                 title=f"{len(issues)} issue(s) found",
                 border_style="red",
-            )
+            ),
         )
         sys.exit(1)
     elif warnings:
@@ -207,7 +207,7 @@ def doctor():
                 "\n".join(f"  - {w}" for w in warnings),
                 title=f"All checks passed with {len(warnings)} warning(s)",
                 border_style="yellow",
-            )
+            ),
         )
     else:
         console.print("\n[green]All checks passed![/green]")

--- a/twag/cli/process.py
+++ b/twag/cli/process.py
@@ -52,7 +52,7 @@ def process(
             target_row = get_tweet_by_id(conn, target_tweet_id)
             if not target_row:
                 raise click.ClickException(
-                    f"Status not found in database: {target_tweet_id}. Fetch it first with `twag fetch {target_tweet_id}`."
+                    f"Status not found in database: {target_tweet_id}. Fetch it first with `twag fetch {target_tweet_id}`.",
                 )
             unprocessed_rows = [target_row]
         else:

--- a/twag/cli/search.py
+++ b/twag/cli/search.py
@@ -37,7 +37,12 @@ from ._console import console
     help="Sort order: rank (BM25, requires query), score, time",
 )
 @click.option(
-    "--format", "-f", "fmt", type=click.Choice(["brief", "full", "json"]), default="brief", help="Output format"
+    "--format",
+    "-f",
+    "fmt",
+    type=click.Choice(["brief", "full", "json"]),
+    default="brief",
+    help="Output format",
 )
 def search(
     query: str | None,

--- a/twag/cli/web.py
+++ b/twag/cli/web.py
@@ -100,7 +100,7 @@ def web(host: str, port: int, reload: bool, dev: bool):
             subprocess.run(cmd, check=True)
         except FileNotFoundError:
             console.print(
-                "[red]Error: 'uv' not found. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh[/red]"
+                "[red]Error: 'uv' not found. Install with: curl -LsSf https://astral.sh/uv/install.sh | sh[/red]",
             )
             sys.exit(1)
         except KeyboardInterrupt:

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -136,17 +136,17 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
     # Ensure performance indexes exist on existing databases
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tweets_processed_score "
-        "ON tweets(processed_at, relevance_score DESC, created_at DESC)"
+        "ON tweets(processed_at, relevance_score DESC, created_at DESC)",
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tweets_author ON tweets(author_handle)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tweets_signal_tier ON tweets(signal_tier)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_tweets_bookmarked ON tweets(bookmarked) WHERE bookmarked = 1")
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tweets_quote ON tweets(quote_tweet_id) WHERE quote_tweet_id IS NOT NULL"
+        "CREATE INDEX IF NOT EXISTS idx_tweets_quote ON tweets(quote_tweet_id) WHERE quote_tweet_id IS NOT NULL",
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tweets_reply "
-        "ON tweets(in_reply_to_tweet_id) WHERE in_reply_to_tweet_id IS NOT NULL"
+        "ON tweets(in_reply_to_tweet_id) WHERE in_reply_to_tweet_id IS NOT NULL",
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_fetch_log_endpoint ON fetch_log(endpoint, executed_at DESC)")
 

--- a/twag/db/context_commands.py
+++ b/twag/db/context_commands.py
@@ -67,7 +67,7 @@ def get_all_context_commands(conn: sqlite3.Connection, enabled_only: bool = Fals
                 description=row["description"],
                 enabled=bool(row["enabled"]),
                 created_at=created_at,
-            )
+            ),
         )
     return results
 

--- a/twag/db/narratives.py
+++ b/twag/db/narratives.py
@@ -41,7 +41,7 @@ def get_active_narratives(conn: sqlite3.Connection) -> list[sqlite3.Row]:
         SELECT * FROM narratives
         WHERE active = 1
         ORDER BY last_mentioned_at DESC
-        """
+        """,
     )
     return cursor.fetchall()
 

--- a/twag/db/prompts.py
+++ b/twag/db/prompts.py
@@ -151,7 +151,7 @@ def get_all_prompts(conn: sqlite3.Connection) -> list[Prompt]:
                 version=row["version"],
                 updated_at=updated_at,
                 updated_by=row["updated_by"],
-            )
+            ),
         )
     return results
 

--- a/twag/db/reactions.py
+++ b/twag/db/reactions.py
@@ -63,7 +63,7 @@ def get_reactions_for_tweet(conn: sqlite3.Connection, tweet_id: str) -> list[Rea
                 reason=row["reason"],
                 target=row["target"],
                 created_at=created_at,
-            )
+            ),
         )
     return results
 
@@ -75,7 +75,7 @@ def get_reactions_summary(conn: sqlite3.Connection) -> dict[str, int]:
         SELECT reaction_type, COUNT(*) as count
         FROM reactions
         GROUP BY reaction_type
-        """
+        """,
     )
     return {row["reaction_type"]: row["count"] for row in cursor.fetchall()}
 

--- a/twag/db/search.py
+++ b/twag/db/search.py
@@ -271,7 +271,7 @@ def search_tweets(
                 tickers=tickers,
                 bookmarked=bool(row["bookmarked"]),
                 rank=row["rank"],
-            )
+            ),
         )
 
     return results
@@ -485,7 +485,7 @@ def get_feed_tweets(
                 original_author_name=row["original_author_name"],
                 original_content=row["original_content"],
                 reactions=reactions,
-            )
+            ),
         )
 
     return results

--- a/twag/db/tweets.py
+++ b/twag/db/tweets.py
@@ -603,7 +603,7 @@ def get_processed_counts(conn: sqlite3.Connection) -> dict[str, int]:
             SUM(CASE WHEN processed_at >= datetime('now', '-7 days') THEN 1 ELSE 0 END) as last_7d
         FROM tweets
         WHERE processed_at IS NOT NULL
-        """
+        """,
     )
     row = cursor.fetchone()
     if row:
@@ -637,7 +637,7 @@ def get_bookmark_counts_by_author(conn: sqlite3.Connection) -> list[tuple[str, i
         WHERE bookmarked = 1
         GROUP BY author_handle
         ORDER BY bookmark_count DESC
-        """
+        """,
     )
     return [(row[0], row[1]) for row in cursor.fetchall()]
 

--- a/twag/fetcher/extractors.py
+++ b/twag/fetcher/extractors.py
@@ -83,7 +83,7 @@ class Tweet:
             or data.get("inReplyToStatusIdStr")
             or legacy.get("in_reply_to_status_id_str")
             or legacy.get("in_reply_to_status_id")
-            or ""
+            or "",
         ).strip()
         if not in_reply_to_tweet_id:
             in_reply_to_tweet_id = None
@@ -94,7 +94,7 @@ class Tweet:
             or data.get("conversation_id")
             or legacy.get("conversation_id_str")
             or legacy.get("conversation_id")
-            or ""
+            or "",
         ).strip()
         if not conversation_id:
             conversation_id = None
@@ -106,7 +106,7 @@ class Tweet:
             media_items
             or data.get("media")
             or data.get("entities", {}).get("media")
-            or data.get("extended_entities", {}).get("media")
+            or data.get("extended_entities", {}).get("media"),
         )
 
         # Links
@@ -387,7 +387,7 @@ def _extract_media_items(data: dict[str, Any]) -> list[dict[str, Any]]:
                     "type": "photo",
                     "source": "article",
                     "media_id": media.get("media_id"),
-                }
+                },
             )
 
     cover_media = raw_article_result.get("cover_media") if isinstance(raw_article_result, dict) else {}
@@ -402,7 +402,7 @@ def _extract_media_items(data: dict[str, Any]) -> list[dict[str, Any]]:
                     "type": "photo",
                     "source": "article_cover",
                     "media_id": cover_media.get("media_id"),
-                }
+                },
             )
 
     items: list[dict[str, Any]] = []
@@ -459,7 +459,7 @@ def _extract_links(data: dict[str, Any], content: str) -> list[dict[str, str]]:
                 "url": raw or resolved,
                 "expanded_url": resolved,
                 "display_url": display,
-            }
+            },
         )
 
     if not links:

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -147,7 +147,10 @@ def expand_links_in_place(links: list[dict]) -> list[dict]:
 
 
 def _normalize_structured_links(
-    text: str, links: list[dict], *, already_expanded: bool = False
+    text: str,
+    links: list[dict],
+    *,
+    already_expanded: bool = False,
 ) -> list[dict[str, str]]:
     normalized: list[dict[str, str]] = []
     seen_keys: set[tuple[str, str]] = set()
@@ -179,7 +182,7 @@ def _normalize_structured_links(
                 "url": raw_url or resolved,
                 "expanded_url": resolved,
                 "display_url": display_url or _display_url_for(resolved),
-            }
+            },
         )
 
     known_urls = {item["url"] for item in normalized} | {item["expanded_url"] for item in normalized}
@@ -275,7 +278,7 @@ def normalize_tweet_links(
     has_resolved_non_short = any(
         bool(
             (item.get("expanded_url") or item.get("url"))
-            and not _is_shortener_url(item.get("expanded_url") or item.get("url"))  # ty: ignore[invalid-argument-type]
+            and not _is_shortener_url(item.get("expanded_url") or item.get("url")),  # ty: ignore[invalid-argument-type]
         )
         for item in normalized_links
     )
@@ -307,7 +310,7 @@ def normalize_tweet_links(
                 {
                     "id": status_id,
                     "url": expanded_url or raw_url,
-                }
+                },
             )
             continue
 
@@ -322,7 +325,7 @@ def normalize_tweet_links(
                 "url": resolved,
                 "display_url": display_url or _display_url_for(resolved),
                 "domain": _domain_for(resolved),
-            }
+            },
         )
 
     display_text = replace_urls_in_text(raw_text, external_replacements)

--- a/twag/processor/dependencies.py
+++ b/twag/processor/dependencies.py
@@ -40,7 +40,9 @@ def _row_get(row: sqlite3.Row | dict[str, Any], key: str, default: Any = None) -
 
 
 def _extract_inline_linked_tweet_ids_from_links_json(
-    links_json: str | None, *, skip_id: str | None = None
+    links_json: str | None,
+    *,
+    skip_id: str | None = None,
 ) -> list[str]:
     if not links_json:
         return []

--- a/twag/processor/pipeline.py
+++ b/twag/processor/pipeline.py
@@ -101,7 +101,7 @@ def process_unprocessed(
                     "id": tweet_id,
                     "text": row["content"],
                     "handle": row["author_handle"],
-                }
+                },
             )
             tweet_map[tweet_id] = row
 

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -250,21 +250,21 @@ def _select_article_top_visual(
                 str(chart.get("description", "")),
                 str(chart.get("insight", "")),
                 str(chart.get("implication", "")),
-            ]
+            ],
         ).strip()
         table_text = " ".join(
             [
                 str(table.get("title", "")),
                 str(table.get("description", "")),
                 str(table.get("summary", "")),
-            ]
+            ],
         ).strip()
         prose_text = " ".join(
             [
                 str(item.get("prose_summary", "")),
                 str(item.get("short_description", "")),
                 str(item.get("prose_text", "")),
-            ]
+            ],
         ).strip()
         candidate_text = " ".join(part for part in [chart_text, table_text, prose_text] if part).strip()
         if not candidate_text:
@@ -373,7 +373,7 @@ def _triage_rows(
                 "id": tweet_id,
                 "text": _build_triage_text(row),
                 "handle": row["author_handle"],
-            }
+            },
         )
         tweet_map[tweet_id] = row
 
@@ -505,7 +505,9 @@ def _triage_rows(
             try:
                 if media_items and _needs_media_analysis(media_items):
                     media_items, _ = _analyze_media_items(
-                        media_items, vision_model=vision_model, vision_provider=vision_provider
+                        media_items,
+                        vision_model=vision_model,
+                        vision_provider=vision_provider,
                     )
                 article_result = summarize_x_article(
                     article_text,

--- a/twag/renderer.py
+++ b/twag/renderer.py
@@ -78,7 +78,7 @@ def render_digest(
                     "",
                     "## 🔥 High Signal",
                     "",
-                ]
+                ],
             )
             for tweet in high_signal:
                 lines.extend(_render_tweet(conn, tweet))
@@ -91,7 +91,7 @@ def render_digest(
                     "",
                     "## 📈 Market Relevant",
                     "",
-                ]
+                ],
             )
             for tweet in market_relevant:
                 lines.extend(_render_tweet(conn, tweet))
@@ -104,7 +104,7 @@ def render_digest(
                     "",
                     "## 📰 News/Context",
                     "",
-                ]
+                ],
             )
             for tweet in news:
                 lines.extend(_render_tweet(conn, tweet, compact=True))

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -86,7 +86,7 @@ def _call_anthropic_vision(model: str, image_url: str, prompt: str, max_tokens: 
                         "text": prompt,
                     },
                 ],
-            }
+            },
         ],
     )
     return _extract_anthropic_text(response.content)

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -147,7 +147,7 @@ def triage_tweets_batch(
                 categories=categories,
                 summary=item.get("summary", ""),
                 tickers=item.get("tickers", []),
-            )
+            ),
         )
 
     return results
@@ -302,7 +302,7 @@ def summarize_x_article(
                     "point": point,
                     "reasoning": reasoning_text,
                     "evidence": evidence,
-                }
+                },
             )
 
     action_raw = data.get("actionable_items")
@@ -327,7 +327,7 @@ def summarize_x_article(
                     "horizon": (item.get("horizon") or "").strip(),
                     "confidence": confidence,
                     "tickers": [str(t).upper() for t in tickers if isinstance(t, str) and t.strip()],
-                }
+                },
             )
 
     return XArticleSummaryResult(

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -60,7 +60,7 @@ async def list_context_commands(
                 "created_at": cmd.created_at.isoformat() if cmd.created_at else None,
             }
             for cmd in commands
-        ]
+        ],
     }
 
 

--- a/twag/web/routes/prompts.py
+++ b/twag/web/routes/prompts.py
@@ -51,7 +51,7 @@ async def list_prompts(request: Request) -> dict[str, Any]:
                 "updated_by": p.updated_by,
             }
             for p in prompts
-        ]
+        ],
     }
 
 
@@ -169,7 +169,7 @@ async def tune_prompt(request: Request, tune_req: TuneRequest) -> dict[str, Any]
             reason_text = f" (Reason: {reaction.reason})" if reaction.reason else ""
             examples.append(
                 f"- Score: {tweet['relevance_score']}, Categories: {categories}, "
-                f"Summary: {tweet['summary'][:100]}...{reason_text}"
+                f"Summary: {tweet['summary'][:100]}...{reason_text}",
             )
         return "\n".join(examples) if examples else "[none]"
 

--- a/twag/web/routes/reactions.py
+++ b/twag/web/routes/reactions.py
@@ -177,7 +177,7 @@ async def export_reactions(
                     "categories": categories,
                     "signal_tier": tweet["signal_tier"],
                 },
-            }
+            },
         )
 
     return {

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -36,7 +36,11 @@ def _looks_truncated_text(text: str | None) -> bool:
 
 
 def _build_quote_embed(
-    conn, quote_id: str | None, *, depth: int = 0, seen: set[str] | None = None
+    conn,
+    quote_id: str | None,
+    *,
+    depth: int = 0,
+    seen: set[str] | None = None,
 ) -> dict[str, Any] | None:
     if not quote_id:
         return None
@@ -355,7 +359,7 @@ async def list_tweets(
                     "reference_links": reference_links,
                     "external_links": normalized.external_links,
                     "display_content": display_content,
-                }
+                },
             )
 
     return {
@@ -476,7 +480,7 @@ async def list_categories(request: Request) -> dict[str, Any]:
             WHERE category IS NOT NULL AND processed_at IS NOT NULL
             GROUP BY category
             ORDER BY count DESC
-            """
+            """,
         )
         raw_counts = {row["category"]: row["count"] for row in cursor.fetchall()}
 
@@ -514,7 +518,7 @@ async def list_tickers(request: Request, limit: int = 50) -> dict[str, Any]:
             SELECT tickers
             FROM tweets
             WHERE tickers IS NOT NULL AND processed_at IS NOT NULL
-            """
+            """,
         )
         rows = cursor.fetchall()
 


### PR DESCRIPTION
## Summary
- Enable the `COM812` (missing trailing comma) ruff lint rule in `pyproject.toml`
- Auto-fix all 115 violations across 43 files
- Trailing commas improve git diffs and reduce merge conflicts when adding items to multi-line collections

## Test plan
- [x] `uv run ruff check .` — all checks pass
- [x] `uv run ruff format .` — formatting clean
- [x] `uv run pytest` — all 168 tests pass

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)