### PR TITLE
Add StrEnum taxonomy for signal tiers, pipeline stages, and categories

### DIFF
--- a/twag/db/prompts.py
+++ b/twag/db/prompts.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from twag.models.taxonomy import Category, SignalTier
+
 
 @dataclass
 class Prompt:
@@ -18,42 +20,45 @@ class Prompt:
     updated_by: str | None
 
 
+_CATEGORY_LIST = ", ".join(c.value for c in list(Category))
+_SIGNAL_TIER_LIST = " | ".join(t.value for t in reversed(list(SignalTier)))
+
 # Default prompts to seed from scorer.py
 DEFAULT_PROMPTS = {
-    "triage": """You are a financial markets triage agent. Score this tweet 0-10 for relevance to macro/investing.
+    "triage": f"""You are a financial markets triage agent. Score this tweet 0-10 for relevance to macro/investing.
 
-Categories (assign 1-3 that apply): fed_policy, inflation, job_market, macro_data, earnings, equities, rates_fx, credit, banks, consumer_spending, capex, commodities, energy, metals_mining, geopolitical, sanctions, tech_business, ai_advancement, crypto, noise
+Categories (assign 1-3 that apply): {_CATEGORY_LIST}
 
-Tweet: {tweet_text}
-Author: @{handle}
+Tweet: {{tweet_text}}
+Author: @{{handle}}
 
 Return JSON only:
-{{"score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner summary", "tickers": ["TLT", "GLD"]}}""",
-    "batch_triage": """You are a financial markets triage agent. Score these tweets 0-10 for relevance to macro/investing.
+{{{{"score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner summary", "tickers": ["TLT", "GLD"]}}}}""",
+    "batch_triage": f"""You are a financial markets triage agent. Score these tweets 0-10 for relevance to macro/investing.
 
-Categories (assign 1-3 that apply): fed_policy, inflation, job_market, macro_data, earnings, equities, rates_fx, credit, banks, consumer_spending, capex, commodities, energy, metals_mining, geopolitical, sanctions, tech_business, ai_advancement, crypto, noise
+Categories (assign 1-3 that apply): {_CATEGORY_LIST}
 
 Tweets:
-{tweets}
+{{tweets}}
 
 Return a JSON array with one object per tweet, in order:
-[{{"id": "tweet_id", "score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner", "tickers": ["TLT"]}}]""",
-    "enrichment": """You are a financial analyst. Analyze this tweet for actionable insights.
+[{{{{"id": "tweet_id", "score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner", "tickers": ["TLT"]}}}}]""",
+    "enrichment": f"""You are a financial analyst. Analyze this tweet for actionable insights.
 
-Tweet: {tweet_text}
-Author: @{handle} ({author_category})
-Quoted: {quoted_tweet}
-Linked article: {article_summary}
-Media context: {image_description}
+Tweet: {{tweet_text}}
+Author: @{{handle}} ({{author_category}})
+Quoted: {{quoted_tweet}}
+Linked article: {{article_summary}}
+Media context: {{image_description}}
 
 Provide:
-1. Signal tier: high_signal | market_relevant | news | noise
+1. Signal tier: {_SIGNAL_TIER_LIST}
 2. Key insight (1-2 sentences)
 3. Investment implications with specific tickers
 4. Any emerging narratives this connects to
 
 Return JSON:
-{{"signal_tier": "high_signal", "insight": "...", "implications": "...", "narratives": ["Fed pivot"], "tickers": ["TLT"]}}""",
+{{{{"signal_tier": "high_signal", "insight": "...", "implications": "...", "narratives": ["Fed pivot"], "tickers": ["TLT"]}}}}""",
     "summarize": """Summarize this tweet concisely while preserving all key market-relevant information, data points, and actionable insights. Keep ticker symbols and specific numbers.
 
 Tweet by @{handle}:

--- a/twag/models/__init__.py
+++ b/twag/models/__init__.py
@@ -47,12 +47,20 @@ from .scoring import (
     VisionResult,
     XArticleSummaryResult,
 )
+from .taxonomy import (
+    SIGNAL_TIER_RANK,
+    Category,
+    PipelineStage,
+    SignalTier,
+)
 from .tweet import TweetData
 
 __all__ = [
+    "SIGNAL_TIER_RANK",
     "AccountsConfig",
     "ActionableItem",
     "BirdConfig",
+    "Category",
     "CategoryCount",
     "ChartAnalysis",
     "ContextCommand",
@@ -67,6 +75,7 @@ __all__ = [
     "MediaItem",
     "NotificationConfig",
     "PathsConfig",
+    "PipelineStage",
     "PrimaryPoint",
     "ProcessingConfig",
     "Prompt",
@@ -74,6 +83,7 @@ __all__ = [
     "Reaction",
     "ScoringConfig",
     "SearchResult",
+    "SignalTier",
     "TableAnalysis",
     "TickerCount",
     "TriageResult",

--- a/twag/models/scoring.py
+++ b/twag/models/scoring.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, field_validator
 
+from .taxonomy import SignalTier
+
 
 class TriageResult(BaseModel):
     """Result of tweet triage scoring."""
@@ -25,7 +27,7 @@ class TriageResult(BaseModel):
 class EnrichmentResult(BaseModel):
     """Result of tweet enrichment analysis."""
 
-    signal_tier: str = "noise"
+    signal_tier: str = SignalTier.NOISE
     insight: str = ""
     implications: str = ""
     narratives: list[str] = []

--- a/twag/models/taxonomy.py
+++ b/twag/models/taxonomy.py
@@ -1,0 +1,67 @@
+"""Canonical enums for signal tiers, pipeline stages, and tweet categories."""
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Backport of StrEnum for Python <3.11."""
+
+
+class SignalTier(StrEnum):
+    """Signal tier classification for processed tweets.
+
+    StrEnum ensures backward compatibility with SQLite TEXT columns,
+    JSON serialization, and LLM prompt templates.
+    """
+
+    NOISE = "noise"
+    NEWS = "news"
+    MARKET_RELEVANT = "market_relevant"
+    HIGH_SIGNAL = "high_signal"
+
+
+class PipelineStage(StrEnum):
+    """Processing pipeline stages used as future tags in triage."""
+
+    SUMMARY = "summary"
+    MEDIA = "media"
+    ARTICLE = "article"
+    ENRICH = "enrich"
+
+
+class Category(StrEnum):
+    """Tweet content categories assigned during triage scoring."""
+
+    FED_POLICY = "fed_policy"
+    INFLATION = "inflation"
+    JOB_MARKET = "job_market"
+    MACRO_DATA = "macro_data"
+    EARNINGS = "earnings"
+    EQUITIES = "equities"
+    RATES_FX = "rates_fx"
+    CREDIT = "credit"
+    BANKS = "banks"
+    CONSUMER_SPENDING = "consumer_spending"
+    CAPEX = "capex"
+    COMMODITIES = "commodities"
+    ENERGY = "energy"
+    METALS_MINING = "metals_mining"
+    GEOPOLITICAL = "geopolitical"
+    SANCTIONS = "sanctions"
+    TECH_BUSINESS = "tech_business"
+    AI_ADVANCEMENT = "ai_advancement"
+    CRYPTO = "crypto"
+    NOISE = "noise"
+
+
+# Canonical ranking for signal tier comparison.
+SIGNAL_TIER_RANK: dict[str, int] = {
+    SignalTier.NOISE: 0,
+    SignalTier.NEWS: 1,
+    SignalTier.MARKET_RELEVANT: 2,
+    SignalTier.HIGH_SIGNAL: 3,
+}

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -7,6 +7,7 @@ import httpx
 
 from .config import load_config
 from .fetcher import get_tweet_url
+from .models.taxonomy import Category
 
 
 def is_quiet_hours() -> bool:
@@ -72,7 +73,7 @@ def format_alert(
 
     # Category display - handle list or string
     if isinstance(category, list):
-        cats = [c for c in category if c != "noise"]
+        cats = [c for c in category if c != Category.NOISE]
         cat_display = ", ".join(c.replace("_", " ").upper() for c in cats) if cats else "MARKET"
     else:
         cat_display = category.replace("_", " ").upper() if category else "MARKET"

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -22,6 +22,7 @@ from ..db import (
     update_tweet_processing,
 )
 from ..media import build_media_context, build_media_summary, parse_media_items
+from ..models.taxonomy import SIGNAL_TIER_RANK, PipelineStage, SignalTier
 from ..scorer import (
     TriageResult,
     analyze_media,
@@ -31,13 +32,6 @@ from ..scorer import (
     summarize_x_article,
     triage_tweets_batch,
 )
-
-_SIGNAL_TIER_RANK = {
-    "noise": 0,
-    "news": 1,
-    "market_relevant": 2,
-    "high_signal": 3,
-}
 
 
 def _normalized_worker_count(value: Any, fallback: int) -> int:
@@ -58,8 +52,8 @@ def _prefer_stronger_signal_tier(existing: str | None, candidate: str | None) ->
     if not candidate:
         return existing
 
-    existing_rank = _SIGNAL_TIER_RANK.get(str(existing), -1)
-    candidate_rank = _SIGNAL_TIER_RANK.get(str(candidate), -1)
+    existing_rank = SIGNAL_TIER_RANK.get(str(existing), -1)
+    candidate_rank = SIGNAL_TIER_RANK.get(str(candidate), -1)
     return candidate if candidate_rank > existing_rank else existing
 
 
@@ -385,7 +379,7 @@ def _triage_rows(
     pending_tasks: dict[str, int] = {}
 
     # Unified future map: Future -> (tag, data)
-    # Tags: "summary", "media", "article", "enrich"
+    # Tags: PipelineStage.SUMMARY, .MEDIA, .ARTICLE, .ENRICH
     all_futures: dict[Any, tuple[str, Any]] = {}
 
     # Worker pools return analysis payloads only; SQLite access stays on the owner thread.
@@ -441,7 +435,7 @@ def _triage_rows(
                 image_description=media_context,
                 model=enrich_model,
             )
-            all_futures[future] = ("enrich", (tweet_id, row))
+            all_futures[future] = (PipelineStage.ENRICH, (tweet_id, row))
         else:
             try:
                 result = enrich_tweet(
@@ -501,7 +495,7 @@ def _triage_rows(
                     enrich_model,
                     media_items,
                 )
-            all_futures[future] = ("article", (tweet_id, row))
+            all_futures[future] = (PipelineStage.ARTICLE, (tweet_id, row))
         else:
             try:
                 if media_items and _needs_media_analysis(media_items):
@@ -550,13 +544,13 @@ def _triage_rows(
                 status_cb(f"Saving @{tweet_row['author_handle']}")
 
             if result.score >= 8:
-                tier = "high_signal"
+                tier = SignalTier.HIGH_SIGNAL
             elif result.score >= 6:
-                tier = "market_relevant"
+                tier = SignalTier.MARKET_RELEVANT
             elif result.score >= 4:
-                tier = "news"
+                tier = SignalTier.NEWS
             else:
-                tier = "noise"
+                tier = SignalTier.NOISE
 
             update_tweet_processing(
                 conn,
@@ -584,7 +578,7 @@ def _triage_rows(
                     if status_cb:
                         status_cb(f"Queue summary @{handle}")
                     future = text_pool.submit(summarize_tweet, content, handle, enrich_model, None)
-                    all_futures[future] = ("summary", result.tweet_id)
+                    all_futures[future] = (PipelineStage.SUMMARY, result.tweet_id)
                     task_count += 1
                 else:
                     try:
@@ -632,7 +626,7 @@ def _triage_rows(
                             vision_model=vision_model,
                             vision_provider=vision_provider,
                         )
-                        all_futures[future] = ("media", result.tweet_id)
+                        all_futures[future] = (PipelineStage.MEDIA, result.tweet_id)
                         task_count += 1
                     else:
                         if status_cb:
@@ -719,7 +713,7 @@ def _triage_rows(
         # Apply worker results here so DB writes remain serialized on this thread.
         for future in as_completed(list(all_futures.keys())):
             tag, data = all_futures.pop(future)
-            if tag == "summary":
+            if tag == PipelineStage.SUMMARY:
                 tweet_id = data
                 try:
                     content_summary = future.result()
@@ -732,7 +726,7 @@ def _triage_rows(
                 except Exception:
                     pass
                 _complete_task(tweet_id)
-            elif tag == "media":
+            elif tag == PipelineStage.MEDIA:
                 tweet_id = data
                 try:
                     updated_items, _ = future.result()
@@ -746,7 +740,7 @@ def _triage_rows(
                 except Exception:
                     pass
                 _complete_task(tweet_id)
-            elif tag == "article":
+            elif tag == PipelineStage.ARTICLE:
                 tweet_id, row = data
                 try:
                     article_result, analyzed_items = future.result()
@@ -777,7 +771,7 @@ def _triage_rows(
                 except Exception:
                     pass
                 _complete_task(tweet_id)
-            elif tag == "enrich":
+            elif tag == PipelineStage.ENRICH:
                 tweet_id, row = data
                 try:
                     result = future.result()

--- a/twag/renderer.py
+++ b/twag/renderer.py
@@ -11,6 +11,7 @@ from .config import get_digests_dir, load_config
 from .db import get_connection, get_tweet_by_id, get_tweets_for_digest, mark_tweet_in_digest
 from .fetcher import get_tweet_url
 from .link_utils import normalize_tweet_links
+from .models.taxonomy import Category, SignalTier
 
 
 def _value(tweet: sqlite3.Row | dict, key: str, default=None):
@@ -55,12 +56,12 @@ def render_digest(
         news = []
 
         for tweet in tweets:
-            tier = tweet["signal_tier"] or "noise"
-            if tier == "high_signal":
+            tier = tweet["signal_tier"] or SignalTier.NOISE
+            if tier == SignalTier.HIGH_SIGNAL:
                 high_signal.append(tweet)
-            elif tier == "market_relevant":
+            elif tier == SignalTier.MARKET_RELEVANT:
                 market_relevant.append(tweet)
-            elif tier == "news":
+            elif tier == SignalTier.NEWS:
                 news.append(tweet)
 
         # Render markdown
@@ -222,7 +223,7 @@ def _render_tweet(conn: sqlite3.Connection, tweet: sqlite3.Row, compact: bool = 
                 categories = [tweet["category"]]
 
             # Filter out noise
-            categories = [c for c in categories if c != "noise"]
+            categories = [c for c in categories if c != Category.NOISE]
             if categories:
                 cat_display = ", ".join(c.replace("_", " ").title() for c in categories)
                 lines.append(f"🏷️ **Categories:** {cat_display}")

--- a/twag/scorer/prompts.py
+++ b/twag/scorer/prompts.py
@@ -1,44 +1,49 @@
 """Prompt templates for LLM scoring and analysis."""
 
+from twag.models.taxonomy import Category, SignalTier
+
+_CATEGORY_LIST = ", ".join(c.value for c in list(Category))
+_SIGNAL_TIER_LIST = " | ".join(t.value for t in reversed(list(SignalTier)))
+
 # Triage prompt for fast scoring
-TRIAGE_PROMPT = """You are a financial markets triage agent. Score this tweet 0-10 for relevance to macro/investing.
+TRIAGE_PROMPT = f"""You are a financial markets triage agent. Score this tweet 0-10 for relevance to macro/investing.
 
-Categories (assign 1-3 that apply): fed_policy, inflation, job_market, macro_data, earnings, equities, rates_fx, credit, banks, consumer_spending, capex, commodities, energy, metals_mining, geopolitical, sanctions, tech_business, ai_advancement, crypto, noise
+Categories (assign 1-3 that apply): {_CATEGORY_LIST}
 
-Tweet: {tweet_text}
-Author: @{handle}
+Tweet: {{tweet_text}}
+Author: @{{handle}}
 
 Return JSON only:
-{{"score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner summary", "tickers": ["TLT", "GLD"]}}"""
+{{{{"score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner summary", "tickers": ["TLT", "GLD"]}}}}"""
 
 # Batch triage prompt
-BATCH_TRIAGE_PROMPT = """You are a financial markets triage agent. Score these tweets 0-10 for relevance to macro/investing.
+BATCH_TRIAGE_PROMPT = f"""You are a financial markets triage agent. Score these tweets 0-10 for relevance to macro/investing.
 
-Categories (assign 1-3 that apply): fed_policy, inflation, job_market, macro_data, earnings, equities, rates_fx, credit, banks, consumer_spending, capex, commodities, energy, metals_mining, geopolitical, sanctions, tech_business, ai_advancement, crypto, noise
+Categories (assign 1-3 that apply): {_CATEGORY_LIST}
 
 Tweets:
-{tweets}
+{{tweets}}
 
 Return a JSON array with one object per tweet, in order:
-[{{"id": "tweet_id", "score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner", "tickers": ["TLT"]}}]"""
+[{{{{"id": "tweet_id", "score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner", "tickers": ["TLT"]}}}}]"""
 
 # Enrichment prompt for high-signal tweets
-ENRICHMENT_PROMPT = """You are a financial analyst. Analyze this tweet for actionable insights.
+ENRICHMENT_PROMPT = f"""You are a financial analyst. Analyze this tweet for actionable insights.
 
-Tweet: {tweet_text}
-Author: @{handle} ({author_category})
-Quoted: {quoted_tweet}
-Linked article: {article_summary}
-Media context: {image_description}
+Tweet: {{tweet_text}}
+Author: @{{handle}} ({{author_category}})
+Quoted: {{quoted_tweet}}
+Linked article: {{article_summary}}
+Media context: {{image_description}}
 
 Provide:
-1. Signal tier: high_signal | market_relevant | news | noise
+1. Signal tier: {_SIGNAL_TIER_LIST}
 2. Key insight (1-2 sentences)
 3. Investment implications with specific tickers
 4. Any emerging narratives this connects to
 
 Return JSON:
-{{"signal_tier": "high_signal", "insight": "...", "implications": "...", "narratives": ["Fed pivot"], "tickers": ["TLT"]}}"""
+{{{{"signal_tier": "high_signal", "insight": "...", "implications": "...", "narratives": ["Fed pivot"], "tickers": ["TLT"]}}}}"""
 
 # Content summarization prompt for long tweets
 SUMMARIZE_PROMPT = """Summarize this tweet concisely while preserving all key market-relevant information, data points, and actionable insights. Keep ticker symbols and specific numbers.

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from twag.config import load_config
+from twag.models.taxonomy import Category, SignalTier
 
 from .llm_client import _call_llm, _call_llm_vision, _parse_json_response
 from .prompts import (
@@ -91,7 +92,7 @@ def triage_tweet(
         data = data[0]
 
     # Handle both old "category" (string) and new "categories" (array) format
-    categories = data.get("categories") or [data.get("category", "noise")]
+    categories = data.get("categories") or [data.get("category", Category.NOISE)]
     if isinstance(categories, str):
         categories = [categories]
 
@@ -136,7 +137,7 @@ def triage_tweets_batch(
     results = []
     for item in data:
         # Handle both old "category" (string) and new "categories" (array) format
-        categories = item.get("categories") or [item.get("category", "noise")]
+        categories = item.get("categories") or [item.get("category", Category.NOISE)]
         if isinstance(categories, str):
             categories = [categories]
 
@@ -185,7 +186,7 @@ def enrich_tweet(
         data = data[0]
 
     return EnrichmentResult(
-        signal_tier=data.get("signal_tier", "noise"),
+        signal_tier=data.get("signal_tier", SignalTier.NOISE),
         insight=data.get("insight", ""),
         implications=data.get("implications", ""),
         narratives=data.get("narratives", []),


### PR DESCRIPTION
## Summary
- Add `twag/models/taxonomy.py` with three `StrEnum` classes: `SignalTier`, `PipelineStage`, and `Category`, plus a canonical `SIGNAL_TIER_RANK` dict
- Replace scattered magic strings across triage, scoring, rendering, and notification modules with enum members
- Derive prompt template category/tier enumerations from enum values instead of hardcoded strings, ensuring a single source of truth

## Test plan
- [x] All 193 existing tests pass unchanged (StrEnum backward-compatible with str)
- [x] `ruff format` and `ruff check` pass on all modified files
- [x] `ty check` passes (0 errors, improved from 2 pre-existing diagnostics)
- [x] Python 3.10 compatibility via `str, Enum` backport when `StrEnum` unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: event-taxonomy:/home/clifton/code/twag
task-type: event-taxonomy
task-title: Event Taxonomy Normalizer
iterations: 1
duration: 12m29s
nightshift:metadata -->
