### PR TITLE
Add centralized logging and replace silent exception swallowing

### DIFF
--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -1,5 +1,8 @@
 """CLI entry point for twag."""
 
+import logging
+import os
+
 import rich_click as click
 
 from .. import __version__
@@ -27,10 +30,23 @@ from .analyze import _echo_wrapped as _echo_wrapped
 from .analyze import _print_status_analysis as _print_status_analysis
 
 
+def _configure_logging() -> None:
+    """Set up root logger with stderr handler, level from TWAG_LOG_LEVEL."""
+    level_name = os.environ.get("TWAG_LOG_LEVEL", "WARNING").upper()
+    level = getattr(logging, level_name, logging.WARNING)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s"))
+    root = logging.getLogger("twag")
+    root.setLevel(level)
+    if not root.handlers:
+        root.addHandler(handler)
+
+
 @click.group()
 @click.version_option(version=__version__)
 def cli():
     """Twitter aggregator for market-relevant signals."""
+    _configure_logging()
 
 
 # Register commands

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from functools import lru_cache
 from threading import Lock
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
+
+log = logging.getLogger(__name__)
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -114,6 +117,7 @@ def _expand_short_url(url: str) -> str:
                 if resolved:
                     return resolved
         except Exception:
+            log.debug("URL expansion failed for %s (%s)", cleaned, method, exc_info=True)
             continue
     return cleaned
 

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -1,5 +1,6 @@
 """Telegram notifications for high-signal tweets."""
 
+import logging
 import os
 from datetime import datetime
 
@@ -7,6 +8,8 @@ import httpx
 
 from .config import load_config
 from .fetcher import get_tweet_url
+
+log = logging.getLogger(__name__)
 
 
 def is_quiet_hours() -> bool:
@@ -134,6 +137,7 @@ def send_telegram_alert(
         )
         return response.status_code == 200
     except Exception:
+        log.error("Telegram alert delivery failed", exc_info=True)
         return False
 
 

--- a/twag/processor/pipeline.py
+++ b/twag/processor/pipeline.py
@@ -350,6 +350,7 @@ def enrich_high_signal(
                             (result.signal_tier, tweet_id),
                         )
                 except Exception:
+                    log.warning("Enrichment failed for tweet %s", tweet_id, exc_info=True)
                     continue
         finally:
             if text_pool:
