### PR TITLE
feat: add `twag diff` semantic diff explainer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Visual selection prioritizes data-oriented images (charts, tables, documents).
 Defined in `twag/cli/`:
 
 - **Setup:** `init`, `doctor`
-- **Pipeline:** `fetch`, `process`, `analyze`, `digest`
+- **Pipeline:** `fetch`, `process`, `analyze`, `digest`, `diff`
 - **Accounts:** `list`, `add`, `promote`, `demote`, `mute`, `boost`, `decay`, `import`
 - **Query:** `search`, `narratives list`
 - **Maintenance:** `stats`, `prune`, `export`

--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ twag analyze 1234567890123456789 --reprocess  # Force re-analyze
 twag analyze 1234567890123456789 -m gemini-2.0-flash  # Override model
 ```
 
+### Diff Commands
+
+```bash
+twag diff                          # Explain last commit
+twag diff HEAD~3..HEAD             # Explain last 3 commits
+twag diff main..feature-branch     # Explain branch changes
+twag diff -m gemini-2.0-flash      # Override model
+```
+
 ### Digest Commands
 
 ```bash

--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -13,6 +13,7 @@ from . import accounts as _accounts_mod
 from . import analyze as _analyze_mod
 from . import config_cmd as _config_mod
 from . import db_cmd as _db_mod
+from . import diff_cmd as _diff_mod
 from . import digest as _digest_mod
 from . import fetch as _fetch_mod
 from . import init_cmd as _init_mod
@@ -47,6 +48,7 @@ cli.add_command(_stats_mod.prune)
 cli.add_command(_stats_mod.export)
 cli.add_command(_config_mod.config)
 cli.add_command(_db_mod.db)
+cli.add_command(_diff_mod.diff)
 cli.add_command(_search_mod.search)
 cli.add_command(_web_mod.web)
 

--- a/twag/cli/diff_cmd.py
+++ b/twag/cli/diff_cmd.py
@@ -1,0 +1,42 @@
+"""CLI command for semantic diff explanation."""
+
+import subprocess
+
+import rich_click as click
+from rich.console import Console
+from rich.markdown import Markdown
+
+
+@click.command("diff")
+@click.argument("ref_range", default="HEAD~1..HEAD")
+@click.option("-m", "--model", default=None, help="Override LLM model.")
+@click.option("-p", "--provider", default=None, help="Override LLM provider.")
+def diff(ref_range: str, model: str | None, provider: str | None):
+    """Explain the semantic meaning of code changes.
+
+    REF_RANGE is a git ref range (default: HEAD~1..HEAD).
+    Examples: HEAD~3..HEAD, main..feature-branch, abc123..def456
+    """
+    console = Console()
+
+    result = subprocess.run(
+        ["git", "diff", ref_range],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        console.print(f"[red]git diff failed:[/red] {result.stderr.strip()}")
+        raise SystemExit(1)
+
+    diff_text = result.stdout.strip()
+    if not diff_text:
+        console.print("[yellow]No changes found in the given range.[/yellow]")
+        return
+
+    from twag.scorer.scoring import explain_diff
+
+    with console.status("Analyzing diff..."):
+        explanation = explain_diff(diff_text, model=model, provider=provider)
+
+    console.print(Markdown(explanation))

--- a/twag/scorer/prompts.py
+++ b/twag/scorer/prompts.py
@@ -1,5 +1,18 @@
 """Prompt templates for LLM scoring and analysis."""
 
+# Semantic diff explanation prompt
+DIFF_EXPLAIN_PROMPT = """You are a senior software engineer. Explain the semantic meaning of the following code diff in plain English.
+
+Focus on:
+- What the changes accomplish functionally (not line-by-line narration)
+- Why these changes might have been made
+- Any notable side effects, risks, or behavioral changes
+
+Be concise. Use bullet points for multiple changes.
+
+Diff:
+{diff}"""
+
 # Triage prompt for fast scoring
 TRIAGE_PROMPT = """You are a financial markets triage agent. Score this tweet 0-10 for relevance to macro/investing.
 

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -9,6 +9,7 @@ from .llm_client import _call_llm, _call_llm_vision, _parse_json_response
 from .prompts import (
     ARTICLE_SUMMARY_PROMPT,
     BATCH_TRIAGE_PROMPT,
+    DIFF_EXPLAIN_PROMPT,
     DOCUMENT_SUMMARY_PROMPT,
     ENRICHMENT_PROMPT,
     MEDIA_PROMPT,
@@ -391,3 +392,19 @@ def analyze_media(
 ) -> MediaAnalysisResult:
     """Analyze any tweet media image with OCR and classification."""
     return analyze_image(image_url=image_url, model=model, provider=provider)
+
+
+def explain_diff(
+    diff_text: str,
+    model: str | None = None,
+    provider: str | None = None,
+) -> str:
+    """Send a git diff to the enrichment LLM and return a semantic explanation."""
+    config = load_config()
+    model = model or config["llm"]["enrichment_model"]
+    provider = provider or config["llm"].get("enrichment_provider", "anthropic")
+    reasoning = config["llm"].get("enrichment_reasoning")
+
+    prompt = DIFF_EXPLAIN_PROMPT.format(diff=diff_text)
+    text = _call_llm(provider, model, prompt, max_tokens=4096, reasoning=reasoning)
+    return text.strip()


### PR DESCRIPTION
## Summary
- Adds `twag diff [ref_range]` CLI command that sends a git diff to the enrichment LLM and prints a semantic explanation of what changed functionally
- Reuses existing LLM client infrastructure (`_call_llm` via `explain_diff()` in scorer)
- Defaults to `HEAD~1..HEAD`, accepts any valid git ref range

## Test plan
- [x] `uv run ruff format` / `uv run ruff check` pass
- [x] `uv run pytest` — all tests pass
- [ ] Manual: `twag diff` explains last commit
- [ ] Manual: `twag diff HEAD~3..HEAD` explains multiple commits

Nightshift-Task: semantic-diff
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)