### PR TITLE
Add schema evolution: versioned migrations and drift detection

### DIFF
--- a/tests/test_db_schema_evolution.py
+++ b/tests/test_db_schema_evolution.py
@@ -1,0 +1,149 @@
+"""Tests for schema evolution: versioning, migration registry, drift detection."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from twag.db.connection import (
+    MIGRATIONS,
+    _run_migrations,
+    _validate_schema,
+    get_pending_migrations,
+    get_schema_drift,
+    get_schema_version,
+)
+from twag.db.schema import ACCOUNTS_COLUMNS, SCHEMA, SCHEMA_VERSION, TWEETS_COLUMNS
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path):
+    """Create a fresh in-memory-style DB on disk with base schema."""
+    db_file = tmp_path / "test.db"
+    conn = sqlite3.connect(db_file)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    yield conn
+    conn.close()
+
+
+class TestVersionTracking:
+    def test_fresh_db_starts_at_zero(self, tmp_db: sqlite3.Connection):
+        assert get_schema_version(tmp_db) == 0
+
+    def test_migrations_set_version(self, tmp_db: sqlite3.Connection):
+        _run_migrations(tmp_db)
+        assert get_schema_version(tmp_db) == SCHEMA_VERSION
+
+    def test_version_matches_max_migration(self):
+        max_migration_version = max(v for v, _, _ in MIGRATIONS)
+        assert max_migration_version == SCHEMA_VERSION
+
+
+class TestMigrationIdempotency:
+    def test_run_twice_no_errors(self, tmp_db: sqlite3.Connection):
+        _run_migrations(tmp_db)
+        tmp_db.commit()
+        # Run again — should be a no-op
+        _run_migrations(tmp_db)
+        tmp_db.commit()
+        assert get_schema_version(tmp_db) == SCHEMA_VERSION
+
+    def test_pending_empty_after_migration(self, tmp_db: sqlite3.Connection):
+        _run_migrations(tmp_db)
+        assert get_pending_migrations(tmp_db) == []
+
+    def test_pending_before_migration(self, tmp_db: sqlite3.Connection):
+        pending = get_pending_migrations(tmp_db)
+        assert len(pending) == len(MIGRATIONS)
+
+
+class TestDriftDetection:
+    def test_no_drift_on_fresh_schema(self, tmp_db: sqlite3.Connection):
+        _run_migrations(tmp_db)
+        drift = get_schema_drift(tmp_db)
+        assert drift == {}
+
+    def test_missing_column_detected(self, tmp_db: sqlite3.Connection):
+        _run_migrations(tmp_db)
+        # Simulate drift by adding a column to the expected set
+        # Instead, we'll drop a column by recreating without it — but SQLite
+        # doesn't support DROP COLUMN in older versions.  Easier: temporarily
+        # patch the constant.
+        import twag.db.connection as mod
+
+        original = mod.TWEETS_COLUMNS
+        try:
+            mod.TWEETS_COLUMNS = original | {"fake_future_col"}
+            drift = get_schema_drift(tmp_db)
+            assert "tweets" in drift
+            assert "fake_future_col" in drift["tweets"]["missing"]
+        finally:
+            mod.TWEETS_COLUMNS = original
+
+    def test_extra_column_detected(self, tmp_db: sqlite3.Connection):
+        _run_migrations(tmp_db)
+        tmp_db.execute("ALTER TABLE tweets ADD COLUMN rogue_col TEXT")
+        drift = get_schema_drift(tmp_db)
+        assert "tweets" in drift
+        assert "rogue_col" in drift["tweets"]["extra"]
+
+    def test_validate_schema_logs_drift(self, tmp_db: sqlite3.Connection, caplog):
+        _run_migrations(tmp_db)
+        tmp_db.execute("ALTER TABLE accounts ADD COLUMN rogue_col TEXT")
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            _validate_schema(tmp_db)
+        assert "rogue_col" in caplog.text
+
+    def test_column_constants_match_schema(self, tmp_db: sqlite3.Connection):
+        """Verify TWEETS_COLUMNS and ACCOUNTS_COLUMNS match the CREATE TABLE."""
+        _run_migrations(tmp_db)
+        cursor = tmp_db.execute("PRAGMA table_info(tweets)")
+        actual_tweets = {row[1] for row in cursor.fetchall()}
+        assert actual_tweets == TWEETS_COLUMNS
+
+        cursor = tmp_db.execute("PRAGMA table_info(accounts)")
+        actual_accounts = {row[1] for row in cursor.fetchall()}
+        assert actual_accounts == ACCOUNTS_COLUMNS
+
+
+class TestSchemaStatusCLI:
+    def test_schema_status_output(self, tmp_path: Path, monkeypatch):
+        from twag.cli.db_cmd import db_schema_status
+
+        db_file = tmp_path / "test.db"
+        conn = sqlite3.connect(db_file)
+        conn.executescript(SCHEMA)
+        _run_migrations(conn)
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr("twag.cli.db_cmd.get_database_path", lambda: db_file)
+        monkeypatch.setattr("twag.db.connection.get_database_path", lambda: db_file)
+
+        runner = CliRunner()
+        result = runner.invoke(db_schema_status)
+        assert result.exit_code == 0
+        assert f"Schema version: {SCHEMA_VERSION}" in result.output
+        assert "All migrations applied" in result.output
+        assert "No column drift" in result.output
+
+    def test_schema_status_pending(self, tmp_path: Path, monkeypatch):
+        from twag.cli.db_cmd import db_schema_status
+
+        db_file = tmp_path / "test.db"
+        conn = sqlite3.connect(db_file)
+        conn.executescript(SCHEMA)
+        # Don't run migrations — version stays at 0
+        conn.close()
+
+        monkeypatch.setattr("twag.cli.db_cmd.get_database_path", lambda: db_file)
+        monkeypatch.setattr("twag.db.connection.get_database_path", lambda: db_file)
+
+        runner = CliRunner()
+        result = runner.invoke(db_schema_status)
+        assert result.exit_code == 0
+        assert "pending migration" in result.output

--- a/twag/cli/db_cmd.py
+++ b/twag/cli/db_cmd.py
@@ -8,6 +8,8 @@ import rich_click as click
 
 from ..config import get_database_path
 from ..db import dump_sql, get_connection, init_db, rebuild_fts, restore_sql
+from ..db.connection import get_pending_migrations, get_schema_drift, get_schema_version
+from ..db.schema import SCHEMA_VERSION
 from ._console import console
 
 
@@ -145,3 +147,37 @@ def db_restore(input_file: str, force: bool):
     except Exception as e:
         console.print(f"[red]Error restoring database: {e}[/red]")
         sys.exit(1)
+
+
+@db.command("schema-status")
+def db_schema_status():
+    """Report schema version, pending migrations, and column drift."""
+    db_file = get_database_path()
+
+    if not db_file.exists():
+        console.print(f"[red]Database not found: {db_file}[/red]")
+        sys.exit(1)
+
+    with get_connection(readonly=True) as conn:
+        current = get_schema_version(conn)
+        pending = get_pending_migrations(conn)
+        drift = get_schema_drift(conn)
+
+    console.print(f"Schema version: {current} (latest: {SCHEMA_VERSION})")
+
+    if pending:
+        console.print(f"\n[yellow]{len(pending)} pending migration(s):[/yellow]")
+        for version, desc in pending:
+            console.print(f"  v{version}: {desc}")
+    else:
+        console.print("[green]All migrations applied.[/green]")
+
+    if drift:
+        console.print("\n[yellow]Column drift detected:[/yellow]")
+        for table, info in drift.items():
+            if info["missing"]:
+                console.print(f"  {table} missing: {sorted(info['missing'])}")
+            if info["extra"]:
+                console.print(f"  {table} extra:   {sorted(info['extra'])}")
+    else:
+        console.print("[green]No column drift.[/green]")

--- a/twag/db/__init__.py
+++ b/twag/db/__init__.py
@@ -11,7 +11,7 @@ from .accounts import (
     update_account_stats,
     upsert_account,
 )
-from .connection import get_connection, init_db, rebuild_fts
+from .connection import get_connection, get_schema_version, init_db, rebuild_fts
 from .context_commands import (
     ContextCommand,
     delete_context_command,
@@ -51,7 +51,7 @@ from .reactions import (
     get_reactions_with_tweets,
     insert_reaction,
 )
-from .schema import FTS_SCHEMA, SCHEMA
+from .schema import ACCOUNTS_COLUMNS, FTS_SCHEMA, SCHEMA, SCHEMA_VERSION, TWEETS_COLUMNS
 from .search import (
     EQUITY_KEYWORDS,
     FeedTweet,
@@ -89,10 +89,13 @@ from .tweets import (
 )
 
 __all__ = [
+    "ACCOUNTS_COLUMNS",
     "DEFAULT_PROMPTS",
     "EQUITY_KEYWORDS",
     "FTS_SCHEMA",
     "SCHEMA",
+    "SCHEMA_VERSION",
+    "TWEETS_COLUMNS",
     "ContextCommand",
     "FeedTweet",
     "Prompt",
@@ -125,6 +128,7 @@ __all__ = [
     "get_reactions_for_tweet",
     "get_reactions_summary",
     "get_reactions_with_tweets",
+    "get_schema_version",
     "get_tweet_by_id",
     "get_tweet_stats",
     "get_tweets_by_ids",

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -1,13 +1,16 @@
 """Database connection management and initialization."""
 
+import logging
 import sqlite3
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
 from ..config import get_database_path
-from .schema import FTS_SCHEMA, SCHEMA
+from .schema import ACCOUNTS_COLUMNS, FTS_SCHEMA, SCHEMA, SCHEMA_VERSION, TWEETS_COLUMNS
+
+log = logging.getLogger(__name__)
 
 
 def init_db(db_path: Path | None = None) -> None:
@@ -23,6 +26,7 @@ def init_db(db_path: Path | None = None) -> None:
             with get_connection(db_path) as conn:
                 conn.executescript(SCHEMA)
                 _run_migrations(conn)
+                _validate_schema(conn)
                 conn.commit()
             return
         except sqlite3.OperationalError as e:
@@ -32,108 +36,76 @@ def init_db(db_path: Path | None = None) -> None:
             raise
 
 
-def _run_migrations(conn: sqlite3.Connection) -> None:
-    """Run schema migrations for existing databases."""
-    from .prompts import seed_prompts
+# ---------------------------------------------------------------------------
+# Migration registry
+# ---------------------------------------------------------------------------
+# Each entry is (version, description, callable).  The callable receives a
+# sqlite3.Connection and may execute arbitrary SQL.  Migrations whose version
+# is <= the current PRAGMA user_version are skipped automatically.
+#
+# **Adding a new migration:**
+#   1. Append a tuple here with version = SCHEMA_VERSION (after bumping it in
+#      schema.py).
+#   2. Bump SCHEMA_VERSION in schema.py.
+#   3. Keep the migration idempotent (use IF NOT EXISTS / check columns).
 
-    # Check tweets table columns
+
+def _migrate_v1_legacy_columns(conn: sqlite3.Connection) -> None:
+    """Collapse all pre-versioning column additions into migration 1."""
     cursor = conn.execute("PRAGMA table_info(tweets)")
     tweet_columns = {row[1] for row in cursor.fetchall()}
 
-    if "bookmarked" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN bookmarked INTEGER DEFAULT 0")
-        conn.execute("ALTER TABLE tweets ADD COLUMN bookmarked_at TIMESTAMP")
+    _add_columns_if_missing(
+        conn,
+        "tweets",
+        tweet_columns,
+        [
+            ("bookmarked", "INTEGER DEFAULT 0"),
+            ("bookmarked_at", "TIMESTAMP"),
+            ("content_summary", "TEXT"),
+            ("media_items", "TEXT"),
+            ("analysis_json", "TEXT"),
+            ("is_retweet", "INTEGER DEFAULT 0"),
+            ("retweeted_by_handle", "TEXT"),
+            ("retweeted_by_name", "TEXT"),
+            ("original_tweet_id", "TEXT"),
+            ("original_author_handle", "TEXT"),
+            ("original_author_name", "TEXT"),
+            ("original_content", "TEXT"),
+            ("is_x_article", "INTEGER DEFAULT 0"),
+            ("article_title", "TEXT"),
+            ("article_preview", "TEXT"),
+            ("article_text", "TEXT"),
+            ("article_summary_short", "TEXT"),
+            ("article_primary_points_json", "TEXT"),
+            ("article_action_items_json", "TEXT"),
+            ("article_top_visual_json", "TEXT"),
+            ("article_processed_at", "TIMESTAMP"),
+            ("links_json", "TEXT"),
+            ("in_reply_to_tweet_id", "TEXT"),
+            ("conversation_id", "TEXT"),
+            ("links_expanded_at", "TIMESTAMP"),
+            ("quote_reprocessed_at", "TIMESTAMP"),
+        ],
+    )
 
-    if "content_summary" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN content_summary TEXT")
-
-    if "media_items" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN media_items TEXT")
-
-    if "analysis_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN analysis_json TEXT")
-
-    if "is_retweet" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN is_retweet INTEGER DEFAULT 0")
-
-    if "retweeted_by_handle" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN retweeted_by_handle TEXT")
-
-    if "retweeted_by_name" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN retweeted_by_name TEXT")
-
-    if "original_tweet_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_tweet_id TEXT")
-
-    if "original_author_handle" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_author_handle TEXT")
-
-    if "original_author_name" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_author_name TEXT")
-
-    if "original_content" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_content TEXT")
-
-    if "is_x_article" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN is_x_article INTEGER DEFAULT 0")
-
-    if "article_title" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_title TEXT")
-
-    if "article_preview" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_preview TEXT")
-
-    if "article_text" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_text TEXT")
-
-    if "article_summary_short" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_summary_short TEXT")
-
-    if "article_primary_points_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_primary_points_json TEXT")
-
-    if "article_action_items_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_action_items_json TEXT")
-
-    if "article_top_visual_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_top_visual_json TEXT")
-
-    if "article_processed_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_processed_at TIMESTAMP")
-
-    if "links_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN links_json TEXT")
-
-    if "in_reply_to_tweet_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN in_reply_to_tweet_id TEXT")
-
-    if "conversation_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN conversation_id TEXT")
-
-    if "links_expanded_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN links_expanded_at TIMESTAMP")
-
-    if "quote_reprocessed_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN quote_reprocessed_at TIMESTAMP")
-
-    # Check accounts table columns
     cursor = conn.execute("PRAGMA table_info(accounts)")
     account_columns = {row[1] for row in cursor.fetchall()}
+    _add_columns_if_missing(conn, "accounts", account_columns, [("last_fetched_at", "TIMESTAMP")])
 
-    if "last_fetched_at" not in account_columns:
-        conn.execute("ALTER TABLE accounts ADD COLUMN last_fetched_at TIMESTAMP")
 
-    # Initialize FTS5 if not present
+def _migrate_v2_indexes_fts_prompts(conn: sqlite3.Connection) -> None:
+    """Ensure FTS, prompts, and performance indexes exist."""
+    from .prompts import seed_prompts
+
     _init_fts(conn)
 
-    # Seed prompts if table exists but is empty
     cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='prompts'")
     if cursor.fetchone():
         seeded = seed_prompts(conn)
         if seeded > 0:
             conn.commit()
 
-    # Ensure performance indexes exist on existing databases
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tweets_processed_score "
         "ON tweets(processed_at, relevance_score DESC, created_at DESC)"
@@ -149,6 +121,96 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
         "ON tweets(in_reply_to_tweet_id) WHERE in_reply_to_tweet_id IS NOT NULL"
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_fetch_log_endpoint ON fetch_log(endpoint, executed_at DESC)")
+
+
+MIGRATIONS: list[tuple[int, str, Callable[[sqlite3.Connection], None]]] = [
+    (1, "legacy column additions", _migrate_v1_legacy_columns),
+    (2, "indexes, FTS, and prompt seeding", _migrate_v2_indexes_fts_prompts),
+]
+
+
+def _add_columns_if_missing(
+    conn: sqlite3.Connection,
+    table: str,
+    existing: set[str],
+    columns: list[tuple[str, str]],
+) -> None:
+    for col_name, col_type in columns:
+        if col_name not in existing:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}")
+
+
+# ---------------------------------------------------------------------------
+# Version helpers
+# ---------------------------------------------------------------------------
+
+
+def get_schema_version(conn: sqlite3.Connection) -> int:
+    """Return the current PRAGMA user_version of the database."""
+    cursor = conn.execute("PRAGMA user_version")
+    return cursor.fetchone()[0]
+
+
+def get_pending_migrations(conn: sqlite3.Connection) -> list[tuple[int, str]]:
+    """Return list of (version, description) for migrations not yet applied."""
+    current = get_schema_version(conn)
+    return [(v, desc) for v, desc, _ in MIGRATIONS if v > current]
+
+
+def _run_migrations(conn: sqlite3.Connection) -> None:
+    """Run pending schema migrations and update user_version."""
+    current = get_schema_version(conn)
+
+    for version, description, migrate_fn in MIGRATIONS:
+        if version <= current:
+            continue
+        log.info("Applying migration v%d: %s", version, description)
+        migrate_fn(conn)
+        conn.execute(f"PRAGMA user_version = {version}")
+
+    # Ensure version is at least SCHEMA_VERSION even if no migrations ran
+    if get_schema_version(conn) < SCHEMA_VERSION:
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+
+# ---------------------------------------------------------------------------
+# Schema drift detection
+# ---------------------------------------------------------------------------
+
+
+def _get_table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    """Return the set of column names for a table."""
+    cursor = conn.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in cursor.fetchall()}
+
+
+def _validate_schema(conn: sqlite3.Connection) -> None:
+    """Compare live DB columns against the expected constants and log drift."""
+    for table, expected in [("tweets", TWEETS_COLUMNS), ("accounts", ACCOUNTS_COLUMNS)]:
+        actual = _get_table_columns(conn, table)
+        missing = expected - actual
+        extra = actual - expected
+        if missing:
+            log.warning("Table %s is missing expected columns: %s", table, sorted(missing))
+        if extra:
+            log.warning("Table %s has columns not in schema constants: %s", table, sorted(extra))
+
+
+def get_schema_drift(conn: sqlite3.Connection) -> dict[str, dict[str, set[str]]]:
+    """Return drift info: {table: {missing: set, extra: set}} for each table."""
+    result: dict[str, dict[str, set[str]]] = {}
+    for table, expected in [("tweets", TWEETS_COLUMNS), ("accounts", ACCOUNTS_COLUMNS)]:
+        actual = _get_table_columns(conn, table)
+        missing = expected - actual
+        extra = actual - expected
+        if missing or extra:
+            result[table] = {"missing": missing, "extra": extra}
+    return result
+
+
+# ---------------------------------------------------------------------------
+# FTS helpers
+# ---------------------------------------------------------------------------
 
 
 def _init_fts(conn: sqlite3.Connection) -> None:

--- a/twag/db/schema.py
+++ b/twag/db/schema.py
@@ -1,5 +1,74 @@
 """Database schema definitions for twag."""
 
+# Current schema version — bump when adding a new migration
+SCHEMA_VERSION = 2
+
+# Expected column sets for drift detection
+TWEETS_COLUMNS: set[str] = {
+    "id",
+    "author_handle",
+    "author_name",
+    "content",
+    "created_at",
+    "first_seen_at",
+    "source",
+    "processed_at",
+    "relevance_score",
+    "category",
+    "summary",
+    "content_summary",
+    "signal_tier",
+    "tickers",
+    "analysis_json",
+    "has_quote",
+    "quote_tweet_id",
+    "in_reply_to_tweet_id",
+    "conversation_id",
+    "has_media",
+    "media_analysis",
+    "media_items",
+    "has_link",
+    "links_json",
+    "link_summary",
+    "is_x_article",
+    "article_title",
+    "article_preview",
+    "article_text",
+    "article_summary_short",
+    "article_primary_points_json",
+    "article_action_items_json",
+    "article_top_visual_json",
+    "article_processed_at",
+    "links_expanded_at",
+    "quote_reprocessed_at",
+    "is_retweet",
+    "retweeted_by_handle",
+    "retweeted_by_name",
+    "original_tweet_id",
+    "original_author_handle",
+    "original_author_name",
+    "original_content",
+    "included_in_digest",
+    "bookmarked",
+    "bookmarked_at",
+}
+
+ACCOUNTS_COLUMNS: set[str] = {
+    "handle",
+    "display_name",
+    "tier",
+    "weight",
+    "category",
+    "tweets_seen",
+    "tweets_kept",
+    "avg_relevance_score",
+    "last_high_signal_at",
+    "last_fetched_at",
+    "added_at",
+    "auto_promoted",
+    "muted",
+}
+
 SCHEMA = """
 -- Tweets: Core storage with deduplication
 CREATE TABLE IF NOT EXISTS tweets (


### PR DESCRIPTION
## Summary
- Introduce `PRAGMA user_version` tracking and a numbered migration registry (`MIGRATIONS` list in `connection.py`) to replace the flat `_run_migrations` function — each migration runs exactly once based on version
- Add `TWEETS_COLUMNS` and `ACCOUNTS_COLUMNS` constants in `schema.py` for drift detection, and a `_validate_schema` helper that logs warnings on DB init
- Add `twag db schema-status` CLI command reporting current version, pending migrations, and column drift
- 13 new tests covering version tracking, migration idempotency, drift detection, and CLI output

## Test plan
- [x] `uv run pytest tests/test_db_schema_evolution.py` — 13 tests pass
- [x] Full suite `uv run pytest` — all tests pass
- [x] `uv run ruff check` and `uv run ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)