### PR TITLE
Align SKILL.md with Agent Skills spec

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: twag
 description: Twitter/X aggregator for market-relevant signals with LLM-powered scoring. Fetches, processes, and curates tweets for market analysis.
-read_when:
-  - Processing Twitter/X feed for market signals
-  - Searching for market-relevant tweets
-  - Generating daily tweet digests
-  - Managing followed Twitter accounts
-  - Finding tweets about specific tickers or topics
-homepage: https://github.com/clifton/twag
+compatibility: Requires Python 3.10+ and bird CLI for Twitter/X access
 metadata:
   openclaw:
     emoji: "📊"
+    homepage: https://github.com/clifton/twag
+    read_when:
+      - Processing Twitter/X feed for market signals
+      - Searching for market-relevant tweets
+      - Generating daily tweet digests
+      - Managing followed Twitter accounts
+      - Finding tweets about specific tickers or topics
     requires:
       bins: ["twag", "bird"]
       env: ["GEMINI_API_KEY", "AUTH_TOKEN", "CT0"]
@@ -31,7 +32,7 @@ metadata:
         bins: ["bird"]
         label: "Install bird CLI (brew)"
         os: ["darwin"]
-allowed-tools: Bash(twag:*), Bash(bird:*)
+allowed-tools: Bash(twag:*) Bash(bird:*)
 ---
 
 # twag — Twitter/X Market Signal Aggregator


### PR DESCRIPTION
## Summary
- **allowed-tools**: Changed from comma-delimited (`Bash(twag:*), Bash(bird:*)`) to space-delimited (`Bash(twag:*) Bash(bird:*)`) per [Agent Skills spec](https://agentskills.io/specification.md)
- **Non-standard fields**: Moved `read_when` and `homepage` from top-level frontmatter into `metadata.openclaw` — the spec only allows `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools` at top level
- **compatibility**: Added field noting Python 3.10+ and bird CLI requirements

All body content (CLI commands, file references, flags) verified current — no stale references found.

## Test plan
- [ ] Verify SKILL.md YAML parses correctly
- [ ] Verify OpenClaw still reads `homepage` and `read_when` from their new `metadata.openclaw` location
- [ ] Confirm `allowed-tools` space-delimited format works with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: skill-groom:/home/clifton/code/twag
task-type: skill-groom
task-title: Skill Grooming
iterations: 1
duration: 4m1s
nightshift:metadata -->
