### PR TITLE
Add version-tracked schema migration system

### DIFF
--- a/tests/test_article_processing.py
+++ b/tests/test_article_processing.py
@@ -3,6 +3,7 @@
 import json
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, cast
 
 from twag.db import (
     get_connection,
@@ -235,14 +236,17 @@ def test_prefer_stronger_signal_tier_avoids_downgrade() -> None:
 
 
 def test_build_triage_text_prefers_article_body() -> None:
-    row = {
-        "content": "Short teaser",
-        "is_x_article": 1,
-        "article_title": "Capex note",
-        "article_preview": "Preview",
-        "article_text": "Deep dive " * 800,
-    }
-    text = _build_triage_text(row)  # type: ignore[arg-type]
+    row = cast(
+        Any,
+        {
+            "content": "Short teaser",
+            "is_x_article": 1,
+            "article_title": "Capex note",
+            "article_preview": "Preview",
+            "article_text": "Deep dive " * 800,
+        },
+    )
+    text = _build_triage_text(row)
 
     assert text.startswith("Capex note")
     assert "Deep dive" in text

--- a/tests/test_db_retweet_backfill.py
+++ b/tests/test_db_retweet_backfill.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+from typing import Any, cast
 
 import twag.db.connection as db_connection_mod
 from twag.db import get_connection, get_tweet_by_id, init_db, insert_tweet
@@ -210,12 +211,12 @@ def test_insert_tweet_retries_transient_database_lock(monkeypatch):
             self.params = params
             return None
 
-    conn = _LockOnceConnection()
+    conn = cast(Any, _LockOnceConnection())
     sleeps: list[float] = []
     monkeypatch.setattr(db_connection_mod.time, "sleep", lambda delay: sleeps.append(delay))
 
     inserted = insert_tweet(
-        conn,  # type: ignore[arg-type]
+        conn,
         tweet_id="retry-1",
         author_handle="retry_user",
         content="retry content",

--- a/tests/test_schema_evolution.py
+++ b/tests/test_schema_evolution.py
@@ -1,0 +1,209 @@
+"""Tests for schema version tracking and migration system."""
+
+import sqlite3
+
+import pytest
+
+from twag.db import get_connection, get_schema_version, init_db, upsert_narrative
+from twag.db.schema import LATEST_SCHEMA_VERSION
+
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    """Create a fresh database via init_db."""
+    path = tmp_path / "fresh.db"
+    init_db(path)
+    return path
+
+
+class TestFreshDatabase:
+    """Tests for fresh database initialization."""
+
+    def test_schema_version_table_exists(self, fresh_db):
+        with get_connection(fresh_db) as conn:
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'")
+            assert cursor.fetchone() is not None
+
+    def test_schema_version_is_latest(self, fresh_db):
+        with get_connection(fresh_db) as conn:
+            version = get_schema_version(conn)
+        assert version == LATEST_SCHEMA_VERSION
+
+    def test_idx_tweets_reply_exists(self, fresh_db):
+        with get_connection(fresh_db) as conn:
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_tweets_reply'")
+            assert cursor.fetchone() is not None
+
+    def test_narratives_name_unique(self, fresh_db):
+        with get_connection(fresh_db) as conn:
+            conn.execute("INSERT INTO narratives (name, sentiment) VALUES ('test_narrative', 'bullish')")
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute("INSERT INTO narratives (name, sentiment) VALUES ('test_narrative', 'bearish')")
+
+
+class TestLegacyMigration:
+    """Tests for migrating a pre-versioned database."""
+
+    def _create_legacy_db(self, path):
+        """Create a minimal legacy database without schema_version."""
+        conn = sqlite3.connect(path)
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS tweets (
+                id TEXT PRIMARY KEY,
+                author_handle TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at TIMESTAMP,
+                first_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                source TEXT,
+                processed_at TIMESTAMP,
+                relevance_score REAL,
+                category TEXT,
+                summary TEXT,
+                signal_tier TEXT,
+                tickers TEXT,
+                has_quote INTEGER DEFAULT 0,
+                quote_tweet_id TEXT,
+                has_media INTEGER DEFAULT 0,
+                media_analysis TEXT,
+                has_link INTEGER DEFAULT 0,
+                link_summary TEXT,
+                included_in_digest TEXT,
+                FOREIGN KEY (quote_tweet_id) REFERENCES tweets(id)
+            );
+            CREATE TABLE IF NOT EXISTS accounts (
+                handle TEXT PRIMARY KEY,
+                display_name TEXT,
+                tier INTEGER DEFAULT 2,
+                weight REAL DEFAULT 50.0,
+                category TEXT,
+                tweets_seen INTEGER DEFAULT 0,
+                tweets_kept INTEGER DEFAULT 0,
+                avg_relevance_score REAL,
+                last_high_signal_at TIMESTAMP,
+                added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                auto_promoted INTEGER DEFAULT 0,
+                muted INTEGER DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS narratives (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                first_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_mentioned_at TIMESTAMP,
+                mention_count INTEGER DEFAULT 1,
+                sentiment TEXT,
+                related_tickers TEXT,
+                active INTEGER DEFAULT 1
+            );
+            CREATE TABLE IF NOT EXISTS tweet_narratives (
+                tweet_id TEXT,
+                narrative_id INTEGER,
+                PRIMARY KEY (tweet_id, narrative_id)
+            );
+            CREATE TABLE IF NOT EXISTS fetch_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                endpoint TEXT NOT NULL,
+                executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                tweets_fetched INTEGER,
+                new_tweets INTEGER,
+                query_params TEXT
+            );
+            CREATE TABLE IF NOT EXISTS reactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tweet_id TEXT NOT NULL,
+                reaction_type TEXT NOT NULL,
+                reason TEXT,
+                target TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (tweet_id) REFERENCES tweets(id)
+            );
+            CREATE TABLE IF NOT EXISTS prompts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                template TEXT NOT NULL,
+                version INTEGER DEFAULT 1,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_by TEXT
+            );
+            CREATE TABLE IF NOT EXISTS prompt_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                prompt_name TEXT NOT NULL,
+                template TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS context_commands (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                command_template TEXT NOT NULL,
+                description TEXT,
+                enabled INTEGER DEFAULT 1,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX IF NOT EXISTS idx_tweets_created ON tweets(created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_tweets_score ON tweets(relevance_score DESC);
+        """)
+        conn.commit()
+        conn.close()
+
+    def test_legacy_db_gets_migrated_to_latest(self, tmp_path):
+        path = tmp_path / "legacy.db"
+        self._create_legacy_db(path)
+
+        # Run init_db which should detect legacy and migrate
+        init_db(path)
+
+        with get_connection(path) as conn:
+            version = get_schema_version(conn)
+            assert version == LATEST_SCHEMA_VERSION
+
+    def test_legacy_db_gets_missing_columns(self, tmp_path):
+        path = tmp_path / "legacy.db"
+        self._create_legacy_db(path)
+        init_db(path)
+
+        with get_connection(path) as conn:
+            cursor = conn.execute("PRAGMA table_info(tweets)")
+            columns = {row[1] for row in cursor.fetchall()}
+
+        assert "bookmarked" in columns
+        assert "is_retweet" in columns
+        assert "is_x_article" in columns
+        assert "links_json" in columns
+        assert "in_reply_to_tweet_id" in columns
+
+    def test_legacy_db_gets_narratives_unique_index(self, tmp_path):
+        path = tmp_path / "legacy.db"
+        self._create_legacy_db(path)
+        init_db(path)
+
+        with get_connection(path) as conn:
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_narratives_name'")
+            assert cursor.fetchone() is not None
+
+    def test_legacy_db_gets_reply_index(self, tmp_path):
+        path = tmp_path / "legacy.db"
+        self._create_legacy_db(path)
+        init_db(path)
+
+        with get_connection(path) as conn:
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_tweets_reply'")
+            assert cursor.fetchone() is not None
+
+
+class TestUpsertNarrativeUniqueness:
+    """Test that upsert_narrative correctly updates on conflict."""
+
+    def test_upsert_updates_existing(self, fresh_db):
+        with get_connection(fresh_db) as conn:
+            id1 = upsert_narrative(conn, "inflation", sentiment="bearish")
+            id2 = upsert_narrative(conn, "inflation", sentiment="bullish")
+            assert id1 == id2
+
+            row = conn.execute("SELECT mention_count FROM narratives WHERE id = ?", (id1,)).fetchone()
+            assert row[0] == 2
+
+    def test_different_narratives_get_different_ids(self, fresh_db):
+        with get_connection(fresh_db) as conn:
+            id1 = upsert_narrative(conn, "inflation")
+            id2 = upsert_narrative(conn, "deflation")
+            assert id1 != id2

--- a/twag/cli/db_cmd.py
+++ b/twag/cli/db_cmd.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import rich_click as click
 
 from ..config import get_database_path
-from ..db import dump_sql, get_connection, init_db, rebuild_fts, restore_sql
+from ..db import dump_sql, get_connection, get_schema_version, init_db, rebuild_fts, restore_sql
+from ..db.schema import LATEST_SCHEMA_VERSION
 from ._console import console
 
 
@@ -36,6 +37,18 @@ def db_init():
     """Initialize/reset the database."""
     init_db()
     console.print(f"Database initialized at: {get_database_path()}")
+
+
+@db.command("schema-version")
+def db_schema_version():
+    """Show current schema version."""
+    db_file = get_database_path()
+    if not db_file.exists():
+        console.print("[red]Database not found. Run 'twag db init' first.[/red]")
+        return
+    with get_connection(readonly=True) as conn:
+        version = get_schema_version(conn)
+    console.print(f"Schema version: {version} (latest: {LATEST_SCHEMA_VERSION})")
 
 
 @db.command("rebuild-fts")

--- a/twag/db/__init__.py
+++ b/twag/db/__init__.py
@@ -11,7 +11,7 @@ from .accounts import (
     update_account_stats,
     upsert_account,
 )
-from .connection import get_connection, init_db, rebuild_fts
+from .connection import get_connection, get_schema_version, init_db, rebuild_fts
 from .context_commands import (
     ContextCommand,
     delete_context_command,
@@ -51,7 +51,7 @@ from .reactions import (
     get_reactions_with_tweets,
     insert_reaction,
 )
-from .schema import FTS_SCHEMA, SCHEMA
+from .schema import FTS_SCHEMA, LATEST_SCHEMA_VERSION, SCHEMA
 from .search import (
     EQUITY_KEYWORDS,
     FeedTweet,
@@ -92,6 +92,7 @@ __all__ = [
     "DEFAULT_PROMPTS",
     "EQUITY_KEYWORDS",
     "FTS_SCHEMA",
+    "LATEST_SCHEMA_VERSION",
     "SCHEMA",
     "ContextCommand",
     "FeedTweet",
@@ -125,6 +126,7 @@ __all__ = [
     "get_reactions_for_tweet",
     "get_reactions_summary",
     "get_reactions_with_tweets",
+    "get_schema_version",
     "get_tweet_by_id",
     "get_tweet_stats",
     "get_tweets_by_ids",

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -3,12 +3,12 @@
 import logging
 import sqlite3
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
 from ..config import get_database_path
-from .schema import FTS_SCHEMA, SCHEMA
+from .schema import FTS_SCHEMA, LATEST_SCHEMA_VERSION, SCHEMA
 
 log = logging.getLogger(__name__)
 _LOCK_RETRY_ATTEMPTS = 4
@@ -26,7 +26,18 @@ def init_db(db_path: Path | None = None) -> None:
     for attempt in range(max_attempts):
         try:
             with get_connection(db_path) as conn:
+                # Detect fresh database before applying SCHEMA
+                is_fresh = (
+                    conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tweets'").fetchone()
+                    is None
+                )
+                if not is_fresh:
+                    # Legacy databases need columns added before SCHEMA indexes
+                    _ensure_tables_exist(conn)
+                    _migrate_v0_legacy(conn)
                 conn.executescript(SCHEMA)
+                if is_fresh:
+                    _set_schema_version(conn, LATEST_SCHEMA_VERSION)
                 _run_migrations(conn)
                 conn.commit()
             return
@@ -77,108 +88,138 @@ def commit_with_retry(conn: sqlite3.Connection) -> None:
     _with_lock_retry("sqlite commit", conn.commit)
 
 
+def _ensure_tables_exist(conn: sqlite3.Connection) -> None:
+    """Execute only CREATE TABLE statements from SCHEMA (skip indexes).
+
+    This is needed before legacy migration so that new tables (like
+    schema_version) exist, but index creation is deferred until after
+    columns are added by the migration.
+    """
+    import re
+
+    for stmt in SCHEMA.split(";"):
+        stmt = stmt.strip()
+        if re.match(r"CREATE\s+(TABLE|VIRTUAL\s+TABLE)", stmt, re.IGNORECASE):
+            conn.execute(stmt)
+
+
+def get_schema_version(conn: sqlite3.Connection) -> int:
+    """Return the current schema version, or 0 if untracked."""
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'")
+    if cursor.fetchone() is None:
+        return 0
+    row = conn.execute("SELECT version FROM schema_version WHERE id = 1").fetchone()
+    return row[0] if row else 0
+
+
+def _set_schema_version(conn: sqlite3.Connection, version: int) -> None:
+    """Set the schema version, creating the table if needed."""
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS schema_version (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            version INTEGER NOT NULL,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO schema_version (id, version, updated_at) VALUES (1, ?, CURRENT_TIMESTAMP) "
+        "ON CONFLICT(id) DO UPDATE SET version = excluded.version, updated_at = CURRENT_TIMESTAMP",
+        (version,),
+    )
+
+
 def _run_migrations(conn: sqlite3.Connection) -> None:
-    """Run schema migrations for existing databases."""
+    """Run schema migrations for existing databases.
+
+    On a fresh database (schema_version table created by SCHEMA with latest
+    version), this is a no-op beyond seeding prompts and FTS.  On a legacy
+    database without schema_version, we run the legacy column-check migration
+    first (v0 → v1), then apply any newer numbered migrations.
+    """
     from .prompts import seed_prompts
 
-    # Check tweets table columns
-    cursor = conn.execute("PRAGMA table_info(tweets)")
-    tweet_columns = {row[1] for row in cursor.fetchall()}
+    current = get_schema_version(conn)
 
-    if "bookmarked" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN bookmarked INTEGER DEFAULT 0")
-        conn.execute("ALTER TABLE tweets ADD COLUMN bookmarked_at TIMESTAMP")
+    # Legacy database: no schema_version table yet
+    if current == 0:
+        _migrate_v0_legacy(conn)
+        _set_schema_version(conn, 0)
+        current = 0
 
-    if "content_summary" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN content_summary TEXT")
+    # Numbered migrations: each entry is (version, migrate_fn)
+    migrations: list[tuple[int, Callable]] = [
+        (1, _migrate_v1_narratives_unique),
+    ]
 
-    if "media_items" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN media_items TEXT")
+    for version, migrate_fn in migrations:
+        if current < version:
+            log.info("Applying schema migration v%d", version)
+            migrate_fn(conn)
+            _set_schema_version(conn, version)
+            current = version
 
-    if "analysis_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN analysis_json TEXT")
-
-    if "is_retweet" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN is_retweet INTEGER DEFAULT 0")
-
-    if "retweeted_by_handle" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN retweeted_by_handle TEXT")
-
-    if "retweeted_by_name" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN retweeted_by_name TEXT")
-
-    if "original_tweet_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_tweet_id TEXT")
-
-    if "original_author_handle" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_author_handle TEXT")
-
-    if "original_author_name" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_author_name TEXT")
-
-    if "original_content" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_content TEXT")
-
-    if "is_x_article" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN is_x_article INTEGER DEFAULT 0")
-
-    if "article_title" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_title TEXT")
-
-    if "article_preview" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_preview TEXT")
-
-    if "article_text" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_text TEXT")
-
-    if "article_summary_short" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_summary_short TEXT")
-
-    if "article_primary_points_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_primary_points_json TEXT")
-
-    if "article_action_items_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_action_items_json TEXT")
-
-    if "article_top_visual_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_top_visual_json TEXT")
-
-    if "article_processed_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_processed_at TIMESTAMP")
-
-    if "links_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN links_json TEXT")
-
-    if "in_reply_to_tweet_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN in_reply_to_tweet_id TEXT")
-
-    if "conversation_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN conversation_id TEXT")
-
-    if "links_expanded_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN links_expanded_at TIMESTAMP")
-
-    if "quote_reprocessed_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN quote_reprocessed_at TIMESTAMP")
-
-    # Check accounts table columns
-    cursor = conn.execute("PRAGMA table_info(accounts)")
-    account_columns = {row[1] for row in cursor.fetchall()}
-
-    if "last_fetched_at" not in account_columns:
-        conn.execute("ALTER TABLE accounts ADD COLUMN last_fetched_at TIMESTAMP")
-
-    # Initialize FTS5 if not present
+    # Always ensure FTS and prompts are initialized (idempotent)
     _init_fts(conn)
 
-    # Seed prompts if table exists but is empty
     cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='prompts'")
     if cursor.fetchone():
         seeded = seed_prompts(conn)
         if seeded > 0:
             conn.commit()
 
-    # Ensure performance indexes exist on existing databases
+
+def _migrate_v0_legacy(conn: sqlite3.Connection) -> None:
+    """Legacy migration: add columns and indexes that pre-versioned databases may lack."""
+    # Check tweets table columns
+    cursor = conn.execute("PRAGMA table_info(tweets)")
+    tweet_columns = {row[1] for row in cursor.fetchall()}
+
+    _add_columns_if_missing(
+        conn,
+        "tweets",
+        tweet_columns,
+        [
+            ("bookmarked", "INTEGER DEFAULT 0"),
+            ("bookmarked_at", "TIMESTAMP"),
+            ("content_summary", "TEXT"),
+            ("media_items", "TEXT"),
+            ("analysis_json", "TEXT"),
+            ("is_retweet", "INTEGER DEFAULT 0"),
+            ("retweeted_by_handle", "TEXT"),
+            ("retweeted_by_name", "TEXT"),
+            ("original_tweet_id", "TEXT"),
+            ("original_author_handle", "TEXT"),
+            ("original_author_name", "TEXT"),
+            ("original_content", "TEXT"),
+            ("is_x_article", "INTEGER DEFAULT 0"),
+            ("article_title", "TEXT"),
+            ("article_preview", "TEXT"),
+            ("article_text", "TEXT"),
+            ("article_summary_short", "TEXT"),
+            ("article_primary_points_json", "TEXT"),
+            ("article_action_items_json", "TEXT"),
+            ("article_top_visual_json", "TEXT"),
+            ("article_processed_at", "TIMESTAMP"),
+            ("links_json", "TEXT"),
+            ("in_reply_to_tweet_id", "TEXT"),
+            ("conversation_id", "TEXT"),
+            ("links_expanded_at", "TIMESTAMP"),
+            ("quote_reprocessed_at", "TIMESTAMP"),
+        ],
+    )
+
+    # Check accounts table columns
+    cursor = conn.execute("PRAGMA table_info(accounts)")
+    account_columns = {row[1] for row in cursor.fetchall()}
+
+    _add_columns_if_missing(
+        conn,
+        "accounts",
+        account_columns,
+        [("last_fetched_at", "TIMESTAMP")],
+    )
+
+    # Ensure indexes exist on legacy databases
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tweets_processed_score "
         "ON tweets(processed_at, relevance_score DESC, created_at DESC)"
@@ -194,6 +235,23 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
         "ON tweets(in_reply_to_tweet_id) WHERE in_reply_to_tweet_id IS NOT NULL"
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_fetch_log_endpoint ON fetch_log(endpoint, executed_at DESC)")
+
+
+def _add_columns_if_missing(
+    conn: sqlite3.Connection,
+    table: str,
+    existing: set[str],
+    columns: list[tuple[str, str]],
+) -> None:
+    """Add columns to a table if they don't already exist."""
+    for col_name, col_type in columns:
+        if col_name not in existing:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}")
+
+
+def _migrate_v1_narratives_unique(conn: sqlite3.Connection) -> None:
+    """Add UNIQUE index on narratives.name for existing databases."""
+    conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_narratives_name ON narratives(name)")
 
 
 def _init_fts(conn: sqlite3.Connection) -> None:

--- a/twag/db/schema.py
+++ b/twag/db/schema.py
@@ -1,5 +1,8 @@
 """Database schema definitions for twag."""
 
+# Bump this when adding a new migration in connection.py
+LATEST_SCHEMA_VERSION = 1
+
 SCHEMA = """
 -- Tweets: Core storage with deduplication
 CREATE TABLE IF NOT EXISTS tweets (
@@ -85,7 +88,7 @@ CREATE TABLE IF NOT EXISTS accounts (
 -- Narratives: Emerging theme tracking
 CREATE TABLE IF NOT EXISTS narratives (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
+    name TEXT NOT NULL UNIQUE,
     first_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     last_mentioned_at TIMESTAMP,
     mention_count INTEGER DEFAULT 1,
@@ -172,6 +175,14 @@ CREATE TABLE IF NOT EXISTS context_commands (
 CREATE INDEX IF NOT EXISTS idx_reactions_tweet ON reactions(tweet_id);
 CREATE INDEX IF NOT EXISTS idx_reactions_type ON reactions(reaction_type);
 CREATE INDEX IF NOT EXISTS idx_prompt_history_name ON prompt_history(prompt_name, version DESC);
+CREATE INDEX IF NOT EXISTS idx_tweets_reply ON tweets(in_reply_to_tweet_id) WHERE in_reply_to_tweet_id IS NOT NULL;
+
+-- Schema version tracking
+CREATE TABLE IF NOT EXISTS schema_version (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    version INTEGER NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 """
 
 # FTS5 schema for full-text search


### PR DESCRIPTION
## Summary
- Replace column-presence-check migrations with a `schema_version` table and numbered migration functions, making future schema changes safer and auditable
- Fix `narratives.name` missing UNIQUE constraint which caused `upsert_narrative` to silently insert duplicates instead of updating
- Add missing `idx_tweets_reply` index to SCHEMA constant (previously only created in `_run_migrations`)
- Add `twag db schema-version` CLI command to inspect current schema version
- Fix pre-existing ty type-check errors in test files

## Test plan
- [x] 10 new tests in `test_schema_evolution.py` covering fresh DB init, legacy migration, and upsert uniqueness
- [x] All 203 tests pass
- [x] ruff format/lint clean
- [x] ty type-check clean (both `uv run ty` and `uvx ty`)

Nightshift-Task: schema-evolution
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: schema-evolution:/home/clifton/code/twag
task-type: schema-evolution
task-title: Schema Evolution Advisor
iterations: 2
duration: 19m9s
nightshift:metadata -->
