### PR TITLE
Fix API contract inconsistencies and add verification tests

### DIFF
--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -1,60 +1,20 @@
-"""Contract tests: single-tweet and list-tweet endpoints return the same field set."""
+"""Contract tests: API responses match expected shapes and Pydantic models."""
 
+import re
 from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 
 from twag.db import get_connection, insert_tweet, update_tweet_processing
 from twag.db.reactions import insert_reaction
+from twag.models.api import TweetResponse
 from twag.web.app import create_app
 
+# ISO 8601 pattern (with or without timezone)
+ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
 # Fields that both /api/tweets and /api/tweets/{id} must return.
-SHARED_FIELDS = {
-    "id",
-    "author_handle",
-    "author_name",
-    "display_author_handle",
-    "display_author_name",
-    "display_tweet_id",
-    "content",
-    "content_summary",
-    "summary",
-    "created_at",
-    "relevance_score",
-    "categories",
-    "signal_tier",
-    "tickers",
-    "bookmarked",
-    "has_quote",
-    "quote_tweet_id",
-    "has_media",
-    "media_analysis",
-    "media_items",
-    "has_link",
-    "link_summary",
-    "is_x_article",
-    "article_title",
-    "article_preview",
-    "article_text",
-    "article_summary_short",
-    "article_primary_points",
-    "article_action_items",
-    "article_top_visual",
-    "article_processed_at",
-    "is_retweet",
-    "retweeted_by_handle",
-    "retweeted_by_name",
-    "original_tweet_id",
-    "original_author_handle",
-    "original_author_name",
-    "original_content",
-    "reactions",
-    "quote_embed",
-    "inline_quote_embeds",
-    "reference_links",
-    "external_links",
-    "display_content",
-}
+SHARED_FIELDS = set(TweetResponse.model_fields.keys())
 
 
 def _setup(monkeypatch, tmp_path, db_name="contract.db"):
@@ -85,7 +45,7 @@ def _insert(conn, tweet_id="t1", author_handle="alice", content="hello world", *
     )
 
 
-# ── Field parity ──────────────────────────────────────────────
+# ── Field parity against TweetResponse model ────────────────
 
 
 def test_single_tweet_has_all_shared_fields(monkeypatch, tmp_path):
@@ -127,6 +87,68 @@ def test_field_sets_identical(monkeypatch, tmp_path):
     single = client.get("/api/tweets/t1").json()
     listed = client.get("/api/tweets", params={"since": "30d"}).json()["tweets"][0]
     assert set(single.keys()) == set(listed.keys())
