### PR TITLE
Add 103 unit tests for 6 untested modules

### DIFF
--- a/tests/test_article_processing.py
+++ b/tests/test_article_processing.py
@@ -242,7 +242,7 @@ def test_build_triage_text_prefers_article_body() -> None:
         "article_preview": "Preview",
         "article_text": "Deep dive " * 800,
     }
-    text = _build_triage_text(row)  # type: ignore[arg-type]
+    text = _build_triage_text(row)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     assert text.startswith("Capex note")
     assert "Deep dive" in text

--- a/tests/test_db_accounts.py
+++ b/tests/test_db_accounts.py
@@ -1,0 +1,207 @@
+"""Tests for twag.db.accounts — account CRUD with in-memory SQLite."""
+
+import sqlite3
+
+import pytest
+
+from twag.db.accounts import (
+    apply_account_decay,
+    boost_account,
+    demote_account,
+    get_accounts,
+    mute_account,
+    promote_account,
+    upsert_account,
+)
+
+ACCOUNTS_SCHEMA = """
+CREATE TABLE accounts (
+    handle TEXT PRIMARY KEY,
+    display_name TEXT,
+    tier INTEGER DEFAULT 2,
+    weight REAL DEFAULT 50.0,
+    category TEXT,
+    tweets_seen INTEGER DEFAULT 0,
+    tweets_kept INTEGER DEFAULT 0,
+    avg_relevance_score REAL,
+    last_high_signal_at TIMESTAMP,
+    last_fetched_at TIMESTAMP,
+    added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    auto_promoted INTEGER DEFAULT 0,
+    muted INTEGER DEFAULT 0
+);
+"""
+
+
+@pytest.fixture
+def conn():
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.executescript(ACCOUNTS_SCHEMA)
+    yield db
+    db.close()
+
+
+class TestUpsertAccount:
+    def test_insert_new(self, conn):
+        upsert_account(conn, "alice", display_name="Alice", tier=1)
+        conn.commit()
+        row = conn.execute("SELECT * FROM accounts WHERE handle = 'alice'").fetchone()
+        assert row is not None
+        assert row["display_name"] == "Alice"
+        assert row["tier"] == 1
+
+    def test_update_preserves_display_name(self, conn):
+        upsert_account(conn, "bob", display_name="Bob", tier=2)
+        conn.commit()
+        # Update without display_name — should keep "Bob"
+        upsert_account(conn, "bob", display_name=None, tier=2)
+        conn.commit()
+        row = conn.execute("SELECT * FROM accounts WHERE handle = 'bob'").fetchone()
+        assert row["display_name"] == "Bob"
+
+    def test_update_tier_only_promotes(self, conn):
+        upsert_account(conn, "charlie", tier=2)
+        conn.commit()
+        # tier=1 is better (lower) than 2, so should update
+        upsert_account(conn, "charlie", tier=1)
+        conn.commit()
+        row = conn.execute("SELECT * FROM accounts WHERE handle = 'charlie'").fetchone()
+        assert row["tier"] == 1
+
+    def test_update_tier_no_demote(self, conn):
+        upsert_account(conn, "dave", tier=1)
+        conn.commit()
+        # tier=2 is worse (higher) than 1, should NOT update
+        upsert_account(conn, "dave", tier=2)
+        conn.commit()
+        row = conn.execute("SELECT * FROM accounts WHERE handle = 'dave'").fetchone()
+        assert row["tier"] == 1
+
+    def test_strips_at_sign(self, conn):
+        upsert_account(conn, "@testuser")
+        conn.commit()
+        row = conn.execute("SELECT * FROM accounts WHERE handle = 'testuser'").fetchone()
+        assert row is not None
+
+
+class TestGetAccounts:
+    def _seed(self, conn):
+        upsert_account(conn, "tier1", tier=1)
+        upsert_account(conn, "tier2a", tier=2)
+        upsert_account(conn, "tier2b", tier=2)
+        conn.commit()
+
+    def test_tier_filter(self, conn):
+        self._seed(conn)
+        rows = get_accounts(conn, tier=1)
+        assert len(rows) == 1
+        assert rows[0]["handle"] == "tier1"
+
+    def test_muted_excluded_by_default(self, conn):
+        self._seed(conn)
+        mute_account(conn, "tier2a")
+        conn.commit()
+        rows = get_accounts(conn)
+        handles = {r["handle"] for r in rows}
+        assert "tier2a" not in handles
+
+    def test_include_muted(self, conn):
+        self._seed(conn)
+        mute_account(conn, "tier2a")
+        conn.commit()
+        rows = get_accounts(conn, include_muted=True)
+        handles = {r["handle"] for r in rows}
+        assert "tier2a" in handles
+
+    def test_ordering_default(self, conn):
+        self._seed(conn)
+        rows = get_accounts(conn)
+        # Default: tier ASC, weight DESC → tier1 first
+        assert rows[0]["handle"] == "tier1"
+
+    def test_limit(self, conn):
+        self._seed(conn)
+        rows = get_accounts(conn, limit=2)
+        assert len(rows) == 2
+
+
+class TestPromoteAccount:
+    def test_promote_to_tier1(self, conn):
+        upsert_account(conn, "user1", tier=2)
+        conn.commit()
+        promote_account(conn, "user1")
+        conn.commit()
+        row = conn.execute("SELECT tier FROM accounts WHERE handle = 'user1'").fetchone()
+        assert row["tier"] == 1
+
+
+class TestDemoteAccount:
+    def test_demote(self, conn):
+        upsert_account(conn, "user1", tier=1)
+        conn.commit()
+        demote_account(conn, "user1", tier=3)
+        conn.commit()
+        row = conn.execute("SELECT tier FROM accounts WHERE handle = 'user1'").fetchone()
+        assert row["tier"] == 3
+
+
+class TestMuteAccount:
+    def test_mute(self, conn):
+        upsert_account(conn, "user1")
+        conn.commit()
+        mute_account(conn, "user1")
+        conn.commit()
+        row = conn.execute("SELECT muted FROM accounts WHERE handle = 'user1'").fetchone()
+        assert row["muted"] == 1
+
+
+class TestBoostAccount:
+    def test_boost_increases_weight(self, conn):
+        upsert_account(conn, "user1")
+        conn.commit()
+        boost_account(conn, "user1", amount=10.0)
+        conn.commit()
+        row = conn.execute("SELECT weight FROM accounts WHERE handle = 'user1'").fetchone()
+        assert row["weight"] == 60.0
+
+    def test_boost_clamps_at_100(self, conn):
+        upsert_account(conn, "user1")
+        conn.commit()
+        boost_account(conn, "user1", amount=200.0)
+        conn.commit()
+        row = conn.execute("SELECT weight FROM accounts WHERE handle = 'user1'").fetchone()
+        assert row["weight"] == 100.0
+
+
+class TestApplyAccountDecay:
+    def test_decay_reduces_weight(self, conn):
+        upsert_account(conn, "user1")
+        conn.commit()
+        affected = apply_account_decay(conn, decay_rate=0.1)
+        conn.commit()
+        assert affected >= 1
+        row = conn.execute("SELECT weight FROM accounts WHERE handle = 'user1'").fetchone()
+        assert row["weight"] == pytest.approx(45.0)
+
+    def test_decay_skips_recent_high_signal(self, conn):
+        upsert_account(conn, "active")
+        conn.commit()
+        # Set a recent high signal timestamp
+        conn.execute("UPDATE accounts SET last_high_signal_at = datetime('now') WHERE handle = 'active'")
+        conn.commit()
+        original = conn.execute("SELECT weight FROM accounts WHERE handle = 'active'").fetchone()
+        apply_account_decay(conn, decay_rate=0.1)
+        conn.commit()
+        after = conn.execute("SELECT weight FROM accounts WHERE handle = 'active'").fetchone()
+        assert after["weight"] == original["weight"]
+
+    def test_decay_floor_at_10(self, conn):
+        upsert_account(conn, "low")
+        conn.commit()
+        conn.execute("UPDATE accounts SET weight = 10.0 WHERE handle = 'low'")
+        conn.commit()
+        apply_account_decay(conn, decay_rate=0.5)
+        conn.commit()
+        row = conn.execute("SELECT weight FROM accounts WHERE handle = 'low'").fetchone()
+        assert row["weight"] == 10.0

