### PR TITLE
Add missing docstrings to public API surfaces

### DIFF
--- a/twag/article_sections.py
+++ b/twag/article_sections.py
@@ -17,11 +17,13 @@ def _json_list(value: str | None) -> list[Any]:
 
 
 def normalize_horizon(value: Any) -> str:
+    """Normalize a time-horizon value by replacing underscores with spaces."""
     text = str(value or "").strip()
     return text.replace("_", " ") if text else ""
 
 
 def format_confidence(value: Any) -> str:
+    """Format a confidence value as a compact string (e.g. 0.85 → '0.85')."""
     if value is None:
         return ""
     if isinstance(value, bool):
@@ -32,6 +34,7 @@ def format_confidence(value: Any) -> str:
 
 
 def parse_primary_points(value: str | None, *, limit: int | None = None) -> list[dict[str, str]]:
+    """Parse a JSON string of primary points into cleaned dicts with point/reasoning/evidence."""
     points: list[dict[str, str]] = []
     for item in _json_list(value):
         if not isinstance(item, dict):
@@ -52,6 +55,7 @@ def parse_primary_points(value: str | None, *, limit: int | None = None) -> list
 
 
 def parse_action_items(value: str | None, *, limit: int | None = None) -> list[dict[str, str]]:
+    """Parse a JSON string of action items into cleaned dicts with action/trigger/horizon/confidence/tickers."""
     actions: list[dict[str, str]] = []
     for item in _json_list(value):
         if not isinstance(item, dict):

--- a/twag/cli/_progress.py
+++ b/twag/cli/_progress.py
@@ -28,18 +28,22 @@ class RichProgressReporter:
         self._total = 0
 
     def _description(self) -> str:
+        """Return the fixed-width task description for the progress bar."""
         return f"{self._label:<25s}"
 
     def update_status(self, message: str) -> None:
+        """Update the progress bar description text."""
         self._label = message
         self._progress.update(self._task_id, description=self._description())
 
     def advance(self, step: int = 1) -> None:
+        """Advance the progress bar by *step* units (clamped to total)."""
         step = max(step, 0)
         self._count = min(self._total, self._count + step)
         self._progress.update(self._task_id, advance=step, description=self._description())
 
     def set_total(self, total: int) -> None:
+        """Set the expected total, ensuring it is at least the current count."""
         total = max(total, self._count)
         self._total = total
         self._progress.update(self._task_id, total=total, description=self._description())
@@ -49,13 +53,13 @@ class NullProgressReporter:
     """No-op progress reporter for non-interactive / library use."""
 
     def update_status(self, message: str) -> None:
-        pass
+        """No-op: ignore status updates."""
 
     def advance(self, step: int = 1) -> None:
-        pass
+        """No-op: ignore progress advances."""
 
     def set_total(self, total: int) -> None:
-        pass
+        """No-op: ignore total changes."""
 
 
 def create_progress() -> Progress:

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -29,6 +29,8 @@ _network_expansion_lock = Lock()
 
 @dataclass
 class LinkNormalizationResult:
+    """Result of normalizing tweet links: cleaned display text, inline embeds, and external links."""
+
     display_text: str
     inline_tweet_links: list[dict[str, str]]
     external_links: list[dict[str, str]]

--- a/twag/media.py
+++ b/twag/media.py
@@ -7,6 +7,7 @@ from typing import Any
 
 
 def parse_media_items(raw: str | None) -> list[dict[str, Any]]:
+    """Deserialize a JSON media payload into a list of media-item dicts."""
     if not raw:
         return []
     try:
@@ -30,6 +31,7 @@ def parse_media_items(raw: str | None) -> list[dict[str, Any]]:
 
 
 def build_media_summary(items: list[dict[str, Any]]) -> str:
+    """Build a pipe-delimited one-line summary from analyzed media items."""
     parts: list[str] = []
     for item in items:
         prose_summary = (item.get("prose_summary") or "").strip()
@@ -48,6 +50,7 @@ def build_media_summary(items: list[dict[str, Any]]) -> str:
 
 
 def build_media_context(items: list[dict[str, Any]]) -> str:
