### PR TITLE
Add event taxonomy normalizer

### DIFF
--- a/twag/article_visuals.py
+++ b/twag/article_visuals.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import re
 from typing import Any
 
-_DATA_KINDS = {"chart", "table", "document", "screenshot"}
+from .taxonomy import MediaKind
+
+_DATA_KINDS = {MediaKind.CHART, MediaKind.TABLE, MediaKind.DOCUMENT, MediaKind.SCREENSHOT}
 _TEXTUAL_DATA_PATTERN = re.compile(
     r"\b(chart|graph|table|capex|revenue|margin|growth|yoy|qoq|forecast|projection|run[-\s]?rate|backlog|roi|ebitda|eps)\b"
 )
@@ -32,9 +34,9 @@ def _infer_kind(item: dict[str, Any]) -> str:
     if isinstance(item.get("chart"), dict) and (
         item["chart"].get("description") or item["chart"].get("insight") or item["chart"].get("implication")
     ):
-        return "chart"
+        return MediaKind.CHART
     if isinstance(item.get("table"), dict) and (item["table"].get("columns") or item["table"].get("summary")):
-        return "table"
+        return MediaKind.TABLE
     text_blob = _text_blob(
         item.get("short_description"),
         item.get("prose_summary"),
@@ -42,20 +44,20 @@ def _infer_kind(item: dict[str, Any]) -> str:
         item.get("alt_text"),
     )
     if _looks_data_text(text_blob):
-        return "chart"
+        return MediaKind.CHART
     return kind
 
 
 def _extract_takeaway(item: dict[str, Any], kind: str) -> str:
-    if kind == "chart":
+    if kind == MediaKind.CHART:
         raw_chart = item.get("chart")
         chart = raw_chart if isinstance(raw_chart, dict) else {}
         return str(chart.get("insight") or chart.get("implication") or chart.get("description") or "").strip()
-    if kind == "table":
+    if kind == MediaKind.TABLE:
         raw_table = item.get("table")
         table = raw_table if isinstance(raw_table, dict) else {}
         return str(table.get("summary") or table.get("description") or "").strip()
-    if kind in {"document", "screenshot"}:
+    if kind in {MediaKind.DOCUMENT, MediaKind.SCREENSHOT}:
         return str(item.get("prose_summary") or item.get("short_description") or "").strip()
     return str(item.get("short_description") or "").strip()
 
