### PR TITLE
feat: add privacy policy and consistency checker

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,147 @@
+# Privacy Policy
+
+Last updated: 2026-03-08
+
+twag is a **local-first** Twitter/X market signal aggregator. It runs on your
+machine, stores data locally, and exposes a web interface only on `localhost`.
+
+---
+
+## Data Collected
+
+twag fetches and stores the following from Twitter/X via the `bird` CLI:
+
+- **Tweet content** — full text, quoted text, article body text
+- **Author information** — handles (`@username`) and display names
+- **Media URLs** — links to images/videos hosted on Twitter CDN (`pbs.twimg.com`)
+- **Links** — URLs embedded in tweets (expanded from `t.co` short links)
+- **Engagement metadata** — retweet/quote attribution
+- **LLM-generated analysis** — relevance scores, summaries, tickers, narratives,
+  image descriptions, article summaries and action items
+
+## Data Storage
+
+| Store | Location | Contents |
+|-------|----------|----------|
+| SQLite database | `~/.local/share/twag/tweets.db` (configurable) | All tweet data, accounts, narratives, reactions, prompts, fetch logs |
+| Digest files | `~/.local/share/twag/digests/` | Markdown digest exports |
+| Config | `~/.config/twag/` | Following list, settings |
+| Credentials | `~/.env` or environment variables | API keys and auth tokens |
+
+### Database Tables
+
+| Table | Privacy-relevant data |
+|-------|----------------------|
+| `tweets` | `author_handle`, `author_name`, `content`, `original_content`, `article_text`, `summary`, `links_json`, `original_author_handle`, `original_author_name`, `retweeted_by_handle`, `retweeted_by_name`, `analysis_json` |
+| `accounts` | `handle`, `display_name`, `tier`, `weight`, `muted`, `tweets_seen`, `tweets_kept`, `avg_relevance_score` |
+| `narratives` | `name`, `sentiment`, `related_tickers` |
+| `tweet_narratives` | Junction table (tweet ↔ narrative) |
+| `fetch_log` | `endpoint`, `query_params` |
+| `reactions` | `reaction_type`, `reason`, `target` (may contain author handles) |
+| `prompts` | `name`, `template`, `updated_by` |
+| `prompt_history` | `prompt_name`, `template`, `version` |
+| `context_commands` | `name`, `command_template`, `description` |
+| `tweets_fts` | FTS5 index over `content`, `summary`, `author_handle`, `tickers` |
+
+## External Services
+
+### Twitter/X (via bird CLI)
+
+- **What is sent:** authentication tokens (`AUTH_TOKEN`, `CT0`) as CLI flags
+- **What is received:** tweet JSON payloads (content, authors, media, links)
+- **Note:** auth tokens are visible in the process list while `bird` runs
+
+### LLM APIs (Gemini / Anthropic)
+
+- **Gemini (Google):** tweet text, author handles, prompts, and raw image bytes
+  are sent to the Gemini API for scoring and vision analysis
+- **Anthropic:** tweet text, author handles, prompts, and image URLs are sent to
+  the Anthropic API; Anthropic fetches images server-side from the provided URL
+
+Data sent to LLMs includes: full tweet text, author handles, quoted tweet text,
+article summaries, image descriptions, link summaries, and LLM prompt templates.
+
+### Telegram
+
+- **What is sent:** author handle, tweet content preview (up to 150 chars),
+  LLM-generated summary, tickers, and tweet URL
+- **Sent via:** `POST` to `https://api.telegram.org/bot{token}/sendMessage`
+
+### Link Expansion Destinations
+
+- **What is sent:** HTTP HEAD/GET requests to `t.co` short URLs, which redirect
+  to the final destination URL
+- **User-Agent:** `twag/1.0 (+https://github.com/clifton/twag)`
+- **Scope:** only `t.co` domain URLs are expanded; max 512 per process lifetime
+
+### Image Fetching (for Gemini vision)
+
+- **What is fetched:** raw image bytes from tweet media URLs
+  (typically `pbs.twimg.com`)
+- **Via:** `httpx.get()` with 30s timeout
+
+## Credential Handling
+
+| Credential | Source | Usage |
+|------------|--------|-------|
+| `AUTH_TOKEN` | `~/.env` or env var | Twitter session token, passed as bird CLI flag |
+| `CT0` | `~/.env` or env var | Twitter CSRF token, passed as bird CLI flag |
+| `GEMINI_API_KEY` | `~/.env` or env var | Google Gemini API authentication |
+| `ANTHROPIC_API_KEY` | `~/.env` or env var | Anthropic API authentication |
+| `TELEGRAM_BOT_TOKEN` | env var only | Telegram bot API authentication |
+| `TELEGRAM_CHAT_ID` | env var or config | Telegram destination chat |
+
+Credentials are loaded by `twag/auth.py` from environment variables or `~/.env`.
+The full process environment is passed to the `bird` subprocess.
+
+## Web API Exposure
+
+The web interface binds to **localhost only** (`127.0.0.1`). CORS is restricted
+to `localhost` and `127.0.0.1` origins.
+
+- **No authentication** is required to access the web API
+- **No cookies or sessions** are used
+- **No analytics or tracking** is present
+
+### Endpoints
+
+| Method | Path | Data exposed |
+|--------|------|--------------|
+| GET | `/api/tweets` | Paginated tweet feed with content, summaries, media, links, author data |
+| GET | `/api/tweets/{tweet_id}` | Single tweet with all stored fields |
+| GET | `/api/categories` | Category counts |
+| GET | `/api/tickers` | Ticker mention counts |
+| POST | `/api/react` | Store reaction (can trigger account muting) |
+| GET | `/api/reactions/{tweet_id}` | Reactions for a tweet |
+| DELETE | `/api/reactions/{reaction_id}` | Delete a reaction |
+| GET | `/api/reactions/summary` | Reaction type counts |
+| GET | `/api/reactions/export` | Reactions with tweet data for LLM prompt tuning |
+| GET | `/api/prompts` | LLM prompt templates |
+| GET | `/api/prompts/{name}` | Single prompt |
+| PUT | `/api/prompts/{name}` | Update prompt |
+| GET | `/api/prompts/{name}/history` | Prompt version history |
+| POST | `/api/prompts/{name}/rollback` | Rollback prompt |
+| POST | `/api/prompts/tune` | Send reactions + tweet content to LLM |
+| POST | `/api/prompts/{name}/apply-suggestion` | Apply LLM suggestion |
+| GET | `/api/context-commands` | Shell command templates |
+| POST | `/api/context-commands` | Create command template |
+| GET | `/api/context-commands/{name}` | Get command |
+| PUT | `/api/context-commands/{name}` | Update command |
+| DELETE | `/api/context-commands/{name}` | Delete command |
+| POST | `/api/context-commands/{name}/toggle` | Enable/disable command |
+| POST | `/api/context-commands/{name}/test` | Execute shell command with tweet variable substitution |
+| POST | `/api/analyze/{tweet_id}` | Run shell commands + LLM analysis on tweet |
+| GET | `/{full_path:path}` | SPA frontend catch-all |
+
+## Data Retention
+
+- The `twag prune` command removes tweets older than a configurable threshold
+- No automatic data expiration — pruning is user-initiated
+- Digest files persist until manually deleted
+
+## Logging
+
+- Python logging may include tweet IDs, bird CLI command names, and stderr output
+- **No tweet content, author handles, or URLs are written to log output**
+- Rich console output to terminal (stdout) includes tweet content and author
+  handles during interactive CLI use