+
+
+def test_response_fields_match_pydantic_model(monkeypatch, tmp_path):
+    """Both endpoints return exactly the fields defined in TweetResponse."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    single_keys = set(client.get("/api/tweets/t1").json().keys())
+    list_keys = set(client.get("/api/tweets", params={"since": "30d"}).json()["tweets"][0].keys())
+
+    model_fields = set(TweetResponse.model_fields.keys())
+    assert single_keys == model_fields, (
+        f"Single drift: extra={single_keys - model_fields}, missing={model_fields - single_keys}"
+    )
+    assert list_keys == model_fields, (
+        f"List drift: extra={list_keys - model_fields}, missing={model_fields - list_keys}"
+    )
+
+
+# ── Date format consistency ──────────────────────────────────
+
+
+def test_created_at_iso_format_both_endpoints(monkeypatch, tmp_path):
+    """created_at must be ISO 8601 on both endpoints."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    single = client.get("/api/tweets/t1").json()
+    listed = client.get("/api/tweets", params={"since": "30d"}).json()["tweets"][0]
+
+    assert single["created_at"] is not None
+    assert ISO_DATE_RE.match(single["created_at"]), f"Not ISO: {single['created_at']}"
+    assert listed["created_at"] is not None
+    assert ISO_DATE_RE.match(listed["created_at"]), f"Not ISO: {listed['created_at']}"
+
+
+def test_article_processed_at_iso_when_present(monkeypatch, tmp_path):
+    """article_processed_at must be ISO 8601 when set, on both endpoints."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        # Simulate article processing by setting article_processed_at
+        conn.execute(
+            "UPDATE tweets SET article_processed_at = ? WHERE id = ?",
+            (datetime.now(timezone.utc).isoformat(), "t1"),
+        )
+        conn.commit()
+
+    client = TestClient(app)
+    single = client.get("/api/tweets/t1").json()
+    listed = client.get("/api/tweets", params={"since": "30d"}).json()["tweets"][0]
+
+    assert single["article_processed_at"] is not None
+    assert ISO_DATE_RE.match(single["article_processed_at"]), f"Not ISO: {single['article_processed_at']}"
+    assert listed["article_processed_at"] is not None
+    assert ISO_DATE_RE.match(listed["article_processed_at"]), f"Not ISO: {listed['article_processed_at']}"
 
 
 # ── Reactions type ────────────────────────────────────────────
@@ -270,3 +292,165 @@ def test_single_tweet_no_links_json(monkeypatch, tmp_path):
     client = TestClient(app)
     body = client.get("/api/tweets/t1").json()
     assert "links_json" not in body
+
+
+# ── Categories endpoint ──────────────────────────────────────
+
+
+def test_categories_response_shape(monkeypatch, tmp_path):
+    """GET /api/categories returns {categories: [{name: str, count: int}]}."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn, tweet_id="t1")
+        _insert(conn, tweet_id="t2", author_handle="bob", content="another")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/categories").json()
+    assert "categories" in body
+    assert isinstance(body["categories"], list)
+    for cat in body["categories"]:
+        assert "name" in cat and isinstance(cat["name"], str)
+        assert "count" in cat and isinstance(cat["count"], int)
+
+
+def test_categories_returns_aggregated_counts(monkeypatch, tmp_path):
+    """Categories endpoint aggregates across tweets."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn, tweet_id="t1")
+        _insert(conn, tweet_id="t2", author_handle="bob", content="another")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/categories").json()
+    macro = next((c for c in body["categories"] if c["name"] == "macro"), None)
+    assert macro is not None
+    assert macro["count"] >= 2
+
+
+# ── Tickers endpoint ─────────────────────────────────────────
+
+
+def test_tickers_response_shape(monkeypatch, tmp_path):
+    """GET /api/tickers returns {tickers: [{symbol: str, count: int}]}."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn, tweet_id="t1")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/tickers").json()
+    assert "tickers" in body
+    assert isinstance(body["tickers"], list)
+    for ticker in body["tickers"]:
+        assert "symbol" in ticker and isinstance(ticker["symbol"], str)
+        assert "count" in ticker and isinstance(ticker["count"], int)
+
+
+def test_tickers_returns_aggregated_counts(monkeypatch, tmp_path):
+    """Tickers endpoint aggregates across tweets."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn, tweet_id="t1")
+        _insert(conn, tweet_id="t2", author_handle="bob", content="spx talk")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/tickers").json()
+    spx = next((t for t in body["tickers"] if t["symbol"] == "SPX"), None)
+    assert spx is not None
+    assert spx["count"] >= 2
+
+
+# ── Reactions CRUD endpoints ─────────────────────────────────
+
+
+def test_react_creates_reaction(monkeypatch, tmp_path):
+    """POST /api/react creates a reaction and returns id + tweet_id."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.post("/api/react", json={"tweet_id": "t1", "reaction_type": ">>"})
+    body = resp.json()
+    assert "id" in body
+    assert body["tweet_id"] == "t1"
+    assert body["reaction_type"] == ">>"
+
+
+def test_react_invalid_type_returns_error(monkeypatch, tmp_path):
+    """POST /api/react with invalid type returns error."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.post("/api/react", json={"tweet_id": "t1", "reaction_type": "invalid"})
+    body = resp.json()
+    assert "error" in body
+
+
+def test_get_reactions_for_tweet(monkeypatch, tmp_path):
+    """GET /api/reactions/{tweet_id} returns reactions list."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        insert_reaction(conn, tweet_id="t1", reaction_type=">>")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/reactions/t1").json()
+    assert body["tweet_id"] == "t1"
+    assert isinstance(body["reactions"], list)
+    assert len(body["reactions"]) >= 1
+    r = body["reactions"][0]
+    assert "id" in r
+    assert "reaction_type" in r
+
+
+def test_delete_reaction(monkeypatch, tmp_path):
+    """DELETE /api/reactions/{id} removes the reaction."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        rid = insert_reaction(conn, tweet_id="t1", reaction_type=">>")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.delete(f"/api/reactions/{rid}")
+    assert resp.json()["message"] == "Reaction deleted"
+
+
+def test_reactions_summary_not_shadowed(monkeypatch, tmp_path):
+    """GET /api/reactions/summary is not captured by the {tweet_id} route."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        insert_reaction(conn, tweet_id="t1", reaction_type=">>")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/reactions/summary").json()
+    # Must have 'summary' key, NOT 'tweet_id' (which would mean it hit the wrong route)
+    assert "summary" in body
+    assert "tweet_id" not in body
+
+
+def test_reactions_export_not_shadowed(monkeypatch, tmp_path):
+    """GET /api/reactions/export is not captured by the {tweet_id} route."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        insert_reaction(conn, tweet_id="t1", reaction_type=">>")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/reactions/export").json()
+    # Must have 'count' and 'reactions' keys, NOT 'tweet_id'
+    assert "count" in body
+    assert "reactions" in body
+    assert "tweet_id" not in body

--- a/tests/test_article_processing.py
+++ b/tests/test_article_processing.py
@@ -242,7 +242,7 @@ def test_build_triage_text_prefers_article_body() -> None:
         "article_preview": "Preview",
         "article_text": "Deep dive " * 800,
     }
-    text = _build_triage_text(row)  # type: ignore[arg-type]
+    text = _build_triage_text(row)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     assert text.startswith("Capex note")
     assert "Deep dive" in text

--- a/tests/test_db_retweet_backfill.py
+++ b/tests/test_db_retweet_backfill.py
@@ -215,7 +215,7 @@ def test_insert_tweet_retries_transient_database_lock(monkeypatch):
     monkeypatch.setattr(db_connection_mod.time, "sleep", lambda delay: sleeps.append(delay))
 
     inserted = insert_tweet(
-        conn,  # type: ignore[arg-type]
+        conn,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         tweet_id="retry-1",
         author_handle="retry_user",
         content="retry content",

--- a/twag/web/routes/reactions.py
+++ b/twag/web/routes/reactions.py
@@ -1,5 +1,6 @@
 """Reaction API routes."""
 
+import json
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -85,41 +86,7 @@ async def create_reaction(request: Request, reaction: ReactionCreate) -> dict[st
     }
 
 
-@router.get("/reactions/{tweet_id}")
-async def get_tweet_reactions(request: Request, tweet_id: str) -> dict[str, Any]:
-    """Get all reactions for a specific tweet."""
-    db_path = request.app.state.db_path
-
-    with get_connection(db_path, readonly=True) as conn:
-        reactions = get_reactions_for_tweet(conn, tweet_id)
-
-    return {
-        "tweet_id": tweet_id,
-        "reactions": [
-            {
-                "id": r.id,
-                "reaction_type": r.reaction_type,
-                "reason": r.reason,
-                "target": r.target,
-                "created_at": r.created_at.isoformat() if r.created_at else None,
-            }
-            for r in reactions
-        ],
-    }
-
-
-@router.delete("/reactions/{reaction_id}")
-async def remove_reaction(request: Request, reaction_id: int) -> dict[str, Any]:
-    """Delete a reaction."""
-    db_path = request.app.state.db_path
-
-    with get_connection(db_path) as conn:
-        deleted = delete_reaction(conn, reaction_id)
-        conn.commit()
-
-    if deleted:
-        return {"message": "Reaction deleted"}
-    return {"error": "Reaction not found"}
+# Literal paths must be registered before parameterized paths to avoid shadowing.
 
 
 @router.get("/reactions/summary")
@@ -143,8 +110,6 @@ async def export_reactions(
     Export reactions with associated tweet data.
     Useful for prompt tuning analysis.
     """
