### PR TITLE
docs: backfill missing docstring, sync CONTRIBUTING, document scripts/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ FETCH → PROCESS → DIGEST
 - `twag/article_sections.py` — Article section extraction
 - `twag/web/` — FastAPI backend (app, tweet_utils, routes: tweets, context, prompts, reactions)
 - `twag/web/frontend/` — React feed UI
+- `scripts/` — Utility scripts (benchmarking, cron runner, migrations, model testing)
 
 ## Key Files
 
@@ -46,6 +47,10 @@ FETCH → PROCESS → DIGEST
 | `CLAUDE.md` | This file — agent/developer guidance |
 | `TELEGRAM_DIGEST_FORMAT.md` | Telegram output formatting rules |
 | `SUGGESTED_CRON_SCHEDULE.md` | Automation setup guide |
+| `scripts/benchmark_parallelism.py` | Scorer parallelism benchmarking |
+| `scripts/cron-runner.sh` | Cron job wrapper script |
+| `scripts/migrate.sh` | Database migration helper |
+| `scripts/test_models.py` | LLM model testing utility |
 
 ## OpenClaw Skill Context
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,16 +21,16 @@ npm install
 
 ```bash
 # Python tests
-pytest
+uv run pytest
 
 # With coverage
-pytest --cov=twag
+uv run pytest --cov=twag
 
 # Lint check
-ruff check .
+uv run ruff check .
 
 # Format check
-ruff format --check .
+uv run ruff format --check .
 ```
 
 ## Code Style
@@ -42,8 +42,8 @@ ruff format --check .
 Run before committing:
 
 ```bash
-ruff format .
-ruff check --fix .
+uv run ruff format .
+uv run ruff check --fix .
 ```
 
 ## Making Changes

--- a/tests/test_link_utils.py
+++ b/tests/test_link_utils.py
@@ -1,3 +1,5 @@
+"""Tests for twag.link_utils — URL expansion, normalization, and embed classification."""
+
 from twag.link_utils import expand_links_in_place, normalize_tweet_links
 
 


### PR DESCRIPTION
## Summary
- Add module-level docstring to `tests/test_link_utils.py`
- Prefix `ruff`/`pytest` commands with `uv run` in `CONTRIBUTING.md` to match `CLAUDE.md` guidance
- Add `scripts/` directory to Architecture section and Key Files table in `CLAUDE.md`

## Test plan
- [x] `uv run ruff check` passes
- [x] `uv run pytest tests/test_link_utils.py` passes
- Markdown changes are review-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/home/clifton/code/twag
task-type: docs-backfill
task-title: Documentation Backfiller
iterations: 2
duration: 6m8s
nightshift:metadata -->