@@ -397,8 +398,7 @@ def run_full_cycle(
                 stats["tier1_fetched"] += fetched
                 stats["tier1_new"] += new
             except Exception:
-                # Log but continue
-                pass
+                log.error("Failed to fetch tier-1 account @%s", account["handle"], exc_info=True)
 
     # Process unprocessed tweets
     if process:

--- a/twag/processor/storage.py
+++ b/twag/processor/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -29,6 +30,8 @@ from .dependencies import (
     _fetch_quote_chain,
     _fetch_reply_chain,
 )
+
+log = logging.getLogger(__name__)
 
 
 def _store_tweets(
@@ -91,6 +94,7 @@ def _store_tweets(
 
         if inserted:
             new_count += 1
+            log.debug("Stored new tweet %s from @%s", tweet.id, tweet.author_handle)
 
         if bookmarked:
             mark_tweet_bookmarked(conn, tweet.id)

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -31,6 +32,8 @@ from ..scorer import (
     summarize_x_article,
     triage_tweets_batch,
 )
+
+log = logging.getLogger(__name__)
 
 _SIGNAL_TIER_RANK = {
     "noise": 0,
@@ -136,6 +139,7 @@ def _analyze_media_items(
         try:
             result = analyze_media(url, model=vision_model, provider=vision_provider)
         except Exception:
+            log.warning("Media analysis failed for %s", url, exc_info=True)
             continue
 
         item["kind"] = result.kind
@@ -187,6 +191,7 @@ def _merge_document_media(media_items: list[dict[str, Any]]) -> bool:
     try:
         combined_summary = summarize_document_text(combined_text)
     except Exception:
+        log.warning("Document summarization failed, using fallback", exc_info=True)
         combined_summary = (media_items[doc_entries[0][1]].get("prose_summary") or "").strip()
 
     primary_idx = doc_entries[0][1]
@@ -455,7 +460,7 @@ def _triage_rows(
                 )
                 _save_enrichment_result(conn, tweet_id, row, result)
             except Exception:
-                pass
+                log.warning("Enrichment failed for tweet %s", tweet_id, exc_info=True)
             _complete_task(tweet_id)
 
     def _submit_article(tweet_id: str, tweet_row: sqlite3.Row) -> None:
@@ -540,7 +545,7 @@ def _triage_rows(
                         media_items=media_items,
                     )
             except Exception:
-                pass
+                log.warning("Article processing failed for tweet %s", tweet_id, exc_info=True)
             _complete_task(tweet_id)
 
     def _handle_results(results: list[TriageResult]) -> None:
@@ -601,7 +606,7 @@ def _triage_rows(
                             content_summary=content_summary,
                         )
                     except Exception:
-                        pass
+                        log.warning("Summarization failed for tweet %s", result.tweet_id, exc_info=True)
 
             if update_stats:
                 update_account_stats(
@@ -698,6 +703,7 @@ def _triage_rows(
                 try:
                     results = future.result()
                 except Exception:
+                    log.error("Triage batch %d failed", batch_index, exc_info=True)
                     if status_cb:
                         status_cb(f"Batch {batch_index} failed")
                     if progress_cb:
@@ -730,7 +736,7 @@ def _triage_rows(
                             content_summary=content_summary,
                         )
                 except Exception:
-                    pass
+                    log.warning("Summary worker failed for tweet %s", tweet_id, exc_info=True)
                 _complete_task(tweet_id)
             elif tag == "media":
                 tweet_id = data
@@ -744,7 +750,7 @@ def _triage_rows(
                         media_items=updated_items,
                     )
                 except Exception:
-                    pass
+                    log.warning("Media worker failed for tweet %s", tweet_id, exc_info=True)
                 _complete_task(tweet_id)
             elif tag == "article":
                 tweet_id, row = data
@@ -775,7 +781,7 @@ def _triage_rows(
                             media_items=analyzed_items,
                         )
                 except Exception:
-                    pass
+                    log.warning("Article worker failed for tweet %s", tweet_id, exc_info=True)
                 _complete_task(tweet_id)
             elif tag == "enrich":
                 tweet_id, row = data
@@ -783,7 +789,7 @@ def _triage_rows(
                     result = future.result()
                     _save_enrichment_result(conn, tweet_id, row, result)
                 except Exception:
-                    pass
+                    log.warning("Enrichment worker failed for tweet %s", tweet_id, exc_info=True)
                 _complete_task(tweet_id)
     finally:
         if triage_pool:

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -1,6 +1,7 @@
 """LLM client infrastructure: provider dispatch, retry logic, JSON parsing."""
 
 import json
+import logging
 import random
 import time
 from typing import Any
@@ -9,6 +10,8 @@ from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+log = logging.getLogger(__name__)
 
 
 def get_anthropic_client() -> Anthropic:
@@ -157,8 +160,10 @@ def _with_retry(fn):
             if "not set" in msg and "api" in msg:
                 raise
             if retries and attempt >= retries:
+                log.warning("LLM call failed after %d attempts: %s", attempt, exc)
                 raise
 
+            log.info("LLM retry attempt %d/%d: %s", attempt, retries, exc)
             delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
             if jitter:
                 delay = max(0.0, delay * (1 + random.uniform(-jitter, jitter)))

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -1,5 +1,6 @@
 """Scoring, triage, enrichment, and analysis functions."""
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -15,6 +16,8 @@ from .prompts import (
     SUMMARIZE_PROMPT,
     TRIAGE_PROMPT,
 )
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -272,9 +275,11 @@ def summarize_x_article(
             data = _parse_json_response(text)
             break
         except Exception:
+            log.warning("Article summarization failed with %s/%s", cand_provider, cand_model, exc_info=True)
             continue
 
     if data is None:
+        log.warning("All LLM candidates failed for article summarization")
         return XArticleSummaryResult(short_summary=fallback_summary)
 
     if isinstance(data, list):


### PR DESCRIPTION
## Summary
- Add `TWAG_LOG_LEVEL` env var support via `_configure_logging()` in the CLI entry point, configuring a stderr handler with consistent format on the `twag` logger namespace
- Add module-level loggers to 7 critical modules: `triage.py`, `pipeline.py`, `scoring.py`, `llm_client.py`, `notifier.py`, `link_utils.py`, `storage.py`
- Replace ~20 bare `except Exception: pass` blocks with `log.warning`/`log.error` calls that include context (tweet_id, provider, batch index) and `exc_info=True`
- Fix the "Log but continue" comment-only bug in `pipeline.py:run_full_cycle` to actually log the exception
- Log LLM retry attempts with attempt number and error message
- Log when all LLM provider candidates fail in `summarize_x_article`

## Test plan
- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes  
- [x] `uv run ty check` passes (note: `uvx ty check` has 2 pre-existing errors in test files unrelated to this change)
- [x] All 193 pytest tests pass
- [ ] Verify logging output with `TWAG_LOG_LEVEL=DEBUG twag process --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: logging-audit:/home/clifton/code/twag
task-type: logging-audit
task-title: Logging Quality Auditor
iterations: 2
duration: 16m37s
nightshift:metadata -->
