### PR TITLE
Verify and enforce API contract consistency

### DIFF
--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -1,0 +1,332 @@
+"""API contract verification tests.
+
+Ensures that backend route responses match the declared Pydantic models
+and that frontend TypeScript types stay aligned with backend field names.
+"""
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from twag.db import get_connection, insert_tweet, update_tweet_processing
+from twag.models.api import CategoryCount, TickerCount, TweetListResponse, TweetResponse
+from twag.web.app import create_app
+
+
+def _insert_processed_tweet(conn, *, tweet_id: str, author_handle: str, content: str, **kwargs) -> None:
+    inserted = insert_tweet(
+        conn,
+        tweet_id=tweet_id,
+        author_handle=author_handle,
+        content=content,
+        created_at=datetime.now(timezone.utc),
+        source="test",
+        **kwargs,
+    )
+    assert inserted is True
+    update_tweet_processing(
+        conn,
+        tweet_id=tweet_id,
+        relevance_score=7.0,
+        categories=["macro"],
+        summary=f"summary-{tweet_id}",
+        signal_tier="market_relevant",
+        tickers=["SPX"],
+    )
+
+
+# -- Expected field sets derived from Pydantic models --
+
+TWEET_RESPONSE_FIELDS = set(TweetResponse.model_fields.keys())
+
+TWEET_LIST_RESPONSE_FIELDS = set(TweetListResponse.model_fields.keys())
+
+
+# ---------------------------------------------------------------------------
+# /api/tweets list endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_list_tweets_response_validates_against_pydantic_model(monkeypatch, tmp_path):
+    """Every field in /api/tweets response must parse via TweetListResponse."""
+    db_path = tmp_path / "contract_list.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="c-1", author_handle="alice", content="Contract test tweet")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tweets", params={"since": "30d"})
+    assert resp.status_code == 200
+
+    # Must validate without errors
+    parsed = TweetListResponse.model_validate(resp.json())
+    assert parsed.count == 1
+    assert parsed.tweets[0].id == "c-1"
+
+
+def test_list_tweets_response_keys_match_model_fields(monkeypatch, tmp_path):
+    """JSON keys in each tweet must exactly match TweetResponse field names."""
+    db_path = tmp_path / "contract_keys.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="c-2", author_handle="bob", content="Key check")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tweets", params={"since": "30d"})
+    tweet_keys = set(resp.json()["tweets"][0].keys())
+    assert tweet_keys == TWEET_RESPONSE_FIELDS
+
+
+def test_list_tweets_reactions_is_list(monkeypatch, tmp_path):
+    """reactions field must be a list of strings, not string|null."""
+    db_path = tmp_path / "contract_reactions.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="c-3", author_handle="carol", content="Reactions check")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tweets", params={"since": "30d"})
+    tweet = resp.json()["tweets"][0]
+    assert isinstance(tweet["reactions"], list)
+
+
+# ---------------------------------------------------------------------------
+# /api/tweets/{tweet_id} single endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_single_tweet_response_validates_against_pydantic_model(monkeypatch, tmp_path):
+    """Single tweet endpoint must validate against TweetResponse."""
+    db_path = tmp_path / "contract_single.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="s-1", author_handle="dave", content="Single tweet test")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tweets/s-1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "error" not in data
+
+    parsed = TweetResponse.model_validate(data)
+    assert parsed.id == "s-1"
+
+
+def test_single_tweet_keys_match_list_tweet_keys(monkeypatch, tmp_path):
+    """Single tweet endpoint must return the same field set as the list endpoint."""
+    db_path = tmp_path / "contract_single_keys.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="sk-1", author_handle="eve", content="Field alignment")
+        conn.commit()
+
+    client = TestClient(app)
+
+    list_resp = client.get("/api/tweets", params={"since": "30d"})
+    list_keys = set(list_resp.json()["tweets"][0].keys())
+
+    single_resp = client.get("/api/tweets/sk-1")
+    single_keys = set(single_resp.json().keys())
+
+    assert single_keys == list_keys, f"Missing: {list_keys - single_keys}, Extra: {single_keys - list_keys}"
+
+
+def test_single_tweet_has_enriched_display_fields(monkeypatch, tmp_path):
+    """Single tweet must include display_content, quote_embed, external_links, etc."""
+    db_path = tmp_path / "contract_enriched.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="e-1", author_handle="frank", content="Enriched fields check")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tweets/e-1")
+    data = resp.json()
+
+    enriched_fields = {
+        "display_author_handle",
+        "display_author_name",
+        "display_tweet_id",
+        "display_content",
+        "quote_embed",
+        "inline_quote_embeds",
+        "reference_links",
+        "external_links",
+    }
+    assert enriched_fields.issubset(set(data.keys()))
+
+
+def test_single_tweet_no_links_json(monkeypatch, tmp_path):
+    """Single tweet must NOT expose raw links_json (replaced by external_links)."""
+    db_path = tmp_path / "contract_no_links_json.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="nlj-1", author_handle="grace", content="No links_json")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tweets/nlj-1")
+    assert "links_json" not in resp.json()
+
+
+def test_single_tweet_reactions_is_list(monkeypatch, tmp_path):
+    """Single tweet reactions must be list[str]."""
+    db_path = tmp_path / "contract_single_reactions.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="sr-1", author_handle="heidi", content="Reactions type")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tweets/sr-1")
+    assert isinstance(resp.json()["reactions"], list)
+
+
+# ---------------------------------------------------------------------------
+# /api/categories
+# ---------------------------------------------------------------------------
+
+
+def test_categories_response_shape(monkeypatch, tmp_path):
+    """Categories endpoint must return {categories: [{name, count}]}."""
+    db_path = tmp_path / "contract_cats.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="cat-1", author_handle="ivan", content="Cat test")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/categories")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "categories" in data
+    for cat in data["categories"]:
+        parsed = CategoryCount.model_validate(cat)
+        assert parsed.count > 0
+
+
+# ---------------------------------------------------------------------------
+# /api/tickers
+# ---------------------------------------------------------------------------
+
+
+def test_tickers_response_shape(monkeypatch, tmp_path):
+    """Tickers endpoint must return {tickers: [{symbol, count}]}."""
+    db_path = tmp_path / "contract_tickers.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="tick-1", author_handle="judy", content="Ticker test")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tickers")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "tickers" in data
+    for ticker in data["tickers"]:
+        parsed = TickerCount.model_validate(ticker)
+        assert parsed.count > 0
+
+
+# ---------------------------------------------------------------------------
+# Frontend TypeScript alignment
+# ---------------------------------------------------------------------------
+
+# Fields that the frontend Tweet interface expects from the backend.
+# Extracted from twag/web/frontend/src/api/types.ts Tweet interface.
+FRONTEND_TWEET_FIELDS = {
+    "id",
+    "author_handle",
+    "author_name",
+    "display_author_handle",
+    "display_author_name",
+    "display_tweet_id",
+    "content",
+    "content_summary",
+    "summary",
+    "created_at",
+    "relevance_score",
+    "categories",
+    "signal_tier",
+    "tickers",
+    "bookmarked",
+    "has_quote",
+    "quote_tweet_id",
+    "has_media",
+    "media_analysis",
+    "media_items",
+    "has_link",
+    "link_summary",
+    "is_x_article",
+    "article_title",
+    "article_preview",
+    "article_text",
+    "article_summary_short",
+    "article_primary_points",
+    "article_action_items",
+    "article_top_visual",
+    "article_processed_at",
+    "reactions",
+    "is_retweet",
+    "retweeted_by_handle",
+    "retweeted_by_name",
+    "original_tweet_id",
+    "original_author_handle",
+    "original_author_name",
+    "original_content",
+    "quote_embed",
+    "inline_quote_embeds",
+    "reference_links",
+    "external_links",
+    "display_content",
+}
+
+
+def test_frontend_tweet_fields_match_backend_model():
+    """Frontend TypeScript Tweet interface fields must match TweetResponse model fields."""
+    assert FRONTEND_TWEET_FIELDS == TWEET_RESPONSE_FIELDS, (
+        f"Frontend-only: {FRONTEND_TWEET_FIELDS - TWEET_RESPONSE_FIELDS}, "
+        f"Backend-only: {TWEET_RESPONSE_FIELDS - FRONTEND_TWEET_FIELDS}"
+    )
+
+
+def test_frontend_tweet_fields_match_list_api_response(monkeypatch, tmp_path):
+    """Frontend fields must match actual API response keys (not just model)."""
+    db_path = tmp_path / "contract_frontend_api.db"
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+
+    with get_connection(db_path) as conn:
+        _insert_processed_tweet(conn, tweet_id="fe-1", author_handle="karl", content="Frontend alignment")
+        conn.commit()
+
+    client = TestClient(app)
+    resp = client.get("/api/tweets", params={"since": "30d"})
+    api_keys = set(resp.json()["tweets"][0].keys())
+    assert api_keys == FRONTEND_TWEET_FIELDS, (
+        f"Frontend-only: {FRONTEND_TWEET_FIELDS - api_keys}, API-only: {api_keys - FRONTEND_TWEET_FIELDS}"
+    )

