### PR TITLE
fix: reduce PII exposure in diagnostics, logs, and test fixtures

### DIFF
--- a/scripts/cron-runner.sh
+++ b/scripts/cron-runner.sh
@@ -73,6 +73,8 @@ ${msg}" >/dev/null 2>&1 && return 0
     fi
 
     # Fallback to direct Telegram API
+    # Note: TELEGRAM_BOT_TOKEN is visible in process listings during curl execution.
+    # This is inherent to the Telegram Bot API URL scheme and cannot be avoided without a proxy.
     if [ -n "$TELEGRAM_BOT_TOKEN" ] && [ -n "$TELEGRAM_CHAT_ID" ]; then
         curl -sf --max-time 10 --connect-timeout 5 -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
             -d "chat_id=${TELEGRAM_CHAT_ID}" \

--- a/tests/fixtures/tweet_2019488673935552978.json
+++ b/tests/fixtures/tweet_2019488673935552978.json
@@ -7,8 +7,8 @@
   "likeCount": 13,
   "conversationId": "2019488673935552978",
   "author": {
-    "username": "undrvalue",
-    "name": "market participant"
+    "username": "test_user_fixture",
+    "name": "Test User"
   },
   "authorId": "2007674507587399680",
   "article": {
@@ -31,8 +31,8 @@
           },
           "core": {
             "created_at": "Sun Jan 04 04:44:43 +0000 2026",
-            "name": "market participant",
-            "screen_name": "undrvalue"
+            "name": "Test User",
+            "screen_name": "test_user_fixture"
           },
           "dm_permissions": {
             "can_dm": false
@@ -43,34 +43,34 @@
           "legacy": {
             "default_profile": true,
             "default_profile_image": false,
-            "description": "Semi-pro investor & analyst. Asymmetric stock picking. $10M+ AUM. Tech, consumer, value.",
+            "description": "Test account bio for fixture data.",
             "entities": {
               "description": {
                 "urls": []
               }
             },
             "fast_followers_count": 0,
-            "favourites_count": 501,
-            "followers_count": 1531,
-            "friends_count": 327,
+            "favourites_count": 100,
+            "followers_count": 100,
+            "friends_count": 50,
             "has_custom_timelines": false,
             "is_translator": false,
-            "listed_count": 33,
-            "media_count": 30,
-            "normal_followers_count": 1531,
+            "listed_count": 5,
+            "media_count": 10,
+            "normal_followers_count": 100,
             "pinned_tweet_ids_str": [
               "2010878894271004909"
             ],
             "possibly_sensitive": false,
             "profile_banner_url": "https://pbs.twimg.com/profile_banners/2007674507587399680/1767506863",
             "profile_interstitial_type": "",
-            "statuses_count": 413,
+            "statuses_count": 50,
             "translator_type": "none",
             "want_retweets": true,
             "withheld_in_countries": []
           },
           "location": {
-            "location": "California"
+            "location": "Test Location"
           },
           "media_permissions": {
             "can_media_tag": true
@@ -78,7 +78,7 @@
           "parody_commentary_fan_label": "None",
           "profile_image_shape": "Circle",
           "profile_bio": {
-            "description": "Semi-pro investor & analyst. Asymmetric stock picking. $10M+ AUM. Tech, consumer, value."
+            "description": "Test account bio for fixture data."
           },
           "privacy": {
             "protected": false

--- a/tests/test_article_processing.py
+++ b/tests/test_article_processing.py
@@ -242,7 +242,7 @@ def test_build_triage_text_prefers_article_body() -> None:
         "article_preview": "Preview",
         "article_text": "Deep dive " * 800,
     }
-    text = _build_triage_text(row)  # type: ignore[arg-type]
+    text = _build_triage_text(row)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     assert text.startswith("Capex note")
     assert "Deep dive" in text

--- a/tests/test_db_retweet_backfill.py
+++ b/tests/test_db_retweet_backfill.py
@@ -215,7 +215,7 @@ def test_insert_tweet_retries_transient_database_lock(monkeypatch):
     monkeypatch.setattr(db_connection_mod.time, "sleep", lambda delay: sleeps.append(delay))
 
     inserted = insert_tweet(
-        conn,  # type: ignore[arg-type]
+        conn,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         tweet_id="retry-1",
         author_handle="retry_user",
         content="retry content",

--- a/twag/cli/init_cmd.py
+++ b/twag/cli/init_cmd.py
@@ -147,14 +147,14 @@ def doctor():
 
     gemini_key = os.environ.get("GEMINI_API_KEY")
     if gemini_key:
-        console.print(f"  {status_icon(True)} GEMINI_API_KEY set ({gemini_key[:8]}...)")
+        console.print(f"  {status_icon(True)} GEMINI_API_KEY set ({len(gemini_key)} chars)")
     else:
         console.print(f"  {status_icon(False)} GEMINI_API_KEY not set")
         issues.append("Set GEMINI_API_KEY environment variable")
 
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     if anthropic_key:
-        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set ({anthropic_key[:8]}...)")
+        console.print(f"  {status_icon(True)} ANTHROPIC_API_KEY set ({len(anthropic_key)} chars)")
     else:
         console.print("  [yellow]WARN[/yellow] ANTHROPIC_API_KEY not set (enrichment disabled)")
         warnings.append("Set ANTHROPIC_API_KEY for enrichment features")

--- a/twag/fetcher/bird_cli.py
+++ b/twag/fetcher/bird_cli.py
@@ -2,7 +2,9 @@
 
 import json
 import logging
+import os
 import random
+import re
 import subprocess
 import tempfile
 import threading
@@ -19,6 +21,21 @@ log = logging.getLogger(__name__)
 _BIRD_RATE_LOCK = threading.Lock()
 _BIRD_LAST_CALL = 0.0
 _MAX_RETWEET_HYDRATIONS = 12
+
+# Patterns that may appear in bird stderr and should be redacted before logging
+_SENSITIVE_ENV_VARS = ("AUTH_TOKEN", "CT0", "GEMINI_API_KEY", "ANTHROPIC_API_KEY", "TELEGRAM_BOT_TOKEN")
+
+
+def _redact_stderr(text: str) -> str:
+    """Strip sensitive token values from bird stderr before logging."""
+    redacted = text
+    for var in _SENSITIVE_ENV_VARS:
+        val = os.environ.get(var)
+        if val and len(val) >= 8:
+            redacted = redacted.replace(val, f"[REDACTED {var}]")
+    # Also redact long hex-like tokens that may leak (32+ hex chars)
+    redacted = re.sub(r"[0-9a-fA-F]{32,}", "[REDACTED]", redacted)
+    return redacted
 
 
 @dataclass(frozen=True)
@@ -81,7 +98,8 @@ def _run_bird_once(
             tmp.seek(0)
             stdout = tmp.read()
         if result.stderr.strip():
-            lines = result.stderr.strip().splitlines()
+            redacted = _redact_stderr(result.stderr.strip())
+            lines = redacted.splitlines()
             meaningful = [ln for ln in lines if not ln.strip().startswith("\u2139")]
             if meaningful and log_failures:
                 level = logging.WARNING if result.returncode == 0 else logging.ERROR
@@ -105,7 +123,9 @@ def run_bird(args: list[str], timeout: int = 60, *, log_failures: bool = True) -
     # Build command with auth if available
     cmd = ["bird", *args]
 
-    # Add auth flags if we have the tokens
+    # Note: auth tokens are passed as CLI flags because bird CLI does not read
+    # them from environment variables. This makes them visible in `ps` output,
+    # which is acceptable for a single-user local tool.
     auth_token = env.get("AUTH_TOKEN")
     ct0 = env.get("CT0")
 


### PR DESCRIPTION
## Summary
- **Doctor output**: Replace API key prefix display (`key[:8]...`) with length-only confirmation (`N chars`) to avoid leaking key prefixes in terminal output
- **Bird CLI stderr**: Add `_redact_stderr()` helper that strips known sensitive env var values and long hex tokens from bird stderr before logging
- **Bird CLI auth**: Document that `--auth-token`/`--ct0` CLI flags are required (bird CLI does not read auth from env vars) and ps-visibility is an accepted tradeoff for a single-user local tool
- **Cron runner**: Document that `TELEGRAM_BOT_TOKEN` is inherently visible in process listings during `curl` execution (Telegram Bot API URL scheme limitation)
- **Test fixture**: Anonymize real Twitter user profile data in `tweet_2019488673935552978.json` (username, bio, location, follower counts replaced with synthetic placeholders)
- **Type checking**: Fix pre-existing `ty` suppression comments for compatibility with newer `ty` versions

## PII findings not changed (acceptable for single-user local tool)
- `fetch_log` handles in DB (operational data, not PII)
- `telegram_chat_id` in config (required for notifications)
- Context API response echoing tweet data (read-only from DB)
- `backup.sql.gz` (already gitignored, local-only)

## Test plan
- [x] All 193 tests pass
- [x] `ruff format` and `ruff check` pass
- [x] `ty check` passes (both v0.0.15 and v0.0.26)
- [x] Bird CLI auth flags are preserved (no breaking change to authenticated requests)

Nightshift-Task: pii-scanner
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: pii-scanner:/home/clifton/code/twag
task-type: pii-scanner
task-title: PII Exposure Scanner
iterations: 2
duration: 19m49s
nightshift:metadata -->