--- a/scripts/check_privacy.py
+++ b/scripts/check_privacy.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Privacy policy consistency checker.
+
+Scans the twag codebase and verifies that PRIVACY.md accurately documents:
+1. External HTTP/API calls
+2. Database tables storing personal data
+3. Credential environment variables
+4. Web API endpoints
+5. Logging of personal data
+
+Exit code 0 = all checks pass, 1 = discrepancies found.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRIVACY_MD = REPO_ROOT / "PRIVACY.md"
+TWAG_SRC = REPO_ROOT / "twag"
+
+
+def _read_privacy() -> str:
+    return PRIVACY_MD.read_text()
+
+
+def _python_files() -> list[Path]:
+    return sorted(TWAG_SRC.rglob("*.py"))
+
+
+# ---------------------------------------------------------------------------
+# 1. External service calls
+# ---------------------------------------------------------------------------
+
+# Patterns that indicate outbound network calls
+_EXTERNAL_CALL_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("httpx", re.compile(r"httpx\.(get|post|put|patch|delete|head)\s*\(")),
+    ("httpx_client", re.compile(r"httpx\.(?:Client|AsyncClient)\s*\(")),
+    ("urlopen", re.compile(r"urlopen\s*\(")),
+    ("anthropic", re.compile(r"(?:client|self\._client)\.messages\.create\s*\(")),
+    ("gemini", re.compile(r"(?:client|self\._client)\.models\.generate_content\s*\(")),
+    ("requests", re.compile(r"requests\.(get|post|put|patch|delete|head)\s*\(")),
+    ("aiohttp", re.compile(r"session\.(get|post|put|patch|delete|head)\s*\(")),
+    ("subprocess_bird", re.compile(r"subprocess\.run\s*\(\s*\[.*bird")),
+]
+
+# Services that must be documented in PRIVACY.md
+_REQUIRED_SERVICES = {
+    "httpx": "httpx",
+    "httpx_client": "httpx",
+    "urlopen": "Link Expansion",
+    "anthropic": "Anthropic",
+    "gemini": "Gemini",
+    "requests": "requests",
+    "aiohttp": "aiohttp",
+    "subprocess_bird": "bird",
+}
+
+_SERVICE_PRIVACY_KEYWORDS = {
+    "httpx": ["telegram", "api.telegram.org", "image", "pbs.twimg"],
+    "urlopen": ["t.co", "link expansion", "expand"],
+    "anthropic": ["anthropic", "anthropic api"],
+    "gemini": ["gemini", "google"],
+    "requests": ["requests"],
+    "aiohttp": ["aiohttp"],
+    "subprocess_bird": ["bird", "twitter", "auth_token", "ct0"],
+}
+
+
+def check_external_calls(privacy_text: str) -> list[str]:
+    """Verify all external call sites are documented."""
+    issues: list[str] = []
+    privacy_lower = privacy_text.lower()
+
+    found_services: dict[str, list[str]] = {}
+
+    for pyfile in _python_files():
+        # Skip test files
+        if "test" in pyfile.name:
+            continue
+        content = pyfile.read_text()
+        rel = pyfile.relative_to(REPO_ROOT)
+        for svc_key, pattern in _EXTERNAL_CALL_PATTERNS:
+            if pattern.search(content):
+                found_services.setdefault(svc_key, []).append(str(rel))
+
+    for svc_key, files in found_services.items():
+        keywords = _SERVICE_PRIVACY_KEYWORDS.get(svc_key, [])
+        if not any(kw in privacy_lower for kw in keywords):
+            label = _REQUIRED_SERVICES[svc_key]
+            issues.append(f"External call type '{label}' found in {', '.join(files)} but not documented in PRIVACY.md")
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# 2. Database tables
+# ---------------------------------------------------------------------------
+
+_CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+(?:VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)",
+    re.IGNORECASE,
+)
+
+
+def check_db_tables(privacy_text: str) -> list[str]:
+    """Verify all DB tables are listed in PRIVACY.md."""
+    issues: list[str] = []
+    privacy_lower = privacy_text.lower()
+
+    schema_files = list(TWAG_SRC.rglob("schema*.py")) + list(TWAG_SRC.rglob("*.sql"))
+
+    tables_found: set[str] = set()
+    for sf in schema_files:
+        content = sf.read_text()
+        for m in _CREATE_TABLE_RE.finditer(content):
+            tables_found.add(m.group(1).lower())
+
+    issues.extend(
+        f"Database table '{table}' not documented in PRIVACY.md"
+        for table in sorted(tables_found)
+        if table not in privacy_lower
+    )
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# 3. Credential env vars
+# ---------------------------------------------------------------------------
+
+_KNOWN_CRED_PATTERNS = [
+    re.compile(r"""(?:os\.environ|os\.getenv|get_api_key)\s*[\[(]\s*["'](\w+_(?:KEY|TOKEN|SECRET|ID))["']"""),
+    re.compile(r"""["'](AUTH_TOKEN|CT0)["']"""),
+    re.compile(r"""["'](TELEGRAM_BOT_TOKEN|TELEGRAM_CHAT_ID)["']"""),
+]
+
+
+def check_credentials(privacy_text: str) -> list[str]:
+    """Verify all credential env vars are documented."""
+    issues: list[str] = []
+    privacy_upper = privacy_text.upper()
+
+    creds_found: dict[str, list[str]] = {}
+
+    for pyfile in _python_files():
+        if "test" in pyfile.name:
+            continue
+        content = pyfile.read_text()
+        rel = pyfile.relative_to(REPO_ROOT)
+        for pattern in _KNOWN_CRED_PATTERNS:
+            for m in pattern.finditer(content):
+                var_name = m.group(1)
+                creds_found.setdefault(var_name, []).append(str(rel))
+
+    for var_name, files in sorted(creds_found.items()):
+        if var_name not in privacy_upper:
+            issues.append(f"Credential '{var_name}' used in {', '.join(files)} but not documented in PRIVACY.md")
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# 4. Web API endpoints
+# ---------------------------------------------------------------------------
+
+_ROUTE_DECORATOR_RE = re.compile(
+    r"""@(?:router|app)\.(get|post|put|delete|patch|head|options)\s*\(\s*["']([^"']+)["']"""
+)
+
+
+def check_web_endpoints(privacy_text: str) -> list[str]:
+    """Verify all web API endpoints are documented."""
+    issues: list[str] = []
+
+    web_dir = TWAG_SRC / "web"
+    if not web_dir.exists():
+        return issues
+
+    endpoints_found: list[tuple[str, str, str]] = []
+
+    for pyfile in web_dir.rglob("*.py"):
+        content = pyfile.read_text()
+        rel = pyfile.relative_to(REPO_ROOT)
+        for m in _ROUTE_DECORATOR_RE.finditer(content):
+            method = m.group(1).upper()
+            path = m.group(2)
+            endpoints_found.append((method, path, str(rel)))
+
+    for method, path, source in endpoints_found:
+        # Normalize path for matching — replace {param} with a pattern
+        # that matches the PRIVACY.md table format
+        search_path = re.sub(r"\{[^}]+\}", r"{", path)
+        # Check if the path appears in the privacy doc
+        if path not in privacy_text and search_path.rstrip("{") not in privacy_text:
+            # Try a looser match: just the path without params
+            base_path = re.sub(r"/\{[^}]+\}", "", path)
+            if base_path not in privacy_text:
+                issues.append(f"Endpoint {method} {path} (in {source}) not documented in PRIVACY.md")
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# 5. Logging of personal data
+# ---------------------------------------------------------------------------
+
+_PERSONAL_DATA_LOG_RE = re.compile(
+    r"""(?:log(?:ger)?\.(?:info|warning|error|debug|critical)|logging\.(?:info|warning|error|debug|critical))\s*\([^)]*(?:author|handle|content|tweet_text|user_?name|email|password)""",
+    re.IGNORECASE,
+)
+
+
+def check_logging(privacy_text: str) -> list[str]:
+    """Check for undocumented logging of personal data."""
+    issues: list[str] = []
+    privacy_lower = privacy_text.lower()
+
+    for pyfile in _python_files():
+        if "test" in pyfile.name:
+            continue
+        content = pyfile.read_text()
+        rel = pyfile.relative_to(REPO_ROOT)
+        for m in _PERSONAL_DATA_LOG_RE.finditer(content):
+            match_text = m.group(0)
+            if ("no tweet content" not in privacy_lower or "no.*author" not in privacy_lower) and str(
+                rel
+            ) not in privacy_lower:
+                issues.append(f"Potential personal data logging in {rel}: '{match_text[:80]}...'")
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    if not PRIVACY_MD.exists():
+        print("FAIL: PRIVACY.md not found at repository root")
+        return 1
+
+    privacy_text = _read_privacy()
+
+    all_issues: list[tuple[str, list[str]]] = []
+
+    checks = [
+        ("External service calls", check_external_calls),
+        ("Database tables", check_db_tables),
+        ("Credential env vars", check_credentials),
+        ("Web API endpoints", check_web_endpoints),
+        ("Personal data logging", check_logging),
+    ]
+
+    for name, check_fn in checks:
+        issues = check_fn(privacy_text)
+        all_issues.append((name, issues))
+
+    # Report
+    print("=" * 60)
+    print("Privacy Policy Consistency Check")
+    print("=" * 60)
+
+    total_issues = 0
+    for name, issues in all_issues:
+        status = "PASS" if not issues else "FAIL"
+        print(f"\n[{status}] {name}")
+        for issue in issues:
+            print(f"  - {issue}")
+            total_issues += 1
+
+    print()
+    print("=" * 60)
+    if total_issues == 0:
+        print("Result: ALL CHECKS PASSED")
+        return 0
+
+    print(f"Result: {total_issues} issue(s) found")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `PRIVACY.md` documenting all data collection (tweets, authors, media), storage (SQLite DB, digests, config), external services (Twitter/X via bird, Gemini, Anthropic, Telegram, link expansion), credential handling, web API endpoints, and data retention
- Add `scripts/check_privacy.py` — a standalone checker that scans the codebase and validates the policy stays consistent with actual code: undocumented external calls, DB tables, credentials, endpoints, and personal data logging produce failures
- Checker exits 0 (pass) or 1 (fail) with a detailed report, suitable for CI

## Test plan
- [x] `uv run ruff check scripts/check_privacy.py` passes
- [x] `uv run python scripts/check_privacy.py` produces ALL CHECKS PASSED
- [x] `uv run pytest` — all existing tests pass

Nightshift-Task: privacy-policy
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: privacy-policy:/home/clifton/code/twag
task-type: privacy-policy
task-title: Privacy Policy Consistency Checker
iterations: 1
duration: 10m18s
nightshift:metadata -->