@@ -96,7 +98,7 @@ def build_article_visuals(
                 visuals.append(
                     {
                         "url": top_url,
-                        "kind": top_kind if top_kind in _DATA_KINDS else "chart",
+                        "kind": top_kind if top_kind in _DATA_KINDS else MediaKind.CHART,
                         "is_top": True,
                         "why_important": why_important,
                         "key_takeaway": key_takeaway,
@@ -116,8 +118,14 @@ def build_article_visuals(
             if not _is_relevant_visual(item, kind):
                 continue
             takeaway = _extract_takeaway(item, kind)
-            normalized_kind = kind if kind in _DATA_KINDS else "chart"
-            priority = {"chart": 0, "table": 1, "screenshot": 2, "document": 3}.get(normalized_kind, 9)
+            normalized_kind = kind if kind in _DATA_KINDS else MediaKind.CHART
+            _kind_priority: dict[str, int] = {
+                MediaKind.CHART: 0,
+                MediaKind.TABLE: 1,
+                MediaKind.SCREENSHOT: 2,
+                MediaKind.DOCUMENT: 3,
+            }
+            priority = _kind_priority.get(normalized_kind, 9)
             extras.append(
                 (
                     priority,

--- a/twag/models/__init__.py
+++ b/twag/models/__init__.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+from ..taxonomy import (
+    SIGNAL_TIER_RANK,
+    Category,
+    MediaKind,
+    ReactionType,
+    SignalTier,
+    score_to_signal_tier,
+)
 from .api import (
     CategoryCount,
     QuoteEmbed,
@@ -50,9 +58,11 @@ from .scoring import (
 from .tweet import TweetData
 
 __all__ = [
+    "SIGNAL_TIER_RANK",
     "AccountsConfig",
     "ActionableItem",
     "BirdConfig",
+    "Category",
     "CategoryCount",
     "ChartAnalysis",
     "ContextCommand",
@@ -65,6 +75,7 @@ __all__ = [
     "LinkNormalizationResult",
     "MediaAnalysisResult",
     "MediaItem",
+    "MediaKind",
     "NotificationConfig",
     "PathsConfig",
     "PrimaryPoint",
@@ -72,8 +83,10 @@ __all__ = [
     "Prompt",
     "QuoteEmbed",
     "Reaction",
+    "ReactionType",
     "ScoringConfig",
     "SearchResult",
+    "SignalTier",
     "TableAnalysis",
     "TickerCount",
     "TriageResult",
@@ -84,4 +97,5 @@ __all__ = [
     "TweetResponse",
     "VisionResult",
     "XArticleSummaryResult",
+    "score_to_signal_tier",
 ]

--- a/twag/models/scoring.py
+++ b/twag/models/scoring.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, field_validator
 
+from ..taxonomy import MediaKind, SignalTier
+
 
 class TriageResult(BaseModel):
     """Result of tweet triage scoring."""
@@ -25,7 +27,7 @@ class TriageResult(BaseModel):
 class EnrichmentResult(BaseModel):
     """Result of tweet enrichment analysis."""
 
-    signal_tier: str = "noise"
+    signal_tier: str = SignalTier.NOISE
     insight: str = ""
     implications: str = ""
     narratives: list[str] = []
@@ -45,7 +47,7 @@ class VisionResult(BaseModel):
 class MediaAnalysisResult(BaseModel):
     """Result of image/media analysis."""
 
-    kind: str = "other"
+    kind: str = MediaKind.OTHER
     short_description: str = ""
     prose_text: str = ""
     prose_summary: str = ""

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -31,13 +31,7 @@ from ..scorer import (
     summarize_x_article,
     triage_tweets_batch,
 )
-
-_SIGNAL_TIER_RANK = {
-    "noise": 0,
-    "news": 1,
-    "market_relevant": 2,
-    "high_signal": 3,
-}
+from ..taxonomy import SIGNAL_TIER_RANK, MediaKind, score_to_signal_tier
 
 
 def _normalized_worker_count(value: Any, fallback: int) -> int:
@@ -58,8 +52,8 @@ def _prefer_stronger_signal_tier(existing: str | None, candidate: str | None) ->
     if not candidate:
         return existing
 
-    existing_rank = _SIGNAL_TIER_RANK.get(str(existing), -1)
-    candidate_rank = _SIGNAL_TIER_RANK.get(str(candidate), -1)
+    existing_rank = SIGNAL_TIER_RANK.get(str(existing), -1)
+    candidate_rank = SIGNAL_TIER_RANK.get(str(candidate), -1)
     return candidate if candidate_rank > existing_rank else existing
 
 
@@ -165,7 +159,7 @@ def _merge_document_media(media_items: list[dict[str, Any]]) -> bool:
     doc_entries: list[tuple[int | None, int, str]] = []
     for idx, item in enumerate(media_items):
         kind = (item.get("kind") or "").lower()
-        if kind not in {"document", "screenshot"}:
+        if kind not in {MediaKind.DOCUMENT, MediaKind.SCREENSHOT}:
             continue
         text = (item.get("prose_text") or "").strip()
         if not text:
@@ -270,27 +264,27 @@ def _select_article_top_visual(
         if not candidate_text:
             continue
 
-        if kind in {"meme", "photo", "other", ""}:
+        if kind in {MediaKind.MEME, MediaKind.PHOTO, MediaKind.OTHER, ""}:
             continue
 
         has_numbers = bool(re.search(r"\d", candidate_text))
         overlap = len(_tokenize_for_overlap(candidate_text) & context_tokens) if context_tokens else 0
 
         # Gate non-chart visuals heavily to avoid irrelevant picks.
-        if kind in {"document", "screenshot"} and (overlap < 2 or not has_numbers):
+        if kind in {MediaKind.DOCUMENT, MediaKind.SCREENSHOT} and (overlap < 2 or not has_numbers):
             continue
-        if kind not in {"chart", "table", "document", "screenshot"}:
+        if kind not in {MediaKind.CHART, MediaKind.TABLE, MediaKind.DOCUMENT, MediaKind.SCREENSHOT}:
             continue
-        if kind in {"chart", "table"} and overlap == 0 and not has_numbers:
+        if kind in {MediaKind.CHART, MediaKind.TABLE} and overlap == 0 and not has_numbers:
             continue
 
-        base = 100.0 if kind in {"chart", "table"} else 70.0
+        base = 100.0 if kind in {MediaKind.CHART, MediaKind.TABLE} else 70.0
         score = base + (10.0 if has_numbers else 0.0) + float(overlap * 5)
 
         takeaway = ""
-        if kind == "chart":
+        if kind == MediaKind.CHART:
             takeaway = str(chart.get("insight") or chart.get("description") or "").strip()
-        elif kind == "table":
+        elif kind == MediaKind.TABLE:
             takeaway = str(table.get("summary") or table.get("description") or "").strip()
         if not takeaway:
             takeaway = str(item.get("prose_summary") or item.get("short_description") or "").strip()
@@ -549,14 +543,7 @@ def _triage_rows(
             if status_cb and tweet_row:
                 status_cb(f"Saving @{tweet_row['author_handle']}")
 
-            if result.score >= 8:
-                tier = "high_signal"
-            elif result.score >= 6:
-                tier = "market_relevant"
-            elif result.score >= 4:
-                tier = "news"
-            else:
-                tier = "noise"
+            tier = score_to_signal_tier(result.score)
 
             update_tweet_processing(
                 conn,

--- a/twag/renderer.py
+++ b/twag/renderer.py
@@ -11,6 +11,7 @@ from .config import get_digests_dir, load_config
 from .db import get_connection, get_tweet_by_id, get_tweets_for_digest, mark_tweet_in_digest
 from .fetcher import get_tweet_url
 from .link_utils import normalize_tweet_links
+from .taxonomy import SignalTier
 
 
 def _value(tweet: sqlite3.Row | dict, key: str, default=None):
@@ -55,12 +56,12 @@ def render_digest(
         news = []
 
         for tweet in tweets:
-            tier = tweet["signal_tier"] or "noise"
-            if tier == "high_signal":
+            tier = tweet["signal_tier"] or SignalTier.NOISE
+            if tier == SignalTier.HIGH_SIGNAL:
                 high_signal.append(tweet)
-            elif tier == "market_relevant":
+            elif tier == SignalTier.MARKET_RELEVANT:
                 market_relevant.append(tweet)
-            elif tier == "news":
+            elif tier == SignalTier.NEWS:
                 news.append(tweet)
 
         # Render markdown

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from twag.config import load_config
+from twag.taxonomy import Category, MediaKind, SignalTier
 
 from .llm_client import _call_llm, _call_llm_vision, _parse_json_response
 from .prompts import (
@@ -91,7 +92,7 @@ def triage_tweet(
         data = data[0]
 
     # Handle both old "category" (string) and new "categories" (array) format
-    categories = data.get("categories") or [data.get("category", "noise")]
+    categories = data.get("categories") or [data.get("category", Category.NOISE)]
     if isinstance(categories, str):
         categories = [categories]
 
@@ -185,7 +186,7 @@ def enrich_tweet(
         data = data[0]
 
     return EnrichmentResult(
-        signal_tier=data.get("signal_tier", "noise"),
+        signal_tier=data.get("signal_tier", SignalTier.NOISE),
         insight=data.get("insight", ""),
         implications=data.get("implications", ""),
         narratives=data.get("narratives", []),
@@ -362,7 +363,7 @@ def analyze_image(
         table = {}
 
     return MediaAnalysisResult(
-        kind=(data.get("kind", "other") or "other").lower(),
+        kind=(data.get("kind", MediaKind.OTHER) or MediaKind.OTHER).lower(),
         short_description=(data.get("short_description") or "").strip(),
         prose_text=(data.get("prose_text") or "").strip(),
         prose_summary=(data.get("prose_summary") or "").strip(),

--- a/twag/taxonomy.py
+++ b/twag/taxonomy.py
@@ -1,0 +1,97 @@
+"""Canonical constants for tweet classification axes.
+
+Every scoring, routing, and display decision that references a signal tier,
+category, media kind, or reaction type should import from here instead of
+using inline string literals.  Prompt text in scorer/prompts.py and
+db/prompts.py is intentionally left as-is (LLM instruction strings).
+"""
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Minimal StrEnum backport for Python 3.10."""
+
+# ── Signal tier ──────────────────────────────────────────────────────────
+
+
+class SignalTier(StrEnum):
+    NOISE = "noise"
+    NEWS = "news"
+    MARKET_RELEVANT = "market_relevant"
+    HIGH_SIGNAL = "high_signal"
+
+
+SIGNAL_TIER_RANK: dict[str, int] = {
+    SignalTier.NOISE: 0,
+    SignalTier.NEWS: 1,
+    SignalTier.MARKET_RELEVANT: 2,
+    SignalTier.HIGH_SIGNAL: 3,
+}
+
+
+def score_to_signal_tier(score: float) -> str:
+    """Map a numeric relevance score to its signal tier string."""
+    if score >= 8:
+        return SignalTier.HIGH_SIGNAL
+    if score >= 6:
+        return SignalTier.MARKET_RELEVANT
+    if score >= 4:
+        return SignalTier.NEWS
+    return SignalTier.NOISE
+
+
+# ── Category ─────────────────────────────────────────────────────────────
+
+
+class Category(StrEnum):
+    FED_POLICY = "fed_policy"
+    INFLATION = "inflation"
+    JOB_MARKET = "job_market"
+    MACRO_DATA = "macro_data"
+    EARNINGS = "earnings"
+    EQUITIES = "equities"
+    RATES_FX = "rates_fx"
+    CREDIT = "credit"
+    BANKS = "banks"
+    CONSUMER_SPENDING = "consumer_spending"
+    CAPEX = "capex"
+    COMMODITIES = "commodities"
+    ENERGY = "energy"
+    METALS_MINING = "metals_mining"
+    GEOPOLITICAL = "geopolitical"
+    SANCTIONS = "sanctions"
+    TECH_BUSINESS = "tech_business"
+    AI_ADVANCEMENT = "ai_advancement"
+    CRYPTO = "crypto"
+    NOISE = "noise"
+
+
+# ── Media kind ───────────────────────────────────────────────────────────
+
+
+class MediaKind(StrEnum):
+    CHART = "chart"
+    TABLE = "table"
+    DOCUMENT = "document"
+    SCREENSHOT = "screenshot"
+    MEME = "meme"
+    PHOTO = "photo"
+    OTHER = "other"
+
+
+# ── Reaction type ────────────────────────────────────────────────────────
+
+
+class ReactionType(StrEnum):
+    BOOST = ">>"
+    UP = ">"
+    DOWN = "<"
+    MUTE_AUTHOR = "x_author"
+    MUTE_TOPIC = "x_topic"

--- a/twag/web/routes/reactions.py
+++ b/twag/web/routes/reactions.py
@@ -14,6 +14,7 @@ from ...db import (
     insert_reaction,
     mute_account,
 )
+from ...taxonomy import ReactionType
 
 router = APIRouter(tags=["reactions"])
 
@@ -42,12 +43,12 @@ async def create_reaction(request: Request, reaction: ReactionCreate) -> dict[st
     db_path = request.app.state.db_path
 
     # Validate reaction type
-    valid_types = {">>", ">", "<", "x_author", "x_topic"}
+    valid_types = set(ReactionType)
     if reaction.reaction_type not in valid_types:
         return {"error": f"Invalid reaction type. Must be one of: {valid_types}"}
 
     # Handle mute actions
-    if reaction.reaction_type == "x_author":
+    if reaction.reaction_type == ReactionType.MUTE_AUTHOR:
         if not reaction.target:
             return {"error": "target (author handle) required for x_author reaction"}
 


### PR DESCRIPTION
## Summary
- Introduce `twag/taxonomy.py` with `StrEnum` classes for the four classification axes: `SignalTier`, `Category`, `MediaKind`, `ReactionType`
- Add `SIGNAL_TIER_RANK` mapping and `score_to_signal_tier()` helper to centralize score-to-tier logic
- Replace scattered string literals across 8 files with canonical imports from `taxonomy.py`, eliminating duplication and typo risk

## Scope
- Python backend constants only — prompt text in `scorer/prompts.py` and `db/prompts.py` left as-is (LLM instruction strings)
- DB schema column names unchanged (no migration needed)
- Frontend TypeScript files out of scope

## Files modified
- `twag/taxonomy.py` (new) — canonical enum definitions
- `twag/models/__init__.py` — re-export taxonomy types
- `twag/models/scoring.py` — use `SignalTier`/`MediaKind` defaults
- `twag/processor/triage.py` — replace `_SIGNAL_TIER_RANK` dict and inline tier/kind strings
- `twag/scorer/scoring.py` — replace fallback string literals
- `twag/renderer.py` — replace signal tier comparisons
- `twag/web/routes/reactions.py` — replace `valid_types` inline set with `ReactionType` enum
- `twag/article_visuals.py` — replace media kind string literals

## Test plan
- [x] `uv run ruff format` — all files formatted
- [x] `uv run ruff check` — no lint errors
- [x] `uv run ty check` — passes (2 pre-existing test-file diagnostics unrelated to this change)
- [x] `uv run pytest` — all 193 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: event-taxonomy:/home/clifton/code/twag
task-type: event-taxonomy
task-title: Event Taxonomy Normalizer
iterations: 1
duration: 10m13s
nightshift:metadata -->
