### PR TITLE
feat: add roadmap entropy detector

### DIFF
--- a/scripts/roadmap_entropy.py
+++ b/scripts/roadmap_entropy.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Standalone roadmap entropy analysis script.
+
+Usage:
+    python scripts/roadmap_entropy.py [--days 90] [--json] [--repo-path /path/to/repo]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from twag.entropy import analyze_entropy
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Detect roadmap scope creep and drift from git history.")
+    parser.add_argument("--days", type=int, default=90, help="Days of history to analyze (default: 90)")
+    parser.add_argument("--json", dest="as_json", action="store_true", help="Output JSON instead of text")
+    parser.add_argument("--repo-path", default=None, help="Path to git repository (default: current dir)")
+    args = parser.parse_args()
+
+    report = analyze_entropy(days=args.days, repo_path=args.repo_path)
+
+    if args.as_json:
+        data = {
+            "overall_score": round(report.overall_score, 1),
+            "commit_topic_entropy": round(report.commit_topic_entropy, 3),
+            "file_churn_dispersion": round(report.file_churn_dispersion, 3),
+            "surface_area_delta": report.surface_area_delta,
+            "todo_accumulation": report.todo_accumulation,
+            "doc_staleness_ratio": round(report.doc_staleness_ratio, 3),
+            "topic_counts": report.topic_counts,
+            "churn_hotspots": [{"file": f, "changes": c} for f, c in report.churn_hotspots],
+            "drift_indicators": [
+                {"category": d.category, "description": d.description, "severity": d.severity}
+                for d in report.drift_indicators
+            ],
+            "recommendations": report.recommendations,
+        }
+        print(json.dumps(data, indent=2))
+        return
+
+    score = report.overall_score
+    if score < 30:
+        label = "Low"
+    elif score < 60:
+        label = "Moderate"
+    else:
+        label = "High"
+
+    print(f"Roadmap Entropy Report (last {args.days} days)")
+    print(f"Overall Score: {score:.0f}/100 ({label} entropy)")
+    print()
+    print("Metrics:")
+    print(f"  Commit topic entropy:  {report.commit_topic_entropy:.3f}")
+    print(f"  File churn dispersion: {report.file_churn_dispersion:.3f}")
+    print(f"  Surface area delta:    {report.surface_area_delta:+d} files")
+    print(f"  TODO/FIXME count:      {report.todo_accumulation}")
+    print(f"  Doc staleness:         {report.doc_staleness_ratio:.0%}")
+    print()
+
+    if report.topic_counts:
+        print("Commit Topics:")
+        for topic, count in sorted(report.topic_counts.items(), key=lambda x: -x[1]):
+            print(f"  {topic:<12} {count}")
+        print()
+
+    if report.churn_hotspots:
+        print("Churn Hotspots (top 10):")
+        for filepath, count in report.churn_hotspots:
+            print(f"  {count:>4}  {filepath}")
+        print()
+
+    if report.drift_indicators:
+        print("Drift Indicators:")
+        for ind in report.drift_indicators:
+            print(f"  [{ind.severity.upper()}] {ind.description}")
+        print()
+
+    if report.recommendations:
+        print("Recommendations:")
+        for rec in report.recommendations:
+            print(f"  - {rec}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -1,0 +1,270 @@
+"""Tests for the roadmap entropy detector."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from twag.cli import cli
+from twag.entropy import (
+    EntropyReport,
+    analyze_entropy,
+    churn_dispersion,
+    classify_commit,
+    count_todos,
+    doc_staleness,
+    get_commit_messages,
+    get_file_churn,
+    get_surface_area_delta,
+    shannon_entropy,
+)
+
+# --- classify_commit ---
+
+
+def test_classify_feat():
+    """`feat:` prefix maps to 'feature' topic."""
+    assert classify_commit("feat: add login page") == "feature"
+
+
+def test_classify_fix():
+    """`fix:` prefix maps to 'bugfix' topic."""
+    assert classify_commit("fix: resolve crash on startup") == "bugfix"
+
+
+def test_classify_scoped():
+    """`feat(scope):` prefix is recognized."""
+    assert classify_commit("feat(auth): add OAuth support") == "feature"
+
+
+def test_classify_breaking():
+    """`feat!:` breaking change prefix is recognized."""
+    assert classify_commit("feat!: redesign API") == "feature"
+
+
+def test_classify_docs():
+    """`docs:` prefix maps to 'docs' topic."""
+    assert classify_commit("docs: update README") == "docs"
+
+
+def test_classify_chore():
+    """`chore:` prefix maps to 'chore' topic."""
+    assert classify_commit("chore: bump dependencies") == "chore"
+
+
+def test_classify_unknown():
+    """Non-conventional messages map to 'other'."""
+    assert classify_commit("just a random commit message") == "other"
+
+
+def test_classify_refactor():
+    """`refactor:` prefix maps to 'refactor' topic."""
+    assert classify_commit("refactor: extract helper function") == "refactor"
+
+
+# --- shannon_entropy ---
+
+
+def test_shannon_entropy_uniform():
+    """Uniform distribution over N categories yields entropy ~1.0."""
+    counts = {"a": 10, "b": 10, "c": 10, "d": 10}
+    e = shannon_entropy(counts)
+    assert 0.99 <= e <= 1.0
+
+
+def test_shannon_entropy_concentrated():
+    """Single-category distribution yields entropy 0.0."""
+    counts = {"a": 100}
+    assert shannon_entropy(counts) == 0.0
+
+
+def test_shannon_entropy_empty():
+    """Empty distribution yields entropy 0.0."""
+    assert shannon_entropy({}) == 0.0
+
+
+def test_shannon_entropy_skewed():
+    """Skewed distribution yields low but nonzero entropy."""
+    counts = {"a": 90, "b": 5, "c": 3, "d": 2}
+    e = shannon_entropy(counts)
+    assert 0.0 < e < 0.7
+
+
+# --- churn_dispersion ---
+
+
+def test_churn_dispersion_focused():
+    """All churn in one file yields dispersion 0.0."""
+    churn = [("main.py", 100)]
+    assert churn_dispersion(churn) == 0.0
+
+
+def test_churn_dispersion_empty():
+    """No churn yields dispersion 0.0."""
+    assert churn_dispersion([]) == 0.0
+
+
+def test_churn_dispersion_spread():
+    """Evenly spread churn yields high dispersion."""
+    churn = [(f"file{i}.py", 1) for i in range(100)]
+    d = churn_dispersion(churn)
+    assert d > 0.8
+
+
+# --- get_commit_messages with mocked git ---
+
+
+def test_get_commit_messages_parses_output():
+    """`get_commit_messages` splits git log output into lines."""
+    fake_output = "feat: add login\nfix: crash\nchore: bump deps\n"
+    with patch("twag.entropy._run_git", return_value=fake_output):
+        msgs = get_commit_messages(days=30)
+    assert msgs == ["feat: add login", "fix: crash", "chore: bump deps"]
+
+
+def test_get_commit_messages_empty():
+    """`get_commit_messages` returns empty list for no commits."""
+    with patch("twag.entropy._run_git", return_value=""):
+        msgs = get_commit_messages(days=30)
+    assert msgs == []
+
+
+# --- get_file_churn with mocked git ---
+
+
+def test_get_file_churn_counts():
+    """`get_file_churn` counts file appearances."""
+    fake_output = "a.py\nb.py\na.py\na.py\nb.py\nc.py\n"
+    with patch("twag.entropy._run_git", return_value=fake_output):
+        churn = get_file_churn(days=30)
+    assert churn[0] == ("a.py", 3)
+    assert churn[1] == ("b.py", 2)
+    assert churn[2] == ("c.py", 1)
+
+
+# --- get_surface_area_delta with mocked git ---
+
+
+def test_surface_area_delta():
+    """`get_surface_area_delta` computes added minus deleted."""
+    call_count = [0]
+
+    def fake_git(args, repo_path=None):
+        call_count[0] += 1
+        if "--diff-filter=A" in args:
+            return "new1.py\nnew2.py\nnew3.py\n"
+        if "--diff-filter=D" in args:
+            return "old1.py\n"
+        return ""
+
+    with patch("twag.entropy._run_git", side_effect=fake_git):
+        delta = get_surface_area_delta(days=30)
+    assert delta == 2
+
+
+# --- count_todos with mocked filesystem ---
+
+
+def test_count_todos(tmp_path):
+    """`count_todos` counts TODO/FIXME markers in source files."""
+    (tmp_path / "code.py").write_text("# TODO: fix this\nx = 1\n# FIXME: broken\n")
+    (tmp_path / "clean.py").write_text("x = 1\ny = 2\n")
+    assert count_todos(str(tmp_path)) == 2
+
+
+def test_count_todos_skips_hidden(tmp_path):
+    """`count_todos` skips hidden directories."""
+    hidden = tmp_path / ".git"
+    hidden.mkdir()
+    (hidden / "code.py").write_text("# TODO: in git\n")
+    (tmp_path / "real.py").write_text("# TODO: real\n")
+    assert count_todos(str(tmp_path)) == 1
+
+
+# --- doc_staleness with mocked git ---
+
+
+def test_doc_staleness_all_fresh():
+    """`doc_staleness` returns 0.0 when all docs are updated."""
+
+    def fake_git(args, repo_path=None):
+        if "ls-files" in args:
+            return "README.md\ncode.py\n"
+        return "README.md\ncode.py\n"
+
+    with patch("twag.entropy._run_git", side_effect=fake_git):
+        ratio = doc_staleness(days=30)
+    assert ratio == 0.0
+
+
+def test_doc_staleness_all_stale():
+    """`doc_staleness` returns 1.0 when no docs are updated but code is."""
+
+    def fake_git(args, repo_path=None):
+        if "ls-files" in args:
+            return "README.md\nDOCS.md\ncode.py\n"
+        return "code.py\n"
+
+    with patch("twag.entropy._run_git", side_effect=fake_git):
+        ratio = doc_staleness(days=30)
+    assert ratio == 1.0
+
+
+# --- analyze_entropy integration ---
+
+
+def test_analyze_entropy_returns_report():
+    """`analyze_entropy` returns an EntropyReport with all fields populated."""
+    with (
+        patch("twag.entropy.get_commit_messages", return_value=["feat: a", "fix: b", "feat: c"]),
+        patch("twag.entropy.get_file_churn", return_value=[("x.py", 5), ("y.py", 3)]),
+        patch("twag.entropy.get_surface_area_delta", return_value=5),
+        patch("twag.entropy.count_todos", return_value=10),
+        patch("twag.entropy.doc_staleness", return_value=0.3),
+    ):
+        report = analyze_entropy(days=30)
+
+    assert isinstance(report, EntropyReport)
+    assert 0 <= report.overall_score <= 100
+    assert report.topic_counts["feature"] == 2
+    assert report.topic_counts["bugfix"] == 1
+    assert report.todo_accumulation == 10
+    assert report.surface_area_delta == 5
+
+
+# --- CLI command ---
+
+
+def test_entropy_cli_runs():
+    """`twag entropy` command exits successfully."""
+    with (
+        patch("twag.entropy.get_commit_messages", return_value=["feat: a", "fix: b"]),
+        patch("twag.entropy.get_file_churn", return_value=[("x.py", 5)]),
+        patch("twag.entropy.get_surface_area_delta", return_value=2),
+        patch("twag.entropy.count_todos", return_value=5),
+        patch("twag.entropy.doc_staleness", return_value=0.2),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["entropy"])
+    assert result.exit_code == 0
+    assert "Entropy Report" in result.output
+
+
+def test_entropy_cli_json():
+    """`twag entropy --json` outputs valid JSON."""
+    import json
+
+    with (
+        patch("twag.entropy.get_commit_messages", return_value=["feat: a"]),
+        patch("twag.entropy.get_file_churn", return_value=[]),
+        patch("twag.entropy.get_surface_area_delta", return_value=0),
+        patch("twag.entropy.count_todos", return_value=0),
+        patch("twag.entropy.doc_staleness", return_value=0.0),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["entropy", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "overall_score" in data
+    assert "recommendations" in data

--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -14,6 +14,7 @@ from . import analyze as _analyze_mod
 from . import config_cmd as _config_mod
 from . import db_cmd as _db_mod
 from . import digest as _digest_mod
+from . import entropy as _entropy_mod
 from . import fetch as _fetch_mod
 from . import init_cmd as _init_mod
 from . import narratives as _narratives_mod
@@ -49,6 +50,7 @@ cli.add_command(_config_mod.config)
 cli.add_command(_db_mod.db)
 cli.add_command(_search_mod.search)
 cli.add_command(_web_mod.web)
+cli.add_command(_entropy_mod.entropy)
 
 
 if __name__ == "__main__":

--- a/twag/cli/entropy.py
+++ b/twag/cli/entropy.py
@@ -1,0 +1,104 @@
+"""CLI command for roadmap entropy analysis."""
+
+from __future__ import annotations
+
+import rich_click as click
+from rich.table import Table
+
+from ..entropy import analyze_entropy
+from ._console import console
+
+_SEVERITY_COLORS = {"low": "green", "medium": "yellow", "high": "red"}
+
+
+@click.command()
+@click.option("--days", default=90, show_default=True, help="Number of days of history to analyze.")
+@click.option("--json", "as_json", is_flag=True, help="Output raw JSON instead of formatted report.")
+def entropy(days: int, as_json: bool) -> None:
+    """Analyze git history for roadmap scope creep and drift signals."""
+    report = analyze_entropy(days=days)
+
+    if as_json:
+        import json
+
+        data = {
+            "overall_score": round(report.overall_score, 1),
+            "commit_topic_entropy": round(report.commit_topic_entropy, 3),
+            "file_churn_dispersion": round(report.file_churn_dispersion, 3),
+            "surface_area_delta": report.surface_area_delta,
+            "todo_accumulation": report.todo_accumulation,
+            "doc_staleness_ratio": round(report.doc_staleness_ratio, 3),
+            "topic_counts": report.topic_counts,
+            "churn_hotspots": [{"file": f, "changes": c} for f, c in report.churn_hotspots],
+            "drift_indicators": [
+                {"category": d.category, "description": d.description, "severity": d.severity}
+                for d in report.drift_indicators
+            ],
+            "recommendations": report.recommendations,
+        }
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    # Header
+    score = report.overall_score
+    if score < 30:
+        score_color = "green"
+        score_label = "Low"
+    elif score < 60:
+        score_color = "yellow"
+        score_label = "Moderate"
+    else:
+        score_color = "red"
+        score_label = "High"
+
+    console.print()
+    console.print(f"[bold]Roadmap Entropy Report[/bold] (last {days} days)")
+    console.print(f"Overall Score: [{score_color} bold]{score:.0f}/100[/{score_color} bold] ({score_label} entropy)")
+    console.print()
+
+    # Metrics table
+    metrics = Table(title="Metrics", show_header=True)
+    metrics.add_column("Metric", style="bold")
+    metrics.add_column("Value", justify="right")
+    metrics.add_row("Commit topic entropy", f"{report.commit_topic_entropy:.3f}")
+    metrics.add_row("File churn dispersion", f"{report.file_churn_dispersion:.3f}")
+    metrics.add_row("Surface area delta", f"{report.surface_area_delta:+d} files")
+    metrics.add_row("TODO/FIXME count", str(report.todo_accumulation))
+    metrics.add_row("Doc staleness", f"{report.doc_staleness_ratio:.0%}")
+    console.print(metrics)
+    console.print()
+
+    # Topic breakdown
+    if report.topic_counts:
+        topics = Table(title="Commit Topics", show_header=True)
+        topics.add_column("Topic", style="bold")
+        topics.add_column("Count", justify="right")
+        for topic, count in sorted(report.topic_counts.items(), key=lambda x: -x[1]):
+            topics.add_row(topic, str(count))
+        console.print(topics)
+        console.print()
+
+    # Churn hotspots
+    if report.churn_hotspots:
+        churn = Table(title="Churn Hotspots (top 10)", show_header=True)
+        churn.add_column("File", style="bold")
+        churn.add_column("Changes", justify="right")
+        for filepath, count in report.churn_hotspots:
+            churn.add_row(filepath, str(count))
+        console.print(churn)
+        console.print()
+
+    # Drift indicators
+    if report.drift_indicators:
+        console.print("[bold]Drift Indicators[/bold]")
+        for ind in report.drift_indicators:
+            color = _SEVERITY_COLORS.get(ind.severity, "white")
+            console.print(f"  [{color}]{ind.severity.upper()}[/{color}] {ind.description}")
+        console.print()
+
+    # Recommendations
+    if report.recommendations:
+        console.print("[bold]Recommendations[/bold]")
+        for rec in report.recommendations:
+            console.print(f"  - {rec}")
+        console.print()

--- a/twag/entropy.py
+++ b/twag/entropy.py
@@ -1,0 +1,350 @@
+"""Roadmap entropy detector — analyzes git history for scope creep and drift signals."""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import subprocess
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+# --- Data structures ---
+
+
+@dataclass
+class DriftIndicator:
+    """A single signal of scope creep or drift."""
+
+    category: str
+    description: str
+    severity: str  # "low", "medium", "high"
+    score_contribution: float
+
+
+@dataclass
+class EntropyReport:
+    """Full entropy analysis result."""
+
+    overall_score: float  # 0-100
+    commit_topic_entropy: float
+    file_churn_dispersion: float
+    surface_area_delta: int
+    todo_accumulation: int
+    doc_staleness_ratio: float
+    drift_indicators: list[DriftIndicator] = field(default_factory=list)
+    topic_counts: dict[str, int] = field(default_factory=dict)
+    churn_hotspots: list[tuple[str, int]] = field(default_factory=list)
+    recommendations: list[str] = field(default_factory=list)
+
+
+# --- Conventional commit prefix mapping ---
+
+TOPIC_PREFIXES = {
+    "feat": "feature",
+    "fix": "bugfix",
+    "docs": "docs",
+    "style": "style",
+    "refactor": "refactor",
+    "perf": "perf",
+    "test": "test",
+    "chore": "chore",
+    "build": "build",
+    "ci": "ci",
+}
+
+_PREFIX_RE = re.compile(r"^(\w+)(?:\(.*?\))?[!]?:\s")
+
+
+def classify_commit(message: str) -> str:
+    """Classify a commit message by conventional-commit prefix."""
+    m = _PREFIX_RE.match(message)
+    if m:
+        prefix = m.group(1).lower()
+        return TOPIC_PREFIXES.get(prefix, "other")
+    return "other"
+
+
+# --- Git helpers ---
+
+
+def _run_git(args: list[str], repo_path: str | None = None) -> str:
+    """Run a git command and return stdout."""
+    cmd = ["git"]
+    if repo_path:
+        cmd += ["-C", repo_path]
+    cmd += args
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+    return result.stdout
+
+
+def get_commit_messages(days: int = 90, repo_path: str | None = None) -> list[str]:
+    """Return commit messages from the last N days."""
+    since = (datetime.now(tz=timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    output = _run_git(["log", f"--since={since}", "--pretty=format:%s"], repo_path)
+    return [line for line in output.strip().splitlines() if line]
+
+
+def get_file_churn(days: int = 90, repo_path: str | None = None) -> list[tuple[str, int]]:
+    """Return (filepath, change_count) sorted by most changed."""
+    since = (datetime.now(tz=timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    output = _run_git(["log", f"--since={since}", "--pretty=format:", "--name-only"], repo_path)
+    counts: Counter[str] = Counter()
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if line:
+            counts[line] += 1
+    return counts.most_common()
+
+
+def get_surface_area_delta(days: int = 90, repo_path: str | None = None) -> int:
+    """Count net new files added in the period (added minus deleted)."""
+    since = (datetime.now(tz=timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    output = _run_git(
+        ["log", f"--since={since}", "--diff-filter=A", "--pretty=format:", "--name-only"],
+        repo_path,
+    )
+    added = len([line for line in output.strip().splitlines() if line.strip()])
+    output = _run_git(
+        ["log", f"--since={since}", "--diff-filter=D", "--pretty=format:", "--name-only"],
+        repo_path,
+    )
+    deleted = len([line for line in output.strip().splitlines() if line.strip()])
+    return added - deleted
+
+
+# --- Code scanning ---
+
+
+_TODO_RE = re.compile(r"\b(TODO|FIXME|HACK|XXX)\b", re.IGNORECASE)
+
+
+def count_todos(repo_path: str | None = None) -> int:
+    """Count TODO/FIXME/HACK/XXX comments in the codebase."""
+    root = repo_path or os.getcwd()
+    count = 0
+    for dirpath, _dirnames, filenames in os.walk(root):
+        # Skip hidden dirs and common non-source dirs
+        parts = dirpath.split(os.sep)
+        if any(
+            p.startswith(".") or p in ("node_modules", "__pycache__", "venv", ".venv", "dist", "build") for p in parts
+        ):
+            continue
+        for fname in filenames:
+            if not fname.endswith((".py", ".ts", ".tsx", ".js", ".jsx", ".md", ".txt")):
+                continue
+            fpath = os.path.join(dirpath, fname)
+            try:
+                with open(fpath, encoding="utf-8", errors="ignore") as f:
+                    for line in f:
+                        if _TODO_RE.search(line):
+                            count += 1
+            except OSError:
+                continue
+    return count
+
+
+def doc_staleness(days: int = 90, repo_path: str | None = None) -> float:
+    """Return ratio of doc files NOT updated vs code files updated in the period.
+
+    Returns a value between 0.0 (docs fully up-to-date) and 1.0 (all docs stale).
+    If there are no doc files in the repo, returns 0.0.
+    """
+    since = (datetime.now(tz=timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    output = _run_git(["log", f"--since={since}", "--pretty=format:", "--name-only"], repo_path)
+    changed_files = {line.strip() for line in output.strip().splitlines() if line.strip()}
+
+    if not changed_files:
+        return 0.0
+
+    code_changed = any(f for f in changed_files if f.endswith((".py", ".ts", ".tsx", ".js", ".jsx")))
+    if not code_changed:
+        return 0.0
+
+    # List all tracked doc files
+    all_files_output = _run_git(["ls-files"], repo_path)
+    all_files = [line.strip() for line in all_files_output.strip().splitlines() if line.strip()]
+    doc_files = [f for f in all_files if f.endswith((".md", ".rst", ".txt")) and not f.startswith("node_modules")]
+
+    if not doc_files:
+        return 0.0
+
+    stale_docs = [f for f in doc_files if f not in changed_files]
+    return len(stale_docs) / len(doc_files)
+
+
+# --- Entropy computation ---
+
+
+def shannon_entropy(counts: dict[str, int]) -> float:
+    """Compute normalized Shannon entropy of a distribution (0-1 scale)."""
+    total = sum(counts.values())
+    if total == 0 or len(counts) <= 1:
+        return 0.0
+    probs = [c / total for c in counts.values()]
+    raw = -sum(p * math.log2(p) for p in probs if p > 0)
+    max_entropy = math.log2(len(counts))
+    if max_entropy == 0:
+        return 0.0
+    return raw / max_entropy
+
+
+def churn_dispersion(churn: list[tuple[str, int]], top_n: int = 10) -> float:
+    """Measure how concentrated churn is in top files (0=focused, 1=dispersed)."""
+    if not churn:
+        return 0.0
+    total = sum(c for _, c in churn)
+    if total == 0:
+        return 0.0
+    top_total = sum(c for _, c in churn[:top_n])
+    concentration = top_total / total
+    # Invert: high concentration = low dispersion
+    return 1.0 - concentration
+
+
+# --- Main analysis ---
+
+
+def analyze_entropy(days: int = 90, repo_path: str | None = None) -> EntropyReport:
+    """Run the full entropy analysis and return a report."""
+    messages = get_commit_messages(days, repo_path)
+    topic_counts: dict[str, int] = defaultdict(int)
+    for msg in messages:
+        topic = classify_commit(msg)
+        topic_counts[topic] += 1
+
+    topic_entropy = shannon_entropy(dict(topic_counts))
+    churn = get_file_churn(days, repo_path)
+    dispersion = churn_dispersion(churn)
+    sa_delta = get_surface_area_delta(days, repo_path)
+    todos = count_todos(repo_path)
+    staleness = doc_staleness(days, repo_path)
+
+    indicators: list[DriftIndicator] = []
+    recommendations: list[str] = []
+
+    # Evaluate topic entropy
+    if topic_entropy > 0.85:
+        indicators.append(
+            DriftIndicator(
+                category="topic_spread",
+                description="Commits spread evenly across many topic areas — possible lack of focus",
+                severity="high",
+                score_contribution=25.0,
+            )
+        )
+        recommendations.append("Consider focusing sprints on fewer topic areas to reduce context switching.")
+    elif topic_entropy > 0.65:
+        indicators.append(
+            DriftIndicator(
+                category="topic_spread",
+                description="Moderate spread across commit topics",
+                severity="medium",
+                score_contribution=15.0,
+            )
+        )
+
+    # Evaluate churn dispersion
+    if dispersion > 0.7:
+        indicators.append(
+            DriftIndicator(
+                category="churn_dispersion",
+                description="File changes are highly dispersed — work touches many unrelated files",
+                severity="high",
+                score_contribution=20.0,
+            )
+        )
+        recommendations.append(
+            "Review if recent work is scattered across too many areas. Consider batching related changes."
+        )
+    elif dispersion > 0.4:
+        indicators.append(
+            DriftIndicator(
+                category="churn_dispersion",
+                description="Moderate file churn dispersion",
+                severity="medium",
+                score_contribution=10.0,
+            )
+        )
+
+    # Evaluate surface area growth
+    if sa_delta > 20:
+        indicators.append(
+            DriftIndicator(
+                category="surface_area",
+                description=f"Net {sa_delta} new files added — expanding project scope",
+                severity="high",
+                score_contribution=15.0,
+            )
+        )
+        recommendations.append("Significant file growth detected. Ensure new files align with roadmap goals.")
+    elif sa_delta > 10:
+        indicators.append(
+            DriftIndicator(
+                category="surface_area",
+                description=f"Net {sa_delta} new files added",
+                severity="medium",
+                score_contribution=8.0,
+            )
+        )
+
+    # Evaluate TODO accumulation
+    if todos > 30:
+        indicators.append(
+            DriftIndicator(
+                category="todo_debt",
+                description=f"{todos} TODO/FIXME/HACK markers found — growing tech debt",
+                severity="high",
+                score_contribution=15.0,
+            )
+        )
+        recommendations.append("Schedule a tech debt sprint to address accumulated TODOs and FIXMEs.")
+    elif todos > 15:
+        indicators.append(
+            DriftIndicator(
+                category="todo_debt",
+                description=f"{todos} TODO/FIXME markers found",
+                severity="medium",
+                score_contribution=8.0,
+            )
+        )
+
+    # Evaluate doc staleness
+    if staleness > 0.7:
+        indicators.append(
+            DriftIndicator(
+                category="doc_staleness",
+                description=f"{staleness:.0%} of docs not updated alongside code changes",
+                severity="high",
+                score_contribution=15.0,
+            )
+        )
+        recommendations.append("Documentation is falling behind code changes. Review and update stale docs.")
+    elif staleness > 0.4:
+        indicators.append(
+            DriftIndicator(
+                category="doc_staleness",
+                description=f"{staleness:.0%} of docs not updated alongside code changes",
+                severity="medium",
+                score_contribution=8.0,
+            )
+        )
+
+    overall = min(100.0, sum(ind.score_contribution for ind in indicators))
+
+    if not indicators:
+        recommendations.append("Project entropy is low — development appears focused and well-organized.")
+
+    return EntropyReport(
+        overall_score=overall,
+        commit_topic_entropy=topic_entropy,
+        file_churn_dispersion=dispersion,
+        surface_area_delta=sa_delta,
+        todo_accumulation=todos,
+        doc_staleness_ratio=staleness,
+        drift_indicators=indicators,
+        topic_counts=dict(topic_counts),
+        churn_hotspots=churn[:10],
+        recommendations=recommendations,
+    )


### PR DESCRIPTION
## Summary
- Adds a roadmap entropy detector that analyzes git history and codebase signals to quantify scope creep and drift
- Categorizes commits by conventional-commit topic, measures file churn dispersion, tracks TODO accumulation, and checks doc staleness
- Produces a scored entropy report (0-100) with drift indicators and actionable recommendations
- Exposed as `twag entropy` CLI command (with `--json` and `--days` options) and standalone `scripts/roadmap_entropy.py`
- 26 tests covering all core analysis functions and CLI integration

## Test plan
- [x] `uv run ruff check` passes with no errors
- [x] `uv run pytest tests/test_entropy.py -v` — 26 tests pass
- [ ] Manual: run `twag entropy` on the repo to verify Rich output
- [ ] Manual: run `twag entropy --json` to verify JSON output

Nightshift-Task: roadmap-entropy
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: roadmap-entropy:/home/clifton/code/twag
task-type: roadmap-entropy
task-title: Roadmap Entropy Detector
iterations: 3
duration: 16m51s
nightshift:metadata -->