-    import json
-
     db_path = request.app.state.db_path
 
     with get_connection(db_path, readonly=True) as conn:
@@ -184,3 +149,40 @@ async def export_reactions(
         "count": len(export_data),
         "reactions": export_data,
     }
+
+
+@router.get("/reactions/{tweet_id}")
+async def get_tweet_reactions(request: Request, tweet_id: str) -> dict[str, Any]:
+    """Get all reactions for a specific tweet."""
+    db_path = request.app.state.db_path
+
+    with get_connection(db_path, readonly=True) as conn:
+        reactions = get_reactions_for_tweet(conn, tweet_id)
+
+    return {
+        "tweet_id": tweet_id,
+        "reactions": [
+            {
+                "id": r.id,
+                "reaction_type": r.reaction_type,
+                "reason": r.reason,
+                "target": r.target,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in reactions
+        ],
+    }
+
+
+@router.delete("/reactions/{reaction_id}")
+async def remove_reaction(request: Request, reaction_id: int) -> dict[str, Any]:
+    """Delete a reaction."""
+    db_path = request.app.state.db_path
+
+    with get_connection(db_path) as conn:
+        deleted = delete_reaction(conn, reaction_id)
+        conn.commit()
+
+    if deleted:
+        return {"message": "Reaction deleted"}
+    return {"error": "Reaction not found"}

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -17,6 +17,18 @@ from ..tweet_utils import (
 
 router = APIRouter(tags=["tweets"])
 MAX_QUOTE_DEPTH = 3
+
+
+def _parse_iso(raw: str | None) -> str | None:
+    """Parse a raw datetime string from SQLite and return consistent ISO format."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw).isoformat()
+    except (ValueError, TypeError):
+        return raw
+
+
 LEGACY_RETWEET_RE = re.compile(r"^\s*RT\s+@([A-Za-z0-9_]{1,15}):\s*(.+)$")
 
 
@@ -527,7 +539,7 @@ async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
         "content": content,
         "content_summary": tweet["content_summary"],
         "summary": tweet["summary"],
-        "created_at": tweet["created_at"],
+        "created_at": _parse_iso(tweet["created_at"]),
         "relevance_score": tweet["relevance_score"],
         "categories": categories,
         "signal_tier": tweet["signal_tier"],
@@ -548,7 +560,7 @@ async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
         "article_primary_points": article_primary_points,
         "article_action_items": article_action_items,
         "article_top_visual": article_top_visual,
-        "article_processed_at": tweet["article_processed_at"],
+        "article_processed_at": _parse_iso(tweet["article_processed_at"]),
         "is_retweet": is_retweet,
         "retweeted_by_handle": retweeted_by_handle,
         "retweeted_by_name": retweeted_by_name,


### PR DESCRIPTION
## Summary
- Fix `created_at` and `article_processed_at` raw-string vs `.isoformat()` inconsistency between single-tweet and list-tweet endpoints
- Reorder reaction routes so `/reactions/summary` and `/reactions/export` aren't shadowed by `/reactions/{tweet_id}`
- Add contract tests validating response fields against `TweetResponse` Pydantic model, ISO date format consistency, categories/tickers response shapes, and reactions CRUD + route ordering
- Fix pre-existing `ty` type-ignore directives for newer ty versions

## Test plan
- [x] All 24 contract tests pass (`uv run pytest tests/test_api_contracts.py`)
- [x] Full test suite passes via pre-commit hook
- [x] `ruff format`, `ruff check`, `ty check` all clean

Nightshift-Task: api-contract-verify
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: api-contract-verify:/home/clifton/code/twag
task-type: api-contract-verify
task-title: API Contract Verification
iterations: 1
duration: 8m8s
nightshift:metadata -->
