### PR TITLE
Fix documentation drift across four docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,10 @@ FETCH → PROCESS → DIGEST
 ```
 
 **Core packages:**
-- `twag/models/` — Pydantic data models (tweet, scoring, media, links, config, API)
+- `twag/models/` — Pydantic data models (tweet, scoring, media, links, config, API, db_models)
 - `twag/auth.py` — Shared credential and env-file parsing
 - `twag/config.py` — Runtime config (paths, defaults, following file)
-- `twag/db/` — SQLite database layer (schema, connections, CRUD, search, maintenance, accounts, narratives, reactions, time utils)
+- `twag/db/` — SQLite database layer (schema, connections, tweets, search, maintenance, accounts, narratives, reactions, context_commands, prompts, time utils)
 - `twag/fetcher/` — bird CLI integration + tweet parsing/extraction
 - `twag/scorer/` — LLM scoring, prompts, and client management
 - `twag/processor/` — Pipeline orchestration (storage, dependencies, triage, pipeline)
@@ -33,6 +33,7 @@ FETCH → PROCESS → DIGEST
 - `twag/link_utils.py` — URL expansion and embed classification
 - `twag/article_visuals.py` — Visual selection for X Articles
 - `twag/article_sections.py` — Article section extraction
+- `twag/text_utils.py` — Text processing utilities
 - `twag/web/` — FastAPI backend (app, tweet_utils, routes: tweets, context, prompts, reactions)
 - `twag/web/frontend/` — React feed UI
 
@@ -66,7 +67,7 @@ metadata:
 ### Setup
 
 ```bash
-pip install -e ".[dev]"
+uv sync --group dev
 ```
 
 ### Lint & Format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ git clone https://github.com/clifton/twag.git
 cd twag
 
 # Install with dev dependencies
-pip install -e ".[dev]"
+uv sync --group dev
 
 # Install frontend dependencies
 cd twag/web/frontend

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -182,18 +182,21 @@ Tweets scoring 8+ will trigger Telegram alerts when you run `twag process --noti
 
 ### systemd (Linux)
 
-Create `~/.config/systemd/user/twag.service`:
+Create `~/.config/systemd/user/twag-aggregator.service`:
 
 ```ini
 [Unit]
 Description=TWAG Twitter Aggregator
+After=network.target
 
 [Service]
 Type=oneshot
 ExecStart=/bin/bash -c 'source ~/.env && twag fetch && twag process'
+WorkingDirectory=%h
+EnvironmentFile=%h/.env
 ```
 
-Create `~/.config/systemd/user/twag.timer`:
+Create `~/.config/systemd/user/twag-aggregator.timer`:
 
 ```ini
 [Unit]
@@ -202,6 +205,7 @@ Description=Run TWAG every 15 minutes
 [Timer]
 OnBootSec=5min
 OnUnitActiveSec=15min
+Persistent=true
 
 [Install]
 WantedBy=timers.target
@@ -211,7 +215,7 @@ Enable:
 
 ```bash
 systemctl --user daemon-reload
-systemctl --user enable --now twag.timer
+systemctl --user enable --now twag-aggregator.timer
 ```
 
 ### launchd (macOS)

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ twag db restore backup.sql --force
 
 ```bash
 # Install dev dependencies
-pip install -e ".[dev]"
+uv sync --group dev
 
 # Run tests
 pytest


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Add missing `db/` modules (`context_commands`, `prompts`, `tweets`), `db_models` to models list, and `text_utils.py` to core packages
- **CLAUDE.md, README.md, CONTRIBUTING.md**: Fix dev setup command from broken `pip install -e ".[dev]"` to `uv sync --group dev` (pyproject.toml uses `[dependency-groups]`, not `[project.optional-dependencies]`)
- **INSTALL.md**: Rename systemd service/timer from `twag` to `twag-aggregator` to match README.md and SUGGESTED_CRON_SCHEDULE.md; add missing `After`, `WorkingDirectory`, `EnvironmentFile`, and `Persistent` directives

## Test plan
- [ ] Verify `uv sync --group dev` installs dev dependencies correctly
- [ ] Confirm systemd unit names are consistent across all docs (`twag-aggregator`)
- [ ] Check CLAUDE.md module lists match actual files in `twag/db/` and `twag/models/`

Nightshift-Task: doc-drift
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: doc-drift:/home/clifton/code/twag
task-type: doc-drift
task-title: Doc Drift Detector
iterations: 1
duration: 4m37s
nightshift:metadata -->
