### PR TITLE
Fix PII/secret exposure in CLI and web API

### DIFF
--- a/twag/cli/config_cmd.py
+++ b/twag/cli/config_cmd.py
@@ -14,11 +14,32 @@ def config():
     """Manage configuration."""
 
 
+_SENSITIVE_KEYS = {"telegram_chat_id", "telegram_bot_token", "api_key", "secret"}
+
+
+def _mask_sensitive(
+    obj: dict | list | str | int | float | bool | None,
+) -> dict | list | str | int | float | bool | None:
+    """Recursively mask values whose keys contain sensitive substrings."""
+    if isinstance(obj, dict):
+        masked = {}
+        for k, v in obj.items():
+            if isinstance(v, str) and any(s in k.lower() for s in _SENSITIVE_KEYS) and len(v) > 4:
+                masked[k] = v[:4] + "****"
+            else:
+                masked[k] = _mask_sensitive(v)
+        return masked
+    if isinstance(obj, list):
+        return [_mask_sensitive(item) for item in obj]
+    return obj
+
+
 @config.command("show")
 def config_show():
     """Show current configuration."""
     cfg = load_config()
-    json_str = json.dumps(cfg, indent=2)
+    masked_cfg = _mask_sensitive(cfg)
+    json_str = json.dumps(masked_cfg, indent=2)
     syntax = Syntax(json_str, "json", theme="monokai")
     console.print(syntax)
 

--- a/twag/cli/init_cmd.py
+++ b/twag/cli/init_cmd.py
@@ -147,14 +147,14 @@ def doctor():
 
     gemini_key = os.environ.get("GEMINI_API_KEY")
     if gemini_key:
-        console.print(f"  {status_icon(True)} GEMINI_API_KEY set ({gemini_key[:8]}...)")
+        console.print(f"  {status_icon(True)} GEMINI_API_KEY set ({gemini_key[:4]}****)")
     else:
         console.print(f"  {status_icon(False)} GEMINI_API_KEY not set")
         issues.append("Set GEMINI_API_KEY environment variable")
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     if anthropic_key:
-        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set ({anthropic_key[:8]}...)")
+        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set ({anthropic_key[:4]}****)")
     else:
         console.print("  [yellow]WARN[/yellow] ANTHROPIC_API_KEY not set (enrichment disabled)")
         warnings.append("Set ANTHROPIC_API_KEY for enrichment features")

--- a/twag/web/app.py
+++ b/twag/web/app.py
@@ -1,4 +1,10 @@
-"""FastAPI application for twag web interface."""
+"""FastAPI application for twag web interface.
+
+Security boundary: This web app is designed for local use only.
+CORS is restricted to localhost/127.0.0.1 origins. There is no built-in
+authentication layer. If exposed beyond localhost, deploy behind a
+reverse proxy with its own auth or add AUTH_HEADER middleware.
+"""
 
 import html
 import os

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -280,19 +280,24 @@ async def test_context_command(
             "error": f"Unsubstituted variables: {unsubstituted}",
             "available_variables": list(variables.keys()),
             "command_template": cmd.command_template,
-            "final_command": final_command,
         }
 
     # Run the command
     stdout, stderr, returncode = await _run_command(final_command)
 
+    # Sanitize output to strip env-var-like patterns (API keys, tokens)
+    env_pattern = re.compile(
+        r"(?i)(api[_-]?key|token|secret|password|auth|ct0)\s*[:=]\s*\S+",
+    )
+    sanitized_stdout = env_pattern.sub(r"\1=****", stdout)
+    sanitized_stderr = env_pattern.sub(r"\1=****", stderr)
+
     return {
         "command_name": name,
         "command_template": cmd.command_template,
-        "final_command": final_command,
         "variables_used": variables,
-        "stdout": stdout,
-        "stderr": stderr,
+        "stdout": sanitized_stdout,
+        "stderr": sanitized_stderr,
         "returncode": returncode,
         "success": returncode == 0,
     }


### PR DESCRIPTION
## Summary
- **`twag doctor`**: Reduced API key prefix display from 8 chars to 4 chars (`AIza****` instead of `AIzaSyDx...`)
- **`twag config show`**: Added recursive masking of sensitive config fields (telegram_chat_id, api_key, bot_token, secret)
- **Context command test endpoint**: Removed `final_command` from HTTP responses and added env-var pattern sanitization on stdout/stderr output
- **Web app**: Added security boundary documentation noting localhost-only CORS restriction and lack of auth middleware

## Test plan
- [x] All existing tests pass (`uv run pytest` — 100%)
- [x] `ruff format` and `ruff check` clean
- [ ] Manual: run `twag doctor` with API keys set, verify only 4-char prefix shown
- [ ] Manual: run `twag config show` with telegram_chat_id set, verify it's masked

Nightshift-Task: pii-scanner
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)