+    """Build a multi-section text block describing each media item for LLM context."""
     sections: list[str] = []
     for idx, item in enumerate(items, start=1):
         kind = item.get("kind") or "image"

--- a/twag/models/scoring.py
+++ b/twag/models/scoring.py
@@ -19,6 +19,7 @@ class TriageResult(BaseModel):
     @field_validator("score")
     @classmethod
     def clamp_score(cls, v: float) -> float:
+        """Clamp the relevance score to the 0-10 range."""
         return max(0.0, min(10.0, float(v)))
 
 
@@ -73,6 +74,7 @@ class ActionableItem(BaseModel):
     @field_validator("confidence")
     @classmethod
     def clamp_confidence(cls, v: float) -> float:
+        """Clamp the confidence value to the 0-1 range."""
         return max(0.0, min(1.0, float(v)))
 
 

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -95,6 +95,7 @@ def ensure_media_analysis(
     vision_model: str | None = None,
     vision_provider: str | None = None,
 ) -> list[dict[str, Any]]:
+    """Analyze unprocessed media for a tweet, persisting results to the DB."""
     if not tweet_row["has_media"]:
         return []
 

--- a/twag/web/tweet_utils.py
+++ b/twag/web/tweet_utils.py
@@ -19,6 +19,7 @@ _TWEET_URL_RE = re.compile(
 
 
 def parse_created_at(value: str | datetime | None) -> datetime | None:
+    """Parse a created_at value into a datetime, accepting ISO strings or passthrough."""
     if value is None:
         return None
     if isinstance(value, datetime):
@@ -30,10 +31,12 @@ def parse_created_at(value: str | datetime | None) -> datetime | None:
 
 
 def extract_tweet_links(text: str) -> list[tuple[str, str]]:
+    """Return (tweet_id, full_url) pairs for all tweet/status URLs found in text."""
     return [(match.group(1), match.group(0)) for match in _TWEET_URL_RE.finditer(text)]
 
 
 def remove_tweet_links(text: str, links: list[tuple[str, str]], remove_ids: set[str]) -> str:
+    """Strip tweet URLs whose IDs are in *remove_ids* and collapse whitespace."""
     cleaned = text
     urls_to_remove: set[str] = set()
     for tweet_id, url in links:
@@ -52,6 +55,7 @@ def normalize_links_for_display(
     links: list[dict] | None,
     has_media: bool = False,
 ) -> LinkNormalizationResult:
+    """Normalize tweet links for web display, assuming URLs are already expanded."""
     return normalize_tweet_links(
         tweet_id=tweet_id,
         text=text,
@@ -62,16 +66,19 @@ def normalize_links_for_display(
 
 
 def parse_tweet_id_from_url(url: str | None) -> str | None:
+    """Extract the numeric tweet ID from a Twitter/X status URL."""
     return parse_tweet_status_id(url)
 
 
 def decode_html_entities(text: str | None) -> str | None:
+    """Unescape HTML entities (e.g. &amp; → &) in text, passing through None."""
     if text is None:
         return None
     return html.unescape(text)
 
 
 def quote_embed_from_row(row) -> dict[str, Any]:
+    """Build a quote-embed dict from a DB row for API responses."""
     created_at = parse_created_at(row["created_at"])
     return {
         "id": row["id"],


### PR DESCRIPTION
## Summary
- Added docstrings to 25+ undocumented public functions, classes, and methods across 7 files
- Covers web utilities, media helpers, article section parsers, processor triage, link utils dataclass, model validators, and CLI progress reporter methods
- No behavioral changes — docstring additions only

## Files
- `twag/web/tweet_utils.py` — 7 functions
- `twag/media.py` — 3 functions
- `twag/article_sections.py` — 4 functions
- `twag/processor/triage.py` — 1 function
- `twag/link_utils.py` — 1 dataclass
- `twag/models/scoring.py` — 2 validators
- `twag/cli/_progress.py` — 7 methods

## Test plan
- [x] `ruff format` — no changes needed
- [x] `ruff check` — all checks passed
- [x] `ty check` — all checks passed
- [x] `pytest` — all 193 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/home/clifton/code/twag
task-type: docs-backfill
task-title: Documentation Backfiller
iterations: 1
duration: 7m3s
nightshift:metadata -->
