### PR TITLE
fix: patch security anti-patterns in web and DB layers

### DIFF
--- a/twag/cli/init_cmd.py
+++ b/twag/cli/init_cmd.py
@@ -147,14 +147,14 @@ def doctor():
 
     gemini_key = os.environ.get("GEMINI_API_KEY")
     if gemini_key:
-        console.print(f"  {status_icon(True)} GEMINI_API_KEY set ({gemini_key[:8]}...)")
+        console.print(f"  {status_icon(True)} GEMINI_API_KEY set (***{gemini_key[-4:]})")
     else:
         console.print(f"  {status_icon(False)} GEMINI_API_KEY not set")
         issues.append("Set GEMINI_API_KEY environment variable")
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     if anthropic_key:
-        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set ({anthropic_key[:8]}...)")
+        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set (***{anthropic_key[-4:]})")
     else:
         console.print("  [yellow]WARN[/yellow] ANTHROPIC_API_KEY not set (enrichment disabled)")
         warnings.append("Set ANTHROPIC_API_KEY for enrichment features")

--- a/twag/db/accounts.py
+++ b/twag/db/accounts.py
@@ -52,7 +52,11 @@ def get_accounts(
     else:
         order_clause = "ORDER BY tier ASC, weight DESC"
 
-    limit_clause = f"LIMIT {limit}" if limit else ""
+    if limit:
+        limit_clause = "LIMIT ?"
+        params.append(limit)
+    else:
+        limit_clause = ""
 
     cursor = conn.execute(
         f"""

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -1,5 +1,6 @@
 """Telegram notifications for high-signal tweets."""
 
+import html
 import os
 from datetime import datetime
 
@@ -67,6 +68,11 @@ def format_alert(
     tickers: list[str] | None = None,
 ) -> str:
     """Format a high-signal alert message."""
+    # HTML-escape user-controlled fields for Telegram HTML parse_mode
+    author_handle = html.escape(author_handle)
+    content = html.escape(content)
+    summary = html.escape(summary) if summary else summary
+
     # Truncate content for preview
     preview = content[:150] + "..." if len(content) > 150 else content
 
@@ -87,8 +93,9 @@ def format_alert(
     if summary:
         lines.append(f"📊 {summary}")
 
-    if tickers:
-        lines.append(f"💡 Tickers: {', '.join(tickers)}")
+    escaped_tickers = [html.escape(t) for t in tickers] if tickers else tickers
+    if escaped_tickers:
+        lines.append(f"💡 Tickers: {', '.join(escaped_tickers)}")
 
     url = get_tweet_url(tweet_id, author_handle)
     lines.append(f"🔗 {url}")

--- a/twag/web/app.py
+++ b/twag/web/app.py
@@ -33,8 +33,8 @@ def create_app() -> FastAPI:
     app.add_middleware(
         CORSMiddleware,
         allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST", "PUT", "DELETE"],
+        allow_headers=["Content-Type", "Accept"],
     )
 
     # Initialize database

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -5,7 +5,7 @@ import re
 import shlex
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from ...db import (
@@ -21,6 +21,30 @@ from ...media import build_media_context, parse_media_items
 from ...processor import ensure_media_analysis
 
 router = APIRouter(tags=["context"])
+
+# Executables allowed in context command templates
+ALLOWED_EXECUTABLES = frozenset({"twag", "bird", "jq", "curl", "echo", "cat", "date"})
+
+
+def _validate_command_template(template: str) -> None:
+    """Validate that a command template only uses allowed executables.
+
+    Raises HTTPException if the executable is not in the allowlist.
+    """
+    try:
+        tokens = shlex.split(template.split("{")[0] if "{" in template else template)
+    except ValueError:
+        tokens = template.split()
+
+    if not tokens:
+        raise HTTPException(status_code=400, detail="Empty command template")
+
+    executable = tokens[0].rsplit("/", 1)[-1]  # strip any path prefix
+    if executable not in ALLOWED_EXECUTABLES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Executable '{executable}' not allowed. Allowed: {sorted(ALLOWED_EXECUTABLES)}",
+        )
 
 
 class ContextCommandCreate(BaseModel):
@@ -70,6 +94,7 @@ async def create_context_command(
     command: ContextCommandCreate,
 ) -> dict[str, Any]:
     """Create a new context command."""
+    _validate_command_template(command.command_template)
     db_path = request.app.state.db_path
 
     with get_connection(db_path) as conn:
@@ -120,6 +145,7 @@ async def update_context_command(
     command: ContextCommandCreate,
 ) -> dict[str, Any]:
     """Update a context command."""
+    _validate_command_template(command.command_template)
     db_path = request.app.state.db_path
 
     with get_connection(db_path) as conn:

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -156,6 +156,11 @@ async def list_tweets(
     """
     db_path = request.app.state.db_path
 
+    # Validate sort parameter against allowlist
+    allowed_sorts = {"relevance", "latest", None}
+    if sort not in allowed_sorts:
+        sort = "relevance"
+
     # Parse time ranges
     since_dt = None
     until_dt = None


### PR DESCRIPTION
## Summary
- **HIGH**: Parameterized LIMIT clause in `twag/db/accounts.py` to prevent SQL injection via f-string interpolation
- **HIGH**: Added executable allowlist validation on context command templates in `twag/web/routes/context.py` to prevent arbitrary command execution (restricts to: twag, bird, jq, curl, echo, cat, date)
- **MEDIUM**: Added sort parameter allowlist in `twag/web/routes/tweets.py` before passing to DB layer
- **MEDIUM**: HTML-escaped user-controlled fields (author_handle, content, tickers, summary) in `twag/notifier.py` before embedding in Telegram HTML messages
- **LOW**: Masked API key display in `twag/cli/init_cmd.py` doctor output — shows `***<last4>` instead of `<first8>...`
- **LOW**: Restricted CORS `allow_methods` and `allow_headers` to explicit values in `twag/web/app.py`

## Test plan
- [x] All existing tests pass (`uv run pytest` — 100%)
- [x] `ruff format` and `ruff check` pass on all modified files
- [ ] Verify context command creation rejects disallowed executables (e.g., `rm`, `bash`)
- [ ] Verify Telegram alerts render correctly with special characters in content

Nightshift-Task: security-footgun
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: security-footgun:/home/clifton/code/twag
task-type: security-footgun
task-title: Security Foot-Gun Finder
iterations: 1
duration: 9m22s
nightshift:metadata -->
