### PR TITLE
fix: remediate PII exposure in fixtures, CLI, and API

### DIFF
--- a/tests/fixtures/tweet_2019488673935552978.json
+++ b/tests/fixtures/tweet_2019488673935552978.json
@@ -7,10 +7,10 @@
   "likeCount": 13,
   "conversationId": "2019488673935552978",
   "author": {
-    "username": "undrvalue",
-    "name": "market participant"
+    "username": "synthuser42",
+    "name": "Synthetic Analyst"
   },
-  "authorId": "2007674507587399680",
+  "authorId": "9000000000000000001",
   "article": {
     "title": "Google's $180 Billion Bet: Is This the Top?",
     "previewText": "Google just guided $180 billion in capex for 2026. Nearly double their 2025 spend. The largest single-year infrastructure commitment in corporate history. \nI'm certainly not the foremost analyst on"
@@ -23,16 +23,16 @@
       "user_results": {
         "result": {
           "__typename": "User",
-          "id": "VXNlcjoyMDA3Njc0NTA3NTg3Mzk5Njgw",
-          "rest_id": "2007674507587399680",
+          "id": "VXNlcjo5MDAwMDAwMDAwMDAwMDAwMDAx",
+          "rest_id": "9000000000000000001",
           "affiliates_highlighted_label": {},
           "avatar": {
-            "image_url": "https://pbs.twimg.com/profile_images/2007696001998413825/yo6xkDTk_normal.jpg"
+            "image_url": "https://pbs.twimg.com/profile_images/0000000000000000000/placeholder_normal.jpg"
           },
           "core": {
             "created_at": "Sun Jan 04 04:44:43 +0000 2026",
-            "name": "market participant",
-            "screen_name": "undrvalue"
+            "name": "Synthetic Analyst",
+            "screen_name": "synthuser42"
           },
           "dm_permissions": {
             "can_dm": false
@@ -43,34 +43,32 @@
           "legacy": {
             "default_profile": true,
             "default_profile_image": false,
-            "description": "Semi-pro investor & analyst. Asymmetric stock picking. $10M+ AUM. Tech, consumer, value.",
+            "description": "Synthetic test account for fixture data.",
             "entities": {
               "description": {
                 "urls": []
               }
             },
             "fast_followers_count": 0,
-            "favourites_count": 501,
-            "followers_count": 1531,
-            "friends_count": 327,
+            "favourites_count": 100,
+            "followers_count": 500,
+            "friends_count": 100,
             "has_custom_timelines": false,
             "is_translator": false,
-            "listed_count": 33,
-            "media_count": 30,
-            "normal_followers_count": 1531,
-            "pinned_tweet_ids_str": [
-              "2010878894271004909"
-            ],
+            "listed_count": 5,
+            "media_count": 10,
+            "normal_followers_count": 500,
+            "pinned_tweet_ids_str": [],
             "possibly_sensitive": false,
-            "profile_banner_url": "https://pbs.twimg.com/profile_banners/2007674507587399680/1767506863",
+            "profile_banner_url": "https://pbs.twimg.com/profile_banners/9000000000000000001/0000000000",
             "profile_interstitial_type": "",
-            "statuses_count": 413,
+            "statuses_count": 50,
             "translator_type": "none",
             "want_retweets": true,
             "withheld_in_countries": []
           },
           "location": {
-            "location": "California"
+            "location": ""
           },
           "media_permissions": {
             "can_media_tag": true
@@ -78,13 +76,13 @@
           "parody_commentary_fan_label": "None",
           "profile_image_shape": "Circle",
           "profile_bio": {
-            "description": "Semi-pro investor & analyst. Asymmetric stock picking. $10M+ AUM. Tech, consumer, value."
+            "description": "Synthetic test account for fixture data."
           },
           "privacy": {
             "protected": false
           },
           "relationship_perspectives": {
-            "following": true
+            "following": false
           },
           "tipjar_settings": {},
           "verification": {
@@ -1388,7 +1386,7 @@
       "reply_count": 1,
       "retweet_count": 0,
       "retweeted": false,
-      "user_id_str": "2007674507587399680",
+      "user_id_str": "9000000000000000001",
       "id_str": "2019488673935552978"
     },
     "quick_promote_eligibility": {

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -384,8 +384,8 @@ class TestTweetFromBirdJson:
         """Parse retweet metadata from Bird --json-full nested _raw legacy payload."""
         data = {
             "id": "2019489337843306678",
-            "author": {"username": "tylercowen", "name": "tylercowen"},
-            "text": "RT @DKThomp: for me the odds that AI is a bubble declined significantly ... under-bu…",
+            "author": {"username": "fakeretweeter", "name": "fakeretweeter"},
+            "text": "RT @fakeoriginal: for me the odds that AI is a bubble declined significantly ... under-bu…",
             "_raw": {
                 "legacy": {
                     "retweeted_status_result": {
@@ -409,8 +409,8 @@ class TestTweetFromBirdJson:
                                 "user_results": {
                                     "result": {
                                         "core": {
-                                            "screen_name": "DKThomp",
-                                            "name": "Derek Thompson",
+                                            "screen_name": "fakeoriginal",
+                                            "name": "Fake Original Poster",
                                         }
                                     }
                                 }
@@ -432,10 +432,10 @@ class TestTweetFromBirdJson:
         tweet = Tweet.from_bird_json(data)
 
         assert tweet.is_retweet is True
-        assert tweet.retweeted_by_handle == "tylercowen"
+        assert tweet.retweeted_by_handle == "fakeretweeter"
         assert tweet.original_tweet_id == "2019484169915572452"
-        assert tweet.original_author_handle == "DKThomp"
-        assert tweet.original_author_name == "Derek Thompson"
+        assert tweet.original_author_handle == "fakeoriginal"
+        assert tweet.original_author_name == "Fake Original Poster"
         assert tweet.original_content is not None
         assert "under-built" in tweet.original_content
         assert "Soviet levels" in tweet.original_content
@@ -587,8 +587,8 @@ class TestRunBird:
         assert code == 0
         mock_subprocess.assert_called_once()
 
-    def test_run_bird_adds_auth_flags(self, mock_subprocess, mock_auth_env):
-        """Auth flags should be added from environment."""
+    def test_run_bird_passes_auth_via_env(self, mock_subprocess, mock_auth_env):
+        """Auth tokens should be passed via env, not CLI flags."""
 
         def _fake_run(*args, **kwargs):
             return MagicMock(stderr="", returncode=0)
@@ -598,10 +598,13 @@ class TestRunBird:
         run_bird(["home"])
 
         call_args = mock_subprocess.call_args[0][0]
-        assert "--auth-token" in call_args
-        assert "test_token" in call_args
-        assert "--ct0" in call_args
-        assert "test_ct0" in call_args
+        # Auth tokens should NOT appear as CLI arguments
+        assert "--auth-token" not in call_args
+        assert "--ct0" not in call_args
+        # They should be in the env passed to subprocess
+        call_kwargs = mock_subprocess.call_args[1]
+        assert call_kwargs["env"]["AUTH_TOKEN"] == "test_token"
+        assert call_kwargs["env"]["CT0"] == "test_ct0"
 
     def test_run_bird_timeout(self, mock_subprocess, mock_auth_env):
         """Timeout should return error."""

--- a/twag/cli/init_cmd.py
+++ b/twag/cli/init_cmd.py
@@ -147,14 +147,14 @@ def doctor():
 
     gemini_key = os.environ.get("GEMINI_API_KEY")
     if gemini_key:
-        console.print(f"  {status_icon(True)} GEMINI_API_KEY set ({gemini_key[:8]}...)")
+        console.print(f"  {status_icon(True)} GEMINI_API_KEY set (redacted)")
     else:
         console.print(f"  {status_icon(False)} GEMINI_API_KEY not set")
         issues.append("Set GEMINI_API_KEY environment variable")
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     if anthropic_key:
-        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set ({anthropic_key[:8]}...)")
+        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set (redacted)")
     else:
         console.print("  [yellow]WARN[/yellow] ANTHROPIC_API_KEY not set (enrichment disabled)")
         warnings.append("Set ANTHROPIC_API_KEY for enrichment features")

--- a/twag/fetcher/bird_cli.py
+++ b/twag/fetcher/bird_cli.py
@@ -77,17 +77,9 @@ def run_bird(args: list[str], timeout: int = 60) -> tuple[str, str, int]:
     _rate_limit_bird()
     env = get_auth_env()
 
-    # Build command with auth if available
+    # Build command — auth tokens are passed via env (AUTH_TOKEN, CT0)
+    # to avoid exposure in /proc/pid/cmdline
     cmd = ["bird", *args]
-
-    # Add auth flags if we have the tokens
-    auth_token = env.get("AUTH_TOKEN")
-    ct0 = env.get("CT0")
-
-    if auth_token and "--auth-token" not in args:
-        cmd.extend(["--auth-token", auth_token])
-    if ct0 and "--ct0" not in args:
-        cmd.extend(["--ct0", ct0])
 
     config = load_config()
     bird_cfg = config.get("bird", {})

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -406,5 +406,5 @@ Return your analysis in a structured format."""
             "analysis": analysis,
         }
 
-    except Exception as e:
-        return {"error": f"Analysis failed: {e!s}"}
+    except Exception:
+        return {"error": "Analysis failed: internal error"}

--- a/twag/web/routes/prompts.py
+++ b/twag/web/routes/prompts.py
@@ -254,8 +254,8 @@ SUGGESTED PROMPT:
             },
         }
 
-    except Exception as e:
-        return {"error": f"LLM call failed: {e!s}"}
+    except Exception:
+        return {"error": "LLM call failed: internal error"}
 
 
 @router.post("/prompts/{name}/apply-suggestion")


### PR DESCRIPTION
## Summary
- Replace real user metadata (bio, location, follower counts, DM settings) in test fixture with synthetic data
- Redact API key prefix display in `twag doctor` command (was showing first 8 chars)
- Pass AUTH_TOKEN/CT0 via subprocess environment instead of CLI flags to avoid `/proc/pid/cmdline` exposure
- Sanitize exception messages in API error responses (`context.py`, `prompts.py`) to prevent internal detail leakage

## Test plan
- [x] All existing tests pass (`uv run pytest` — 168 tests)
- [x] `ruff format` and `ruff check` clean
- [ ] Verify `twag doctor` shows "set (redacted)" instead of key prefixes
- [ ] Verify `bird` CLI still authenticates correctly via env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)