### PR TITLE
fix: enforce API contracts and fix reactions route ordering

### DIFF
--- a/tests/test_web_context_api.py
+++ b/tests/test_web_context_api.py
@@ -1,0 +1,136 @@
+"""API contract tests for context-commands endpoints."""
+
+from fastapi.testclient import TestClient
+
+from twag.db import get_connection, upsert_context_command
+from twag.web.app import create_app
+
+
+def _setup_app(monkeypatch, tmp_path, db_name="twag_context_test.db"):
+    db_path = tmp_path / db_name
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+    return app, db_path
+
+
+def test_list_context_commands_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_context_command(conn, "lookup", "echo {ticker}", "Lookup ticker", True)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/context-commands")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "commands" in data
+    assert isinstance(data["commands"], list)
+    assert len(data["commands"]) >= 1
+    cmd = data["commands"][0]
+    assert "id" in cmd
+    assert "name" in cmd
+    assert "command_template" in cmd
+    assert "enabled" in cmd
+
+
+def test_create_context_command_returns_expected_shape(monkeypatch, tmp_path):
+    app, _ = _setup_app(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/context-commands",
+        json={
+            "name": "price",
+            "command_template": "echo {ticker}",
+            "description": "Get price",
+            "enabled": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "id" in data
+    assert data["name"] == "price"
+    assert data["message"] == "Context command created"
+
+
+def test_get_context_command_by_name(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_context_command(conn, "lookup", "echo {ticker}", "Lookup", True)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/context-commands/lookup")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "lookup"
+    assert "command_template" in data
+    assert "enabled" in data
+
+
+def test_get_context_command_not_found(monkeypatch, tmp_path):
+    app, _ = _setup_app(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.get("/api/context-commands/nonexistent")
+    assert resp.status_code == 200
+    assert "error" in resp.json()
+
+
+def test_update_context_command_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_context_command(conn, "lookup", "echo {ticker}", "Lookup", True)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.put(
+        "/api/context-commands/lookup",
+        json={
+            "name": "lookup",
+            "command_template": "curl {ticker}",
+            "description": "Updated lookup",
+            "enabled": True,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "lookup"
+    assert data["message"] == "Context command updated"
+
+
+def test_delete_context_command_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_context_command(conn, "lookup", "echo {ticker}", "Lookup", True)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.delete("/api/context-commands/lookup")
+    assert resp.status_code == 200
+    assert "message" in resp.json()
+
+    # Deleting again should return error
+    resp2 = client.delete("/api/context-commands/lookup")
+    assert resp2.status_code == 200
+    assert "error" in resp2.json()
+
+
+def test_toggle_context_command_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_context_command(conn, "lookup", "echo {ticker}", "Lookup", True)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.post("/api/context-commands/lookup/toggle", params={"enabled": False})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "message" in data
+    assert "disabled" in data["message"]
+
+
+def test_toggle_context_command_not_found(monkeypatch, tmp_path):
+    app, _ = _setup_app(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.post("/api/context-commands/nonexistent/toggle", params={"enabled": True})
+    assert resp.status_code == 200
+    assert "error" in resp.json()

--- a/tests/test_web_prompts_api.py
+++ b/tests/test_web_prompts_api.py
@@ -1,0 +1,113 @@
+"""API contract tests for prompts endpoints."""
+
+from fastapi.testclient import TestClient
+
+from twag.db import get_connection, upsert_prompt
+from twag.web.app import create_app
+
+
+def _setup_app(monkeypatch, tmp_path, db_name="twag_prompts_test.db"):
+    db_path = tmp_path / db_name
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+    return app, db_path
+
+
+def test_list_prompts_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_prompt(conn, "scoring", "Score this tweet: {content}", "system")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/prompts")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "prompts" in data
+    assert isinstance(data["prompts"], list)
+    assert len(data["prompts"]) >= 1
+    p = data["prompts"][0]
+    assert "id" in p
+    assert "name" in p
+    assert "template" in p
+    assert "version" in p
+
+
+def test_get_prompt_by_name_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_prompt(conn, "scoring", "Score: {content}", "system")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/prompts/scoring")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "scoring"
+    assert "template" in data
+    assert "version" in data
+
+
+def test_get_prompt_not_found(monkeypatch, tmp_path):
+    app, _ = _setup_app(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.get("/api/prompts/nonexistent")
+    assert resp.status_code == 200
+    assert "error" in resp.json()
+
+
+def test_update_prompt_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_prompt(conn, "scoring", "v1 template", "system")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.put("/api/prompts/scoring", json={"template": "v2 template", "updated_by": "test"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "scoring"
+    assert data["version"] == 2
+    assert data["message"] == "Prompt updated"
+
+
+def test_prompt_history_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_prompt(conn, "scoring", "v1", "system")
+        upsert_prompt(conn, "scoring", "v2", "user")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/prompts/scoring/history")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "scoring"
+    assert "history" in data
+    assert isinstance(data["history"], list)
+
+
+def test_prompt_rollback_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_prompt(conn, "scoring", "v1", "system")
+        upsert_prompt(conn, "scoring", "v2", "user")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.post("/api/prompts/scoring/rollback", params={"version": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "message" in data
+
+
+def test_prompt_rollback_invalid_version(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        upsert_prompt(conn, "scoring", "v1", "system")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.post("/api/prompts/scoring/rollback", params={"version": 999})
+    assert resp.status_code == 200
+    assert "error" in resp.json()

--- a/tests/test_web_reactions_api.py
+++ b/tests/test_web_reactions_api.py
@@ -1,0 +1,170 @@
+"""API contract tests for reactions endpoints."""
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from twag.db import get_connection, insert_reaction, insert_tweet, update_tweet_processing
+from twag.web.app import create_app
+
+
+def _setup_app(monkeypatch, tmp_path, db_name="twag_reactions_test.db"):
+    db_path = tmp_path / db_name
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+    return app, db_path
+
+
+def _insert_processed_tweet(conn, *, tweet_id: str, author_handle: str, content: str, **kwargs) -> None:
+    inserted = insert_tweet(
+        conn,
+        tweet_id=tweet_id,
+        author_handle=author_handle,
+        content=content,
+        created_at=datetime.now(timezone.utc),
+        source="test",
+        **kwargs,
+    )
+    assert inserted is True
+    update_tweet_processing(
+        conn,
+        tweet_id=tweet_id,
+        relevance_score=7.0,
+        categories=["macro"],
+        summary=f"summary-{tweet_id}",
+        signal_tier="market_relevant",
+        tickers=["SPX"],
+    )
+
+
+def test_create_reaction_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="t1", author_handle="user1", content="test tweet")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.post("/api/react", json={"tweet_id": "t1", "reaction_type": ">>"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "id" in data
+    assert data["tweet_id"] == "t1"
+    assert data["reaction_type"] == ">>"
+
+
+def test_create_reaction_invalid_type(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="t1", author_handle="user1", content="test")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.post("/api/react", json={"tweet_id": "t1", "reaction_type": "invalid"})
+    assert resp.status_code == 200
+    assert "error" in resp.json()
+
+
+def test_get_tweet_reactions_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="t1", author_handle="user1", content="test")
+        insert_reaction(conn, "t1", ">>", "important", None)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/reactions/t1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["tweet_id"] == "t1"
+    assert isinstance(data["reactions"], list)
+    assert len(data["reactions"]) == 1
+    r = data["reactions"][0]
+    assert "id" in r
+    assert r["reaction_type"] == ">>"
+    assert r["reason"] == "important"
+
+
+def test_delete_reaction_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="t1", author_handle="user1", content="test")
+        rid = insert_reaction(conn, "t1", ">", None, None)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.delete(f"/api/reactions/{rid}")
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Reaction deleted"
+
+    # Deleting again should return error
+    resp2 = client.delete(f"/api/reactions/{rid}")
+    assert resp2.status_code == 200
+    assert "error" in resp2.json()
+
+
+def test_reactions_summary_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="t1", author_handle="user1", content="test")
+        insert_reaction(conn, "t1", ">>", None, None)
+        insert_reaction(conn, "t1", ">", None, None)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/reactions/summary")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "summary" in data
+    assert isinstance(data["summary"], dict)
+
+
+def test_reactions_export_returns_expected_shape(monkeypatch, tmp_path):
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="t1", author_handle="user1", content="test tweet content")
+        insert_reaction(conn, "t1", ">>", "very important", None)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/reactions/export")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "count" in data
+    assert isinstance(data["reactions"], list)
+    if data["count"] > 0:
+        item = data["reactions"][0]
+        assert "reaction" in item
+        assert "tweet" in item
+        assert "id" in item["reaction"]
+        assert "type" in item["reaction"]
+        assert "id" in item["tweet"]
+        assert "author" in item["tweet"]
+
+
+def test_reactions_summary_not_shadowed_by_tweet_id_route(monkeypatch, tmp_path):
+    """Verify /reactions/summary is not captured by /reactions/{tweet_id}."""
+    app, db_path = _setup_app(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="t1", author_handle="user1", content="test")
+        insert_reaction(conn, "t1", ">>", None, None)
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/reactions/summary")
+    assert resp.status_code == 200
+    data = resp.json()
+    # Must have "summary" key (from summary endpoint), NOT "tweet_id" (from {tweet_id} endpoint)
+    assert "summary" in data
+    assert "tweet_id" not in data
+
+
+def test_reactions_export_not_shadowed_by_tweet_id_route(monkeypatch, tmp_path):
+    """Verify /reactions/export is not captured by /reactions/{tweet_id}."""
+    app, _ = _setup_app(monkeypatch, tmp_path)
+    client = TestClient(app)
+    resp = client.get("/api/reactions/export")
+    assert resp.status_code == 200
+    data = resp.json()
+    # Must have "count" key (from export endpoint), NOT "tweet_id" (from {tweet_id} endpoint)
+    assert "count" in data
+    assert "tweet_id" not in data

--- a/twag/models/api.py
+++ b/twag/models/api.py
@@ -91,5 +91,236 @@ class TweetListResponse(BaseModel):
     has_more: bool = False
 
 
+# --- Reaction response models ---
+
+
+class ReactionCreateResponse(BaseModel):
+    """Response from creating a reaction."""
+
+    id: int | None = None
+    tweet_id: str | None = None
+    reaction_type: str | None = None
+    message: str | None = None
+    error: str | None = None
+
+
+class ReactionItem(BaseModel):
+    """A single reaction entry."""
+
+    id: int
+    reaction_type: str
+    reason: str | None = None
+    target: str | None = None
+    created_at: str | None = None
+
+
+class TweetReactionsResponse(BaseModel):
+    """Reactions for a specific tweet."""
+
+    tweet_id: str
+    reactions: list[ReactionItem] = []
+
+
+class ReactionDeleteResponse(BaseModel):
+    """Response from deleting a reaction."""
+
+    message: str | None = None
+    error: str | None = None
+
+
+class ReactionSummaryResponse(BaseModel):
+    """Summary of reaction counts."""
+
+    summary: dict[str, int] = {}
+
+
+class ExportReactionDetail(BaseModel):
+    """Reaction detail in export."""
+
+    id: int
+    type: str
+    reason: str | None = None
+    created_at: str | None = None
+
+
+class ExportTweetDetail(BaseModel):
+    """Tweet detail in export."""
+
+    id: str
+    author: str
+    content: str | None = None
+    summary: str | None = None
+    score: float | None = None
+    categories: list[str] = []
+    signal_tier: str | None = None
+
+
+class ExportReactionItem(BaseModel):
+    """A reaction-tweet pair in export."""
+
+    reaction: ExportReactionDetail
+    tweet: ExportTweetDetail
+
+
+class ReactionExportResponse(BaseModel):
+    """Response from exporting reactions."""
+
+    count: int = 0
+    reactions: list[ExportReactionItem] = []
+
+
+# --- Prompt response models ---
+
+
+class PromptResponse(BaseModel):
+    """A single prompt."""
+
+    id: int | None = None
+    name: str | None = None
+    template: str | None = None
+    version: int | None = None
+    updated_at: str | None = None
+    updated_by: str | None = None
+    error: str | None = None
+
+
+class PromptListResponse(BaseModel):
+    """List of prompts."""
+
+    prompts: list[PromptResponse] = []
+
+
+class PromptUpdateResponse(BaseModel):
+    """Response from updating a prompt."""
+
+    name: str | None = None
+    version: int | None = None
+    message: str | None = None
+    error: str | None = None
+
+
+class PromptHistoryResponse(BaseModel):
+    """Version history for a prompt."""
+
+    name: str
+    history: list[dict[str, Any]] = []
+
+
+class PromptRollbackResponse(BaseModel):
+    """Response from rolling back a prompt."""
+
+    message: str | None = None
+    error: str | None = None
+
+
+class PromptTuneResponse(BaseModel):
+    """Response from prompt tuning."""
+
+    prompt_name: str | None = None
+    current_version: int | None = None
+    analysis: str | None = None
+    suggested_prompt: str | None = None
+    reactions_analyzed: dict[str, int] | None = None
+    error: str | None = None
+
+
+# --- Context command response models ---
+
+
+class ContextCommandItem(BaseModel):
+    """A single context command."""
+
+    id: int | None = None
+    name: str | None = None
+    command_template: str | None = None
+    description: str | None = None
+    enabled: bool | None = None
+    created_at: str | None = None
+    error: str | None = None
+
+
+class ContextCommandListResponse(BaseModel):
+    """List of context commands."""
+
+    commands: list[ContextCommandItem] = []
+
+
+class ContextCommandCreateResponse(BaseModel):
+    """Response from creating a context command."""
+
+    id: int | None = None
+    name: str | None = None
+    message: str | None = None
+    error: str | None = None
+
+
+class ContextCommandDeleteResponse(BaseModel):
+    """Response from deleting a context command."""
+
+    message: str | None = None
+    error: str | None = None
+
+
+class ContextCommandToggleResponse(BaseModel):
+    """Response from toggling a context command."""
+
+    message: str | None = None
+    error: str | None = None
+
+
+class CategoriesResponse(BaseModel):
+    """List of categories with counts."""
+
+    categories: list[CategoryCount] = []
+
+
+class TickersResponse(BaseModel):
+    """List of tickers with counts."""
+
+    tickers: list[TickerCount] = []
+
+
+class SingleTweetResponse(BaseModel):
+    """Single tweet detail (from /tweets/{id} endpoint)."""
+
+    id: str | None = None
+    author_handle: str | None = None
+    author_name: str | None = None
+    content: str | None = None
+    content_summary: str | None = None
+    summary: str | None = None
+    created_at: str | None = None
+    relevance_score: float | None = None
+    categories: list[str] = []
+    signal_tier: str | None = None
+    tickers: list[str] = []
+    bookmarked: bool = False
+    has_quote: bool = False
+    quote_tweet_id: str | None = None
+    has_media: bool = False
+    media_analysis: str | None = None
+    media_items: list[dict[str, Any]] = []
+    has_link: bool = False
+    link_summary: str | None = None
+    is_x_article: bool = False
+    article_title: str | None = None
+    article_preview: str | None = None
+    article_text: str | None = None
+    article_summary_short: str | None = None
+    article_primary_points: list[dict[str, Any]] = []
+    article_action_items: list[dict[str, Any]] = []
+    article_top_visual: dict[str, Any] | None = None
+    article_processed_at: str | None = None
+    is_retweet: bool = False
+    retweeted_by_handle: str | None = None
+    retweeted_by_name: str | None = None
+    original_tweet_id: str | None = None
+    original_author_handle: str | None = None
+    original_author_name: str | None = None
+    original_content: str | None = None
+    links_json: str | None = None
+    error: str | None = None
+
+
 # Rebuild QuoteEmbed to resolve the self-reference
 QuoteEmbed.model_rebuild()

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -18,6 +18,13 @@ from ...db import (
     upsert_context_command,
 )
 from ...media import build_media_context, parse_media_items
+from ...models.api import (
+    ContextCommandCreateResponse,
+    ContextCommandDeleteResponse,
+    ContextCommandItem,
+    ContextCommandListResponse,
+    ContextCommandToggleResponse,
+)
 from ...processor import ensure_media_analysis
 
 router = APIRouter(tags=["context"])
@@ -38,7 +45,7 @@ class TestCommandRequest(BaseModel):
     tweet_id: str
 
 
-@router.get("/context-commands")
+@router.get("/context-commands", response_model=ContextCommandListResponse)
 async def list_context_commands(
     request: Request,
     enabled_only: bool = False,
@@ -64,7 +71,7 @@ async def list_context_commands(
     }
 
 
-@router.post("/context-commands")
+@router.post("/context-commands", response_model=ContextCommandCreateResponse)
 async def create_context_command(
     request: Request,
     command: ContextCommandCreate,
@@ -89,7 +96,7 @@ async def create_context_command(
     }
 
 
-@router.get("/context-commands/{name}")
+@router.get("/context-commands/{name}", response_model=ContextCommandItem)
 async def get_context_command_by_name(
     request: Request,
     name: str,
@@ -113,7 +120,7 @@ async def get_context_command_by_name(
     }
 
 
-@router.put("/context-commands/{name}")
+@router.put("/context-commands/{name}", response_model=ContextCommandCreateResponse)
 async def update_context_command(
     request: Request,
     name: str,
@@ -139,7 +146,7 @@ async def update_context_command(
     }
 
 
-@router.delete("/context-commands/{name}")
+@router.delete("/context-commands/{name}", response_model=ContextCommandDeleteResponse)
 async def remove_context_command(
     request: Request,
     name: str,
@@ -156,7 +163,7 @@ async def remove_context_command(
     return {"error": "Context command not found"}
 
 
-@router.post("/context-commands/{name}/toggle")
+@router.post("/context-commands/{name}/toggle", response_model=ContextCommandToggleResponse)
 async def toggle_command(
     request: Request,
     name: str,

--- a/twag/web/routes/prompts.py
+++ b/twag/web/routes/prompts.py
@@ -14,6 +14,14 @@ from ...db import (
     rollback_prompt,
     upsert_prompt,
 )
+from ...models.api import (
+    PromptHistoryResponse,
+    PromptListResponse,
+    PromptResponse,
+    PromptRollbackResponse,
+    PromptTuneResponse,
+    PromptUpdateResponse,
+)
 
 router = APIRouter(tags=["prompts"])
 
@@ -32,7 +40,7 @@ class TuneRequest(BaseModel):
     reaction_limit: int = 50
 
 
-@router.get("/prompts")
+@router.get("/prompts", response_model=PromptListResponse)
 async def list_prompts(request: Request) -> dict[str, Any]:
     """Get all prompts."""
     db_path = request.app.state.db_path
@@ -55,7 +63,7 @@ async def list_prompts(request: Request) -> dict[str, Any]:
     }
 
 
-@router.get("/prompts/{name}")
+@router.get("/prompts/{name}", response_model=PromptResponse)
 async def get_prompt_by_name(request: Request, name: str) -> dict[str, Any]:
     """Get a specific prompt by name."""
     db_path = request.app.state.db_path
@@ -76,7 +84,7 @@ async def get_prompt_by_name(request: Request, name: str) -> dict[str, Any]:
     }
 
 
-@router.put("/prompts/{name}")
+@router.put("/prompts/{name}", response_model=PromptUpdateResponse)
 async def update_prompt(
     request: Request,
     name: str,
@@ -96,7 +104,7 @@ async def update_prompt(
     }
 
 
-@router.get("/prompts/{name}/history")
+@router.get("/prompts/{name}/history", response_model=PromptHistoryResponse)
 async def get_history(request: Request, name: str, limit: int = 10) -> dict[str, Any]:
     """Get version history for a prompt."""
     db_path = request.app.state.db_path
@@ -110,7 +118,7 @@ async def get_history(request: Request, name: str, limit: int = 10) -> dict[str,
     }
 
 
-@router.post("/prompts/{name}/rollback")
+@router.post("/prompts/{name}/rollback", response_model=PromptRollbackResponse)
 async def rollback_to_version(
     request: Request,
     name: str,
@@ -128,7 +136,7 @@ async def rollback_to_version(
     return {"error": f"Version {version} not found for prompt {name}"}
 
 
-@router.post("/prompts/tune")
+@router.post("/prompts/tune", response_model=PromptTuneResponse)
 async def tune_prompt(request: Request, tune_req: TuneRequest) -> dict[str, Any]:
     """
     LLM-assisted prompt tuning based on user reactions.
@@ -258,7 +266,7 @@ SUGGESTED PROMPT:
         return {"error": f"LLM call failed: {e!s}"}
 
 
-@router.post("/prompts/{name}/apply-suggestion")
+@router.post("/prompts/{name}/apply-suggestion", response_model=PromptUpdateResponse)
 async def apply_suggestion(
     request: Request,
     name: str,

--- a/twag/web/routes/reactions.py
+++ b/twag/web/routes/reactions.py
@@ -1,5 +1,6 @@
 """Reaction API routes."""
 
+import json
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -14,6 +15,13 @@ from ...db import (
     insert_reaction,
     mute_account,
 )
+from ...models.api import (
+    ReactionCreateResponse,
+    ReactionDeleteResponse,
+    ReactionExportResponse,
+    ReactionSummaryResponse,
+    TweetReactionsResponse,
+)
 
 router = APIRouter(tags=["reactions"])
 
@@ -27,7 +35,7 @@ class ReactionCreate(BaseModel):
     target: str | None = None  # author handle or category for X reactions
 
 
-@router.post("/react")
+@router.post("/react", response_model=ReactionCreateResponse)
 async def create_reaction(request: Request, reaction: ReactionCreate) -> dict[str, Any]:
     """
     Create a reaction to a tweet.
@@ -85,44 +93,11 @@ async def create_reaction(request: Request, reaction: ReactionCreate) -> dict[st
     }
 
 
-@router.get("/reactions/{tweet_id}")
-async def get_tweet_reactions(request: Request, tweet_id: str) -> dict[str, Any]:
-    """Get all reactions for a specific tweet."""
-    db_path = request.app.state.db_path
-
-    with get_connection(db_path, readonly=True) as conn:
-        reactions = get_reactions_for_tweet(conn, tweet_id)
-
-    return {
-        "tweet_id": tweet_id,
-        "reactions": [
-            {
-                "id": r.id,
-                "reaction_type": r.reaction_type,
-                "reason": r.reason,
-                "target": r.target,
-                "created_at": r.created_at.isoformat() if r.created_at else None,
-            }
-            for r in reactions
-        ],
-    }
+# Static routes MUST be defined before parameterized routes to avoid
+# FastAPI matching "summary" / "export" as a {tweet_id} path parameter.
 
 
-@router.delete("/reactions/{reaction_id}")
-async def remove_reaction(request: Request, reaction_id: int) -> dict[str, Any]:
-    """Delete a reaction."""
-    db_path = request.app.state.db_path
-
-    with get_connection(db_path) as conn:
-        deleted = delete_reaction(conn, reaction_id)
-        conn.commit()
-
-    if deleted:
-        return {"message": "Reaction deleted"}
-    return {"error": "Reaction not found"}
-
-
-@router.get("/reactions/summary")
+@router.get("/reactions/summary", response_model=ReactionSummaryResponse)
 async def reactions_summary(request: Request) -> dict[str, Any]:
     """Get summary of reaction counts by type."""
     db_path = request.app.state.db_path
@@ -133,7 +108,7 @@ async def reactions_summary(request: Request) -> dict[str, Any]:
     return {"summary": summary}
 
 
-@router.get("/reactions/export")
+@router.get("/reactions/export", response_model=ReactionExportResponse)
 async def export_reactions(
     request: Request,
     reaction_type: str | None = None,
@@ -143,8 +118,6 @@ async def export_reactions(
     Export reactions with associated tweet data.
     Useful for prompt tuning analysis.
     """
-    import json
-
     db_path = request.app.state.db_path
 
     with get_connection(db_path, readonly=True) as conn:
@@ -184,3 +157,40 @@ async def export_reactions(
         "count": len(export_data),
         "reactions": export_data,
     }
+
+
+@router.get("/reactions/{tweet_id}", response_model=TweetReactionsResponse)
+async def get_tweet_reactions(request: Request, tweet_id: str) -> dict[str, Any]:
+    """Get all reactions for a specific tweet."""
+    db_path = request.app.state.db_path
+
+    with get_connection(db_path, readonly=True) as conn:
+        reactions = get_reactions_for_tweet(conn, tweet_id)
+
+    return {
+        "tweet_id": tweet_id,
+        "reactions": [
+            {
+                "id": r.id,
+                "reaction_type": r.reaction_type,
+                "reason": r.reason,
+                "target": r.target,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in reactions
+        ],
+    }
+
+
+@router.delete("/reactions/{reaction_id}", response_model=ReactionDeleteResponse)
+async def remove_reaction(request: Request, reaction_id: int) -> dict[str, Any]:
+    """Delete a reaction."""
+    db_path = request.app.state.db_path
+
+    with get_connection(db_path) as conn:
+        deleted = delete_reaction(conn, reaction_id)
+        conn.commit()
+
+    if deleted:
+        return {"message": "Reaction deleted"}
+    return {"error": "Reaction not found"}

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -9,6 +9,12 @@ from fastapi import APIRouter, Query, Request
 
 from ...db import get_connection, get_feed_tweets, get_tweet_by_id, get_tweets_by_ids, parse_time_range
 from ...media import parse_media_items
+from ...models.api import (
+    CategoriesResponse,
+    SingleTweetResponse,
+    TickersResponse,
+    TweetListResponse,
+)
 from ..tweet_utils import (
     decode_html_entities,
     normalize_links_for_display,
@@ -126,7 +132,7 @@ def _build_quote_embed_from_cache(
     return embed
 
 
-@router.get("/tweets")
+@router.get("/tweets", response_model=TweetListResponse)
 async def list_tweets(
     request: Request,
     category: str | None = None,
@@ -367,7 +373,7 @@ async def list_tweets(
     }
 
 
-@router.get("/tweets/{tweet_id}")
+@router.get("/tweets/{tweet_id}", response_model=SingleTweetResponse)
 async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
     """Get a single tweet by ID."""
     db_path = request.app.state.db_path
@@ -462,7 +468,7 @@ async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
     }
 
 
-@router.get("/categories")
+@router.get("/categories", response_model=CategoriesResponse)
 async def list_categories(request: Request) -> dict[str, Any]:
     """Get list of all categories with tweet counts."""
     db_path = request.app.state.db_path
@@ -501,7 +507,7 @@ async def list_categories(request: Request) -> dict[str, Any]:
     return {"categories": [{"name": name, "count": count} for name, count in sorted_cats]}
 
 
-@router.get("/tickers")
+@router.get("/tickers", response_model=TickersResponse)
 async def list_tickers(request: Request, limit: int = 50) -> dict[str, Any]:
     """Get list of mentioned tickers with counts."""
     import json


### PR DESCRIPTION
## Summary
- **Fix route ordering bug**: Moved `/reactions/summary` and `/reactions/export` above `/reactions/{tweet_id}` in reactions.py so static paths are not shadowed by the path parameter route
- **Wire `response_model` annotations**: Added Pydantic response models to all route decorators across tweets, reactions, prompts, and context-commands endpoints for FastAPI validation and OpenAPI doc generation
- **Add response schema models**: Created missing Pydantic models in `twag/models/api.py` for reactions, prompts, and context-commands endpoints
- **Add contract tests**: New test files for reactions (8 tests), prompts (7 tests), and context-commands (8 tests) endpoints verifying response shapes match declared models, including specific tests for the route ordering fix

## Test plan
- [x] All 33 API contract tests pass (new + existing)
- [x] Full test suite (191 tests) passes
- [x] Ruff format and lint clean
- [x] Verified `/reactions/summary` returns summary data (not empty reactions from `{tweet_id}` route)
- [x] Verified `/reactions/export` returns export data (not empty reactions from `{tweet_id}` route)

Nightshift-Task: api-contract-verify
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)