--- a/tests/test_db_retweet_backfill.py
+++ b/tests/test_db_retweet_backfill.py
@@ -215,7 +215,7 @@ def test_insert_tweet_retries_transient_database_lock(monkeypatch):
     monkeypatch.setattr(db_connection_mod.time, "sleep", lambda delay: sleeps.append(delay))
 
     inserted = insert_tweet(
-        conn,  # type: ignore[arg-type]
+        conn,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         tweet_id="retry-1",
         author_handle="retry_user",
         content="retry content",

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,116 @@
+"""Tests for twag.media — media parsing and formatting."""
+
+import json
+
+from twag.media import build_media_context, build_media_summary, parse_media_items
+
+
+class TestParseMediaItems:
+    def test_none_input(self):
+        assert parse_media_items(None) == []
+
+    def test_empty_string(self):
+        assert parse_media_items("") == []
+
+    def test_invalid_json(self):
+        assert parse_media_items("not json{") == []
+
+    def test_dict_with_items_key(self):
+        data = {"items": [{"kind": "photo"}, {"kind": "video"}]}
+        result = parse_media_items(json.dumps(data))
+        assert len(result) == 2
+        assert result[0]["kind"] == "photo"
+
+    def test_list_format(self):
+        data = [{"kind": "photo"}, {"kind": "video"}]
+        result = parse_media_items(json.dumps(data))
+        assert len(result) == 2
+
+    def test_non_dict_items_filtered(self):
+        data = [{"kind": "photo"}, "not_a_dict", 42, {"kind": "video"}]
+        result = parse_media_items(json.dumps(data))
+        assert len(result) == 2
+
+    def test_unexpected_structure(self):
+        # A dict without "items" key and not a list
+        assert parse_media_items(json.dumps({"foo": "bar"})) == []
+
+    def test_empty_items(self):
+        assert parse_media_items(json.dumps({"items": []})) == []
+        assert parse_media_items(json.dumps([])) == []
+
+
+class TestBuildMediaSummary:
+    def test_empty_list(self):
+        assert build_media_summary([]) == ""
+
+    def test_prose_summary_priority(self):
+        items = [{"prose_summary": "A chart showing growth", "short_description": "chart img"}]
+        assert build_media_summary(items) == "A chart showing growth"
+
+    def test_chart_description_fallback(self):
+        items = [{"chart": {"description": "S&P 500 performance"}}]
+        assert build_media_summary(items) == "Chart: S&P 500 performance"
+
+    def test_short_description_fallback(self):
+        items = [{"short_description": "a logo"}]
+        assert build_media_summary(items) == "a logo"
+
+    def test_pipe_joining(self):
+        items = [
+            {"prose_summary": "First"},
+            {"prose_summary": "Second"},
+        ]
+        assert build_media_summary(items) == "First | Second"
+
+    def test_empty_fields_skipped(self):
+        items = [{"prose_summary": "", "short_description": "", "chart": {}}]
+        assert build_media_summary(items) == ""
+
+
+class TestBuildMediaContext:
+    def test_empty_list(self):
+        assert build_media_context([]) == ""
+
+    def test_kind_header(self):
+        items = [{"kind": "photo", "short_description": "a dog"}]
+        result = build_media_context(items)
+        assert "Media 1 (photo)" in result
+        assert "Image description: a dog" in result
+
+    def test_prose_text_branch(self):
+        items = [{"prose_text": "Full document text here", "kind": "document"}]
+        result = build_media_context(items)
+        assert "Document text:" in result
+        assert "Full document text here" in result
+
+    def test_chart_branch(self):
+        items = [
+            {
+                "kind": "image",
+                "chart": {
+                    "description": "Revenue chart",
+                    "insight": "Revenue grew 20%",
+                    "implication": "Strong quarter ahead",
+                },
+            }
+        ]
+        result = build_media_context(items)
+        assert "Chart description: Revenue chart" in result
+        assert "Chart insight: Revenue grew 20%" in result
+        assert "Chart implication: Strong quarter ahead" in result
+
+    def test_multi_media_formatting(self):
+        items = [
+            {"kind": "photo", "short_description": "first"},
+            {"kind": "video", "short_description": "second"},
+        ]
+        result = build_media_context(items)
+        assert "Media 1 (photo)" in result
+        assert "Media 2 (video)" in result
+        assert "\n\n" in result  # sections separated by blank line
+
+    def test_default_kind(self):
+        items = [{"short_description": "no kind specified"}]
+        result = build_media_context(items)
+        assert "Media 1 (image)" in result

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,162 @@
+"""Tests for twag.notifier — alert formatting and send-gating logic."""
+
+from unittest.mock import patch
+
+from twag.notifier import can_send_alert, format_alert
+
+
+class TestFormatAlert:
+    def test_list_category_filters_noise(self):
+        result = format_alert(
+            tweet_id="123",
+            author_handle="testuser",
+            content="short content",
+            category=["macro", "noise", "earnings"],
+            summary="Big earnings beat",
+        )
+        assert "MACRO" in result
+        assert "EARNINGS" in result
+        assert "NOISE" not in result
+
+    def test_string_category(self):
+        result = format_alert(
+            tweet_id="123",
+            author_handle="testuser",
+            content="content",
+            category="breaking_news",
+            summary="summary",
+        )
+        assert "BREAKING NEWS" in result
+
+    def test_empty_category_list_defaults_to_market(self):
+        result = format_alert(
+            tweet_id="123",
+            author_handle="testuser",
+            content="content",
+            category=["noise"],
+            summary="summary",
+        )
+        assert "MARKET" in result
+
+    def test_tickers_displayed(self):
+        result = format_alert(
+            tweet_id="123",
+            author_handle="testuser",
+            content="content",
+            category="macro",
+            summary="summary",
+            tickers=["AAPL", "TSLA"],
+        )
+        assert "AAPL" in result
+        assert "TSLA" in result
+
+    def test_content_truncation(self):
+        long_content = "x" * 200
+        result = format_alert(
+            tweet_id="123",
+            author_handle="testuser",
+            content=long_content,
+            category="macro",
+            summary="summary",
+        )
+        assert "..." in result
+        # Truncated to 150 chars + "..."
+        assert "x" * 151 not in result
+
+    def test_short_content_not_truncated(self):
+        result = format_alert(
+            tweet_id="123",
+            author_handle="testuser",
+            content="short",
+            category="macro",
+            summary="summary",
+        )
+        assert "..." not in result.split("@testuser")[1].split("\n")[0]
+
+    def test_empty_summary_omitted(self):
+        result = format_alert(
+            tweet_id="123",
+            author_handle="testuser",
+            content="content",
+            category="macro",
+            summary="",
+        )
+        # The summary emoji line should not appear
+        lines = result.split("\n")
+        assert not any(line.startswith("📊") for line in lines)
+
+    def test_no_tickers_omitted(self):
+        result = format_alert(
+            tweet_id="123",
+            author_handle="testuser",
+            content="content",
+            category="macro",
+            summary="summary",
+        )
+        lines = result.split("\n")
+        assert not any("Tickers" in line for line in lines)
+
+    def test_tweet_url_included(self):
+        result = format_alert(
+            tweet_id="456",
+            author_handle="trader",
+            content="content",
+            category="macro",
+            summary="summary",
+        )
+        assert "x.com/trader/status/456" in result
+
+
+class TestCanSendAlert:
+    def _mock_config(self, overrides=None):
+        base = {
+            "notifications": {
+                "telegram_enabled": True,
+                "quiet_hours_start": 23,
+                "quiet_hours_end": 8,
+                "max_alerts_per_hour": 10,
+            },
+            "scoring": {"alert_threshold": 7},
+        }
+        if overrides:
+            base["notifications"].update(overrides)
+        return base
+
+    def test_disabled_returns_false(self):
+        config = self._mock_config({"telegram_enabled": False})
+        with patch("twag.notifier.load_config", return_value=config):
+            assert can_send_alert(score=9) is False
+
+    def test_score_10_overrides_quiet_hours(self):
+        config = self._mock_config({"telegram_enabled": True})
+        with (
+            patch("twag.notifier.load_config", return_value=config),
+            patch("twag.notifier.is_quiet_hours", return_value=True),
+        ):
+            assert can_send_alert(score=10) is True
+
+    def test_quiet_hours_blocks(self):
+        config = self._mock_config({"telegram_enabled": True})
+        with (
+            patch("twag.notifier.load_config", return_value=config),
+            patch("twag.notifier.is_quiet_hours", return_value=True),
+        ):
+            assert can_send_alert(score=5) is False
+
+    def test_rate_limit_blocks(self):
+        config = self._mock_config({"telegram_enabled": True, "max_alerts_per_hour": 5})
+        with (
+            patch("twag.notifier.load_config", return_value=config),
+            patch("twag.notifier.is_quiet_hours", return_value=False),
+            patch("twag.notifier.get_recent_alert_count", return_value=5),
+        ):
+            assert can_send_alert(score=5) is False
+
+    def test_normal_conditions_allow(self):
+        config = self._mock_config({"telegram_enabled": True})
+        with (
+            patch("twag.notifier.load_config", return_value=config),
+            patch("twag.notifier.is_quiet_hours", return_value=False),
+            patch("twag.notifier.get_recent_alert_count", return_value=0),
+        ):
+            assert can_send_alert(score=5) is True

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,80 @@
+"""Tests for twag.text_utils — surrogate sanitization."""
+
+from twag.text_utils import replace_lone_surrogates, sanitize_nested_strings, sanitize_text
+
+
+class TestReplaceLoneSurrogates:
+    def test_empty_string(self):
+        assert replace_lone_surrogates("") == ""
+
+    def test_clean_string(self):
+        assert replace_lone_surrogates("hello world") == "hello world"
+
+    def test_lone_high_surrogate(self):
+        # U+D800 is a lone high surrogate
+        text = "before\ud800after"
+        result = replace_lone_surrogates(text)
+        assert result == "before\ufffdafter"
+
+    def test_lone_low_surrogate(self):
+        text = "before\udc00after"
+        result = replace_lone_surrogates(text)
+        assert result == "before\ufffdafter"
+
+    def test_multiple_surrogates(self):
+        text = "\ud800test\udbff\udc00end"
+        result = replace_lone_surrogates(text)
+        assert "\ud800" not in result
+        assert "\udbff" not in result
+        assert "\udc00" not in result
+        assert "test" in result
+        assert "end" in result
+
+    def test_no_surrogates_returns_original(self):
+        text = "normal ascii + émojis 🎉"
+        assert replace_lone_surrogates(text) is text  # same object
+
+
+class TestSanitizeText:
+    def test_none_returns_none(self):
+        assert sanitize_text(None) is None
+
+    def test_clean_string(self):
+        assert sanitize_text("hello") == "hello"
+
+    def test_surrogate_replaced(self):
+        assert sanitize_text("x\ud800y") == "x\ufffdy"
+
+
+class TestSanitizeNestedStrings:
+    def test_plain_string(self):
+        assert sanitize_nested_strings("hello\ud800") == "hello\ufffd"
+
+    def test_integer_passthrough(self):
+        assert sanitize_nested_strings(42) == 42
+
+    def test_none_passthrough(self):
+        assert sanitize_nested_strings(None) is None
+
+    def test_list(self):
+        result = sanitize_nested_strings(["ok", "bad\ud800"])
+        assert result == ["ok", "bad\ufffd"]
+
+    def test_tuple(self):
+        result = sanitize_nested_strings(("ok", "bad\ud800"))
+        assert result == ("ok", "bad\ufffd")
+        assert isinstance(result, tuple)
+
+    def test_dict_keys_and_values(self):
+        result = sanitize_nested_strings({"key\ud800": "val\udc00"})
+        assert result == {"key\ufffd": "val\ufffd"}
+
+    def test_nested_structure(self):
+        data = {"a": ["x\ud800", {"b": "y\udc00"}]}
+        result = sanitize_nested_strings(data)
+        assert result == {"a": ["x\ufffd", {"b": "y\ufffd"}]}
+
+    def test_empty_containers(self):
+        assert sanitize_nested_strings([]) == []
+        assert sanitize_nested_strings({}) == {}
+        assert sanitize_nested_strings(()) == ()

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,83 @@
+"""Tests for twag.db.time_utils — time range parsing and market day cutoff."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from twag.db.time_utils import _get_et_offset, parse_time_range
+
+
+class TestGetEtOffset:
+    def test_summer_returns_edt(self):
+        """July should be EDT (UTC-4)."""
+        summer = datetime(2025, 7, 15, 12, 0, tzinfo=timezone.utc)
+        with patch("twag.db.time_utils.datetime") as mock_dt:
+            mock_dt.now.return_value = summer
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = _get_et_offset()
+        assert result == timedelta(hours=-4)
+
+    def test_winter_returns_est(self):
+        """January should be EST (UTC-5)."""
+        winter = datetime(2025, 1, 15, 12, 0, tzinfo=timezone.utc)
+        with patch("twag.db.time_utils.datetime") as mock_dt:
+            mock_dt.now.return_value = winter
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = _get_et_offset()
+        assert result == timedelta(hours=-5)
+
+
+class TestParseTimeRange:
+    def test_relative_days(self):
+        since, until = parse_time_range("7d")
+        assert since is not None
+        assert until is None
+        assert (datetime.now(timezone.utc) - since).total_seconds() < 7 * 86400 + 5
+
+    def test_relative_hours(self):
+        since, until = parse_time_range("24h")
+        assert since is not None
+        assert until is None
+        elapsed = (datetime.now(timezone.utc) - since).total_seconds()
+        assert 24 * 3600 - 5 < elapsed < 24 * 3600 + 5
+
+    def test_relative_weeks(self):
+        since, until = parse_time_range("1w")
+        assert since is not None
+        elapsed = (datetime.now(timezone.utc) - since).total_seconds()
+        assert elapsed < 7 * 86400 + 5
+
+    def test_relative_months(self):
+        since, until = parse_time_range("2m")
+        assert since is not None
+        elapsed = (datetime.now(timezone.utc) - since).total_seconds()
+        assert elapsed < 60 * 86400 + 5
+
+    def test_single_date(self):
+        since, until = parse_time_range("2025-01-15")
+        assert since == datetime(2025, 1, 15, tzinfo=timezone.utc)
+        assert until == datetime(2025, 1, 16, tzinfo=timezone.utc)
+
+    def test_date_range(self):
+        since, until = parse_time_range("2025-01-15..2025-01-20")
+        assert since == datetime(2025, 1, 15, tzinfo=timezone.utc)
+        assert until == datetime(2025, 1, 21, tzinfo=timezone.utc)
+
+    def test_today(self):
+        since, until = parse_time_range("today")
+        assert since is not None
+        assert until is None
+        # Should be within the last few days (market cutoff)
+        assert (datetime.now(timezone.utc) - since).days <= 4
+
+    def test_invalid_returns_none(self):
+        since, until = parse_time_range("garbage")
+        assert since is None
+        assert until is None
+
+    def test_whitespace_stripped(self):
+        since, until = parse_time_range("  7d  ")
+        assert since is not None
+
+    def test_case_insensitive(self):
+        since, until = parse_time_range("TODAY")
+        assert since is not None

--- a/tests/test_web_tweet_utils.py
+++ b/tests/test_web_tweet_utils.py
@@ -1,0 +1,140 @@
+"""Tests for twag.web.tweet_utils — URL parsing, HTML decoding, date handling."""
+
+from datetime import datetime, timezone
+
+from twag.web.tweet_utils import (
+    decode_html_entities,
+    extract_tweet_links,
+    parse_created_at,
+    quote_embed_from_row,
+    remove_tweet_links,
+)
+
+
+class TestParseCreatedAt:
+    def test_none_returns_none(self):
+        assert parse_created_at(None) is None
+
+    def test_datetime_passthrough(self):
+        dt = datetime(2025, 1, 15, 12, 0, tzinfo=timezone.utc)
+        assert parse_created_at(dt) is dt
+
+    def test_iso_string(self):
+        result = parse_created_at("2025-01-15T12:00:00+00:00")
+        assert result == datetime(2025, 1, 15, 12, 0, tzinfo=timezone.utc)
+
+    def test_z_suffix(self):
+        result = parse_created_at("2025-01-15T12:00:00Z")
+        assert result == datetime(2025, 1, 15, 12, 0, tzinfo=timezone.utc)
+
+    def test_invalid_returns_none(self):
+        assert parse_created_at("not a date") is None
+
+
+class TestExtractTweetLinks:
+    def test_x_com_url(self):
+        text = "Check https://x.com/user/status/123456789"
+        result = extract_tweet_links(text)
+        assert len(result) == 1
+        assert result[0][0] == "123456789"
+
+    def test_twitter_com_url(self):
+        text = "See https://twitter.com/user/status/987654321"
+        result = extract_tweet_links(text)
+        assert len(result) == 1
+        assert result[0][0] == "987654321"
+
+    def test_mobile_url(self):
+        text = "Link https://mobile.x.com/user/status/111222333"
+        result = extract_tweet_links(text)
+        assert len(result) == 1
+        assert result[0][0] == "111222333"
+
+    def test_no_matches(self):
+        assert extract_tweet_links("no links here") == []
+
+    def test_multiple_links(self):
+        text = "A https://x.com/a/status/111 B https://x.com/b/status/222"
+        result = extract_tweet_links(text)
+        assert len(result) == 2
+
+    def test_url_with_query_params(self):
+        text = "https://x.com/user/status/555?s=20&t=abc"
+        result = extract_tweet_links(text)
+        assert len(result) == 1
+        assert result[0][0] == "555"
+
+
+class TestRemoveTweetLinks:
+    def test_removes_matching_ids(self):
+        text = "Hello https://x.com/user/status/123 world"
+        links = [("123", "https://x.com/user/status/123")]
+        result = remove_tweet_links(text, links, remove_ids={"123"})
+        assert "https://x.com" not in result
+        assert "Hello" in result
+        assert "world" in result
+
+    def test_preserves_non_matching(self):
+        text = "Hello https://x.com/user/status/123 world"
+        links = [("123", "https://x.com/user/status/123")]
+        result = remove_tweet_links(text, links, remove_ids={"999"})
+        assert "https://x.com/user/status/123" in result
+
+    def test_whitespace_collapse(self):
+        text = "Hello   https://x.com/user/status/123   world"
+        links = [("123", "https://x.com/user/status/123")]
+        result = remove_tweet_links(text, links, remove_ids={"123"})
+        # Should collapse multiple spaces
+        assert "  " not in result
+
+
+class TestDecodeHtmlEntities:
+    def test_none_returns_none(self):
+        assert decode_html_entities(None) is None
+
+    def test_html_entities(self):
+        assert decode_html_entities("&amp; &lt; &gt;") == "& < >"
+
+    def test_plain_text_unchanged(self):
+        assert decode_html_entities("hello world") == "hello world"
+
+    def test_numeric_entities(self):
+        assert decode_html_entities("&#39;") == "'"
+
+
+class TestQuoteEmbedFromRow:
+    def _make_row(self, **kwargs):
+        """Create a dict-like row object."""
+        defaults = {
+            "id": "123",
+            "author_handle": "user",
+            "author_name": "User Name",
+            "content": "tweet content",
+            "created_at": "2025-01-15T12:00:00Z",
+        }
+        defaults.update(kwargs)
+        return defaults
+
+    def test_basic_mapping(self):
+        row = self._make_row()
+        result = quote_embed_from_row(row)
+        assert result["id"] == "123"
+        assert result["author_handle"] == "user"
+        assert result["author_name"] == "User Name"
+        assert result["content"] == "tweet content"
+
+    def test_created_at_formatting(self):
+        row = self._make_row(created_at="2025-01-15T12:00:00Z")
+        result = quote_embed_from_row(row)
+        assert result["created_at"] is not None
+        assert "2025-01-15" in result["created_at"]
+
+    def test_none_created_at(self):
+        row = self._make_row(created_at=None)
+        result = quote_embed_from_row(row)
+        assert result["created_at"] is None
+
+    def test_html_entities_decoded(self):
+        row = self._make_row(content="&amp; earnings")
+        result = quote_embed_from_row(row)
+        assert result["content"] == "& earnings"


### PR DESCRIPTION
## Summary
- Add 6 new test files covering modules with zero test coverage: `text_utils`, `db/time_utils`, `media`, `notifier`, `web/tweet_utils`, `db/accounts`
- 103 new tests, bringing total from 193 to 296 (all passing)
- Fix 2 pre-existing `ty` type-checker suppressions so pre-commit hook passes

## New test files
| File | Tests | Module covered |
|------|-------|----------------|
| `tests/test_text_utils.py` | 17 | Surrogate sanitization (replace, sanitize_text, nested) |
| `tests/test_time_utils.py` | 12 | Time range parsing, ET offset (DST/EST) |
| `tests/test_media.py` | 20 | Media item parsing, summary/context formatting |
| `tests/test_notifier.py` | 14 | Alert formatting, send-gating logic |
| `tests/test_web_tweet_utils.py` | 22 | URL parsing, HTML decoding, date handling, quote embeds |
| `tests/test_db_accounts.py` | 18 | Account CRUD with in-memory SQLite |

## Test plan
- [x] All 103 new tests pass
- [x] Full suite: 296 passed (no regressions)
- [x] ruff format/check clean
- [x] ty check clean
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: test-gap:/home/clifton/code/twag
task-type: test-gap
task-title: Test Gap Finder
iterations: 3
duration: 22m20s
nightshift:metadata -->
