### PR TITLE
docs: fix documentation drift across 4 doc files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,10 @@ FETCH → PROCESS → DIGEST
 ```
 
 **Core packages:**
-- `twag/models/` — Pydantic data models (tweet, scoring, media, links, config, API)
+- `twag/models/` — Pydantic data models (tweet, scoring, media, links, config, API, db_models)
 - `twag/auth.py` — Shared credential and env-file parsing
 - `twag/config.py` — Runtime config (paths, defaults, following file)
-- `twag/db/` — SQLite database layer (schema, connections, CRUD, search, maintenance, accounts, narratives, reactions, time utils)
+- `twag/db/` — SQLite database layer (schema, connections, CRUD, search, maintenance, accounts, narratives, reactions, prompts, context_commands, time utils)
 - `twag/fetcher/` — bird CLI integration + tweet parsing/extraction
 - `twag/scorer/` — LLM scoring, prompts, and client management
 - `twag/processor/` — Pipeline orchestration (storage, dependencies, triage, pipeline)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -182,18 +182,21 @@ Now tweets scoring 8+ will trigger Telegram alerts during `twag process`.
 
 ### systemd (Linux)
 
-Create `~/.config/systemd/user/twag.service`:
+Create `~/.config/systemd/user/twag-aggregator.service`:
 
 ```ini
 [Unit]
 Description=TWAG Twitter Aggregator
+After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 'source ~/.env && twag fetch && twag process'
+ExecStart=%h/.local/bin/twag fetch && %h/.local/bin/twag process
+WorkingDirectory=%h
+EnvironmentFile=%h/.env
 ```
 
-Create `~/.config/systemd/user/twag.timer`:
+Create `~/.config/systemd/user/twag-aggregator.timer`:
 
 ```ini
 [Unit]
@@ -202,6 +205,7 @@ Description=Run TWAG every 15 minutes
 [Timer]
 OnBootSec=5min
 OnUnitActiveSec=15min
+Persistent=true
 
 [Install]
 WantedBy=timers.target
@@ -211,7 +215,7 @@ Enable:
 
 ```bash
 systemctl --user daemon-reload
-systemctl --user enable --now twag.timer
+systemctl --user enable --now twag-aggregator.timer
 ```
 
 ### launchd (macOS)

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ twag search "market" --min-score 7          # High-signal only
 twag analyze 1234567890123456789              # Analyze by ID
 twag analyze https://x.com/user/status/123    # Analyze by URL
 twag analyze 1234567890123456789 --reprocess  # Force re-analyze
-twag analyze 1234567890123456789 -m gemini-2.0-flash  # Override model
+twag analyze 1234567890123456789 -m gemini-3-flash-preview  # Override model
 ```
 
 ### Digest Commands
@@ -290,7 +290,7 @@ twag web --dev                  # Dev mode (Vite + hot reload)
 ```bash
 twag config show                # Show current config
 twag config path                # Show config file path
-twag config set llm.triage_model gemini-2.0-flash
+twag config set llm.triage_model gemini-3-flash-preview
 twag config set scoring.alert_threshold 8
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -240,6 +240,7 @@ twag db restore backup.sql --force  # Restore without confirmation
 twag web                      # Start (localhost:5173)
 twag web --host 127.0.0.1     # Localhost only
 twag web --port 8080          # Custom port
+twag web --dev                # Dev mode (Vite + hot reload)
 ```
 
 ### Config
@@ -274,6 +275,7 @@ twag config set key value     # Update setting
 | `ANTHROPIC_API_KEY` | No | Enrichment |
 | `TELEGRAM_BOT_TOKEN` | No | Alerts |
 | `TELEGRAM_CHAT_ID` | No | Alert destination |
+| `TWAG_DATA_DIR` | No | Override data directory |
 
 ## Telegram Digest Format
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Add missing `db/prompts`, `db/context_commands`, and `models/db_models` modules to architecture listing
- **SKILL.md**: Add `--dev` flag to web command examples and `TWAG_DATA_DIR` to env vars table
- **README.md**: Update stale `gemini-2.0-flash` model references to `gemini-3-flash-preview` (matching config.py defaults)
- **INSTALL.md**: Rename systemd service/timer from `twag` to `twag-aggregator` and align ExecStart/EnvironmentFile approach with README.md and SUGGESTED_CRON_SCHEDULE.md

## Test plan
- [ ] Verify no Python lint/test regressions (`ruff check .` and `pytest` both pass)
- [ ] Confirm systemd naming is consistent across README.md, INSTALL.md, and SUGGESTED_CRON_SCHEDULE.md
- [ ] Confirm model name matches `twag/config.py` defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: doc-drift:/home/clifton/code/twag
task-type: doc-drift
task-title: Doc Drift Detector
iterations: 2
duration: 8m28s
nightshift:metadata -->