--- a/twag/web/frontend/src/api/types.ts
+++ b/twag/web/frontend/src/api/types.ts
@@ -32,7 +32,7 @@ export interface Tweet {
   article_action_items: ArticleActionItem[];
   article_top_visual: ArticleTopVisual | null;
   article_processed_at: string | null;
-  reactions: string | null;
+  reactions: string[];
   is_retweet: boolean;
   retweeted_by_handle: string | null;
   retweeted_by_name: string | null;

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Query, Request
 
 from ...db import get_connection, get_feed_tweets, get_tweet_by_id, get_tweets_by_ids, parse_time_range
 from ...media import parse_media_items
+from ...models.api import TweetListResponse
 from ..tweet_utils import (
     decode_html_entities,
     normalize_links_for_display,
@@ -126,7 +127,7 @@ def _build_quote_embed_from_cache(
     return embed
 
 
-@router.get("/tweets")
+@router.get("/tweets", response_model=TweetListResponse)
 async def list_tweets(
     request: Request,
     category: str | None = None,
@@ -369,64 +370,150 @@ async def list_tweets(
 
 @router.get("/tweets/{tweet_id}")
 async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
-    """Get a single tweet by ID."""
+    """Get a single tweet by ID with enriched display fields."""
     db_path = request.app.state.db_path
 
     with get_connection(db_path, readonly=True) as conn:
         tweet = get_tweet_by_id(conn, tweet_id)
 
-    if not tweet:
-        return {"error": "Tweet not found"}
+        if not tweet:
+            return {"error": "Tweet not found"}
 
-    # Parse JSON fields
-    categories = []
-    if tweet["category"]:
-        try:
-            categories = json.loads(tweet["category"])
-            if isinstance(categories, str):
-                categories = [categories]
-        except json.JSONDecodeError:
-            categories = [tweet["category"]]
+        # Parse JSON fields
+        categories = []
+        if tweet["category"]:
+            try:
+                categories = json.loads(tweet["category"])
+                if isinstance(categories, str):
+                    categories = [categories]
+            except json.JSONDecodeError:
+                categories = [tweet["category"]]
 
-    tickers = []
-    if tweet["tickers"]:
-        try:
-            tickers = json.loads(tweet["tickers"])
-        except json.JSONDecodeError:
-            tickers = [t.strip() for t in tweet["tickers"].split(",") if t.strip()]
+        tickers = []
+        if tweet["tickers"]:
+            try:
+                tickers = json.loads(tweet["tickers"])
+            except json.JSONDecodeError:
+                tickers = [t.strip() for t in tweet["tickers"].split(",") if t.strip()]
 
-    article_primary_points = []
-    if tweet["article_primary_points_json"]:
-        try:
-            decoded = json.loads(tweet["article_primary_points_json"])
-            if isinstance(decoded, list):
-                article_primary_points = [item for item in decoded if isinstance(item, dict)]
-        except json.JSONDecodeError:
-            article_primary_points = []
+        article_primary_points = []
+        if tweet["article_primary_points_json"]:
+            try:
+                decoded = json.loads(tweet["article_primary_points_json"])
+                if isinstance(decoded, list):
+                    article_primary_points = [item for item in decoded if isinstance(item, dict)]
+            except json.JSONDecodeError:
+                article_primary_points = []
 
-    article_action_items = []
-    if tweet["article_action_items_json"]:
-        try:
-            decoded = json.loads(tweet["article_action_items_json"])
-            if isinstance(decoded, list):
-                article_action_items = [item for item in decoded if isinstance(item, dict)]
-        except json.JSONDecodeError:
-            article_action_items = []
+        article_action_items = []
+        if tweet["article_action_items_json"]:
+            try:
+                decoded = json.loads(tweet["article_action_items_json"])
+                if isinstance(decoded, list):
+                    article_action_items = [item for item in decoded if isinstance(item, dict)]
+            except json.JSONDecodeError:
+                article_action_items = []
 
-    article_top_visual = None
-    if tweet["article_top_visual_json"]:
-        try:
-            decoded = json.loads(tweet["article_top_visual_json"])
-            if isinstance(decoded, dict):
-                article_top_visual = decoded
-        except json.JSONDecodeError:
-            article_top_visual = None
+        article_top_visual = None
+        if tweet["article_top_visual_json"]:
+            try:
+                decoded = json.loads(tweet["article_top_visual_json"])
+                if isinstance(decoded, dict):
+                    article_top_visual = decoded
+            except json.JSONDecodeError:
+                article_top_visual = None
+
+        # Parse links for display normalization
+        content_raw = tweet["content"] or ""
+        links_json: list[dict] = []
+        if tweet["links_json"]:
+            try:
+                decoded = json.loads(tweet["links_json"])
+                if isinstance(decoded, list):
+                    links_json = [item for item in decoded if isinstance(item, dict)]
+            except json.JSONDecodeError:
+                links_json = []
+
+        normalized = normalize_links_for_display(
+            tweet_id=tweet["id"],
+            text=content_raw,
+            links=links_json,
+            has_media=bool(tweet["has_media"]),
+        )
+
+        # Build quote embed
+        quote_id = tweet["quote_tweet_id"]
+        if not quote_id and not tweet["has_quote"]:
+            quote_id = _inline_quote_id_from_links(tweet["id"], normalized.inline_tweet_links)
+        if quote_id == tweet["id"]:
+            quote_id = None
+        quote_embed = _build_quote_embed(conn, quote_id)
+
+        # Build inline quote embeds and reference links
+        inline_quote_embeds: list[dict[str, Any]] = []
+        reference_links: list[dict[str, str]] = []
+        for link in normalized.inline_tweet_links:
+            tid = link.get("id")
+            url = link.get("url") or ""
+            if not tid or tid == tweet["id"]:
+                continue
+            if quote_id and tid == quote_id:
+                continue
+            embed = _build_quote_embed(conn, tid)
+            if embed:
+                inline_quote_embeds.append(embed)
+            else:
+                reference_links.append({"id": tid, "url": url})
+
+        # Fetch reactions
+        cursor = conn.execute("SELECT reaction_type FROM reactions WHERE tweet_id = ?", (tweet_id,))
+        reactions = [row["reaction_type"] for row in cursor.fetchall()]
+
+    # Display fields with retweet handling
+    display_content = normalized.display_text if content_raw else content_raw
+    is_retweet = bool(tweet["is_retweet"])
+    retweeted_by_handle = tweet["retweeted_by_handle"]
+    retweeted_by_name = tweet["retweeted_by_name"]
+    original_tweet_id = tweet["original_tweet_id"]
+    original_author_handle = tweet["original_author_handle"]
+    original_author_name = tweet["original_author_name"]
+    original_content = tweet["original_content"]
+
+    if not is_retweet:
+        match = LEGACY_RETWEET_RE.match(content_raw)
+        if match:
+            is_retweet = True
+            retweeted_by_handle = tweet["author_handle"]
+            retweeted_by_name = tweet["author_name"]
+            original_author_handle = match.group(1)
+            fallback_original = match.group(2).strip() or None
+            if fallback_original and not _looks_truncated_text(fallback_original):
+                original_content = fallback_original
+
+    display_author_handle = original_author_handle if is_retweet and original_author_handle else tweet["author_handle"]
+    display_author_name = original_author_name if is_retweet and original_author_name else tweet["author_name"]
+    display_tweet_id = original_tweet_id if is_retweet and original_tweet_id else tweet["id"]
+    if is_retweet and original_content:
+        display_content = original_content
+        display_content = normalize_links_for_display(
+            tweet_id=display_tweet_id,
+            text=display_content,
+            links=links_json,
+            has_media=bool(tweet["has_media"]),
+        ).display_text
+
+    content = decode_html_entities(tweet["content"])
+    original_content = decode_html_entities(original_content)
+    display_content = decode_html_entities(display_content)
 
     return {
         "id": tweet["id"],
         "author_handle": tweet["author_handle"],
         "author_name": tweet["author_name"],
-        "content": decode_html_entities(tweet["content"]),
+        "display_author_handle": display_author_handle,
+        "display_author_name": display_author_name,
+        "display_tweet_id": display_tweet_id,
+        "content": content,
         "content_summary": tweet["content_summary"],
         "summary": tweet["summary"],
         "created_at": tweet["created_at"],
@@ -451,14 +538,19 @@ async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
         "article_action_items": article_action_items,
         "article_top_visual": article_top_visual,
         "article_processed_at": tweet["article_processed_at"],
-        "is_retweet": bool(tweet["is_retweet"]),
-        "retweeted_by_handle": tweet["retweeted_by_handle"],
-        "retweeted_by_name": tweet["retweeted_by_name"],
-        "original_tweet_id": tweet["original_tweet_id"],
-        "original_author_handle": tweet["original_author_handle"],
-        "original_author_name": tweet["original_author_name"],
-        "original_content": decode_html_entities(tweet["original_content"]),
-        "links_json": tweet["links_json"],
+        "is_retweet": is_retweet,
+        "retweeted_by_handle": retweeted_by_handle,
+        "retweeted_by_name": retweeted_by_name,
+        "original_tweet_id": original_tweet_id,
+        "original_author_handle": original_author_handle,
+        "original_author_name": original_author_name,
+        "original_content": original_content,
+        "reactions": reactions,
+        "quote_embed": quote_embed,
+        "inline_quote_embeds": inline_quote_embeds,
+        "reference_links": reference_links,
+        "external_links": normalized.external_links,
+        "display_content": display_content,
     }
 
 


### PR DESCRIPTION
## Summary
- Fix frontend `types.ts` reactions field type mismatch: `string | null` → `string[]` to match backend `list[str]`
- Add `response_model=TweetListResponse` to `GET /tweets` for runtime Pydantic validation
- Align `GET /tweets/{tweet_id}` with list endpoint: add enriched display fields (`display_author_handle`, `display_author_name`, `display_tweet_id`, `display_content`, `quote_embed`, `inline_quote_embeds`, `reference_links`, `external_links`), retweet handling, and `reactions` as `list[str]`; remove raw `links_json`
- Add 12 contract verification tests validating response shapes, field alignment between endpoints, and frontend/backend type consistency

## Test plan
- [x] All 12 new contract tests pass
- [x] All 10 existing API tests pass
- [x] ruff format/check clean
- [ ] Verify frontend renders correctly with updated reactions type

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: api-contract-verify:/home/clifton/code/twag
task-type: api-contract-verify
task-title: API Contract Verification
iterations: 2
duration: 13m39s
nightshift:metadata -->
