### PR TITLE
fix: PII exposure in doctor output and web server binding

### DIFF
--- a/twag/cli/init_cmd.py
+++ b/twag/cli/init_cmd.py
@@ -147,14 +147,14 @@ def doctor():
 
     gemini_key = os.environ.get("GEMINI_API_KEY")
     if gemini_key:
-        console.print(f"  {status_icon(True)} GEMINI_API_KEY set ({gemini_key[:8]}...)")
+        console.print(f"  {status_icon(True)} GEMINI_API_KEY set")
     else:
         console.print(f"  {status_icon(False)} GEMINI_API_KEY not set")
         issues.append("Set GEMINI_API_KEY environment variable")
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     if anthropic_key:
-        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set ({anthropic_key[:8]}...)")
+        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set")
     else:
         console.print("  [yellow]WARN[/yellow] ANTHROPIC_API_KEY not set (enrichment disabled)")
         warnings.append("Set ANTHROPIC_API_KEY for enrichment features")

--- a/twag/cli/web.py
+++ b/twag/cli/web.py
@@ -8,7 +8,7 @@ from ._console import console
 
 
 @click.command()
-@click.option("--host", "-h", default="0.0.0.0", help="Host to bind to")
+@click.option("--host", "-h", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", "-p", default=5173, help="Port to bind to")
 @click.option("--reload/--no-reload", default=True, help="Auto-reload on code changes")
 @click.option("--dev", is_flag=True, default=False, help="Dev mode: start Vite + FastAPI with HMR")

--- a/twag/fetcher/bird_cli.py
+++ b/twag/fetcher/bird_cli.py
@@ -77,10 +77,12 @@ def run_bird(args: list[str], timeout: int = 60) -> tuple[str, str, int]:
     _rate_limit_bird()
     env = get_auth_env()
 
-    # Build command with auth if available
+    # Build command with auth if available.
+    # NOTE: auth tokens are passed as CLI args because bird CLI does not support
+    # reading them from environment variables. This makes them visible in the
+    # process table — acceptable for a single-user local tool.
     cmd = ["bird", *args]
 
-    # Add auth flags if we have the tokens
     auth_token = env.get("AUTH_TOKEN")
     ct0 = env.get("CT0")
 


### PR DESCRIPTION
## Summary
- **Doctor command**: Removed partial API key display (`GEMINI_API_KEY` and `ANTHROPIC_API_KEY` were printing first 8 characters to stdout). Now shows only `set`/`not set`, consistent with how `AUTH_TOKEN`/`CT0` were already handled.
- **Web server**: Changed default bind host from `0.0.0.0` to `127.0.0.1` to prevent unintended network exposure of the unauthenticated API.
- **Bird CLI**: Added documentation comment noting that auth tokens must be passed as CLI args (visible in process table) because the bird CLI doesn't support reading them from environment variables. This is acceptable for a single-user local tool.

## Findings not requiring code changes
- Public Twitter handles in DB, search queries in fetch_log, and Telegram alerts with handles are by-design for a single-user local tool.

## Test plan
- [x] All 168 existing tests pass
- [x] `ruff format` and `ruff check` pass

Nightshift-Task: pii-scanner
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: pii-scanner:/home/clifton/code/twag
task-type: pii-scanner
task-title: PII Exposure Scanner
iterations: 1
duration: 5m57s
nightshift:metadata -->
