### PR TITLE
feat: backward-compatibility shims for removed APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ skip_empty = true
 [tool.ty.environment]
 python-version = "3.10"
 
+[tool.ty.src]
+exclude = [".claude/worktrees/**"]
+
 [tool.ty.analysis]
 allowed-unresolved-imports = ["google.*", "google.**", "anthropic.*", "anthropic.**"]
 

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -1,0 +1,225 @@
+"""Verify backward-compatibility shims for APIs removed in v0.2.
+
+Each test imports the removed symbol from its old location and asserts that
+(a) the import succeeds, (b) a DeprecationWarning is emitted, and
+(c) the returned object is usable or delegates correctly.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# twag.config: get_memory_dir, get_workspace_path
+# ---------------------------------------------------------------------------
+
+
+class TestConfigShims:
+    def test_get_memory_dir_warns_and_delegates(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TWAG_DATA_DIR", str(tmp_path))
+        from twag.config import get_memory_dir
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = get_memory_dir()
+        assert result == tmp_path
+        assert any("get_memory_dir" in str(x.message) for x in w)
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+    def test_get_workspace_path_warns_and_delegates(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TWAG_DATA_DIR", str(tmp_path))
+        from twag.config import get_workspace_path
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = get_workspace_path()
+        assert result == tmp_path
+        assert any("get_workspace_path" in str(x.message) for x in w)
+        assert any(issubclass(x.category, DeprecationWarning) for x in w)
+
+
+# ---------------------------------------------------------------------------
+# twag.scorer: VisionResult, triage_tweet
+# ---------------------------------------------------------------------------
+
+
+class TestScorerShims:
+    def test_vision_result_alias(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from twag.scorer import VisionResult
+
+        from twag.scorer import MediaAnalysisResult
+
+        assert VisionResult is MediaAnalysisResult
+        assert any("VisionResult" in str(x.message) for x in w)
+
+    def test_triage_tweet_is_callable(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from twag.scorer import triage_tweet
+
+        assert callable(triage_tweet)
+        assert any("triage_tweet" in str(x.message) for x in w)
+
+
+# ---------------------------------------------------------------------------
+# twag.processor: run_full_cycle
+# ---------------------------------------------------------------------------
+
+
+class TestProcessorShims:
+    def test_run_full_cycle_is_callable(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            from twag.processor import run_full_cycle
+
+        assert callable(run_full_cycle)
+        assert any("run_full_cycle" in str(x.message) for x in w)
+
+
+# ---------------------------------------------------------------------------
+# twag.web.tweet_utils: extract_tweet_links, remove_tweet_links,
+#                        parse_tweet_id_from_url
+# ---------------------------------------------------------------------------
+
+
+class TestWebTweetUtilsShims:
+    def test_extract_tweet_links_warns(self):
+        from twag.web.tweet_utils import extract_tweet_links
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = extract_tweet_links(
+                "Check https://x.com/user/status/12345 out",
+            )
+
+        assert result == [("12345", "https://x.com/user/status/12345")]
+        assert any("extract_tweet_links" in str(x.message) for x in w)
+
+    def test_remove_tweet_links_warns(self):
+        from twag.web.tweet_utils import remove_tweet_links
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = remove_tweet_links(
+                "See https://x.com/u/status/111 here",
+                [("111", "https://x.com/u/status/111")],
+                {"111"},
+            )
+
+        assert "https://x.com" not in result
+        assert any("remove_tweet_links" in str(x.message) for x in w)
+
+    def test_parse_tweet_id_from_url_warns(self):
+        from twag.web.tweet_utils import parse_tweet_id_from_url
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = parse_tweet_id_from_url(
+                "https://twitter.com/user/status/99999",
+            )
+
+        assert result == "99999"
+        assert any("parse_tweet_id_from_url" in str(x.message) for x in w)
+
+    def test_parse_tweet_id_from_url_none(self):
+        from twag.web.tweet_utils import parse_tweet_id_from_url
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assert parse_tweet_id_from_url(None) is None
+
+
+# ---------------------------------------------------------------------------
+# twag.models: shim package
+# ---------------------------------------------------------------------------
+
+
+class TestModelsShim:
+    def test_direct_re_exports(self):
+        """Symbols that map to real dataclasses import without warning."""
+        from twag.models import (
+            EnrichmentResult,
+            LinkNormalizationResult,
+            MediaAnalysisResult,
+            TriageResult,
+            XArticleSummaryResult,
+        )
+
+        assert EnrichmentResult is not None
+        assert MediaAnalysisResult is not None
+        assert TriageResult is not None
+        assert XArticleSummaryResult is not None
+        assert LinkNormalizationResult is not None
+
+    def test_vision_result_warns(self):
+        import twag.models
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            VR = twag.models.VisionResult
+
+        from twag.scorer import MediaAnalysisResult
+
+        assert VR is MediaAnalysisResult
+        assert any("VisionResult" in str(x.message) for x in w)
+
+    def test_removed_symbol_raises(self):
+        import twag.models
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            with pytest.raises(AttributeError, match=r"removed in v0\.2"):
+                _ = twag.models.TweetData
+
+    def test_unknown_attr_raises(self):
+        import twag.models
+
+        with pytest.raises(AttributeError, match="no attribute"):
+            _ = twag.models.CompletelyBogusName
+
+
+# ---------------------------------------------------------------------------
+# API surface snapshots — catch accidental removals from __all__
+# ---------------------------------------------------------------------------
+
+
+class TestAPISurface:
+    def test_scorer_all_contains_expected(self):
+        import twag.scorer
+
+        expected = {
+            "EnrichmentResult",
+            "MediaAnalysisResult",
+            "TriageResult",
+            "XArticleSummaryResult",
+            "triage_tweets_batch",
+            "enrich_tweet",
+            "analyze_media",
+            "analyze_image",
+            "summarize_tweet",
+            "summarize_document_text",
+            "summarize_x_article",
+            # compat shims
+            "VisionResult",
+            "triage_tweet",
+        }
+        assert expected <= set(twag.scorer.__all__)
+
+    def test_processor_all_contains_expected(self):
+        import twag.processor
+
+        expected = {
+            "process_unprocessed",
+            "enrich_high_signal",
+            "reprocess_today_quoted",
+            "fetch_and_store",
+            "fetch_and_store_bookmarks",
+            "ensure_media_analysis",
+            # compat shim
+            "run_full_cycle",
+        }
+        assert expected <= set(twag.processor.__all__)

--- a/twag/_compat.py
+++ b/twag/_compat.py
@@ -1,0 +1,19 @@
+"""Backward-compatibility shims for APIs removed in v0.2.
+
+Each shim re-exports or wraps the replacement API and emits a
+DeprecationWarning directing callers to the new location.
+Shims will be removed in v0.3.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+
+def _deprecated(old: str, new: str, *, removal: str = "v0.3") -> None:
+    """Emit a DeprecationWarning for a moved/removed API."""
+    warnings.warn(
+        f"{old} is deprecated and will be removed in {removal}. Use {new} instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )

--- a/twag/config.py
+++ b/twag/config.py
@@ -178,3 +178,20 @@ def get_digests_dir() -> Path:
 def get_following_path() -> Path:
     """Get the following list path."""
     return get_data_dir() / "following.txt"
+
+
+# Backward-compatibility shims (removed in v0.2, will be deleted in v0.3)
+def get_memory_dir() -> Path:
+    """Deprecated: use get_data_dir() instead."""
+    from twag._compat import _deprecated
+
+    _deprecated("twag.config.get_memory_dir", "twag.config.get_data_dir")
+    return get_data_dir()
+
+
+def get_workspace_path() -> Path:
+    """Deprecated: use get_data_dir() instead."""
+    from twag._compat import _deprecated
+
+    _deprecated("twag.config.get_workspace_path", "twag.config.get_data_dir")
+    return get_data_dir()

--- a/twag/models/__init__.py
+++ b/twag/models/__init__.py
@@ -1,0 +1,90 @@
+"""Backward-compatibility shim for twag.models (removed in v0.2).
+
+The twag.models package was removed because its Pydantic mirrors of internal
+dataclasses were unused. This shim re-exports the canonical types so that
+existing ``from twag.models import ...`` statements keep working temporarily.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+# Link normalization — canonical home is twag.link_utils
+from twag.link_utils import LinkNormalizationResult
+
+# Scoring result types — canonical home is twag.scorer.scoring
+from twag.scorer.scoring import (
+    EnrichmentResult,
+    MediaAnalysisResult,
+    TriageResult,
+    XArticleSummaryResult,
+)
+
+
+def __getattr__(name: str):
+    _REMOVED = {
+        # Former twag.models.scoring
+        "VisionResult": ("twag.scorer.MediaAnalysisResult", MediaAnalysisResult),
+        "PrimaryPoint": None,
+        "ActionableItem": None,
+        # Former twag.models.api
+        "QuoteEmbed": None,
+        "CategoryCount": None,
+        "TickerCount": None,
+        "TweetResponse": None,
+        "TweetListResponse": None,
+        # Former twag.models.config
+        "LLMConfig": None,
+        "ScoringConfig": None,
+        "NotificationConfig": None,
+        "AccountsConfig": None,
+        "FetchConfig": None,
+        "ProcessingConfig": None,
+        "PathsConfig": None,
+        "BirdConfig": None,
+        "TwagConfig": None,
+        # Former twag.models.db_models
+        "SearchResult": None,
+        "Reaction": None,
+        "Prompt": None,
+        "ContextCommand": None,
+        "FeedTweet": None,
+        # Former twag.models.links
+        "TweetLink": None,
+        "InlineTweetLink": None,
+        "ExternalLink": None,
+        # Former twag.models.media
+        "ChartAnalysis": None,
+        "TableAnalysis": None,
+        "MediaItem": None,
+        # Former twag.models.tweet
+        "TweetData": None,
+    }
+
+    if name in _REMOVED:
+        entry = _REMOVED[name]
+        if entry is not None:
+            new_name, obj = entry
+            warnings.warn(
+                f"twag.models.{name} is deprecated and will be removed in v0.3. Use {new_name} instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return obj
+        warnings.warn(
+            f"twag.models.{name} was removed in v0.2 and has no replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise AttributeError(f"twag.models.{name} was removed in v0.2 with no replacement")
+
+    raise AttributeError(f"module 'twag.models' has no attribute {name!r}")
+
+
+__all__ = [
+    "EnrichmentResult",
+    "LinkNormalizationResult",
+    "MediaAnalysisResult",
+    "TriageResult",
+    "XArticleSummaryResult",
+]

--- a/twag/processor/__init__.py
+++ b/twag/processor/__init__.py
@@ -70,6 +70,64 @@ __all__ = [
     "fetch_and_store_bookmarks",
     "process_unprocessed",
     "reprocess_today_quoted",
+    "run_full_cycle",
     "store_bookmarked_tweets",
     "store_fetched_tweets",
 ]
+
+
+def __getattr__(name: str):
+    if name == "run_full_cycle":
+        from twag._compat import _deprecated
+
+        _deprecated(
+            "twag.processor.run_full_cycle",
+            "twag.processor.process_unprocessed + twag.processor.enrich_high_signal",
+        )
+
+        def run_full_cycle(
+            fetch_home: bool = True,
+            fetch_tier1: bool = True,
+            process: bool = True,
+            enrich: bool = True,
+        ) -> dict:
+            """Deprecated orchestrator — use process_unprocessed + enrich_high_signal."""
+            from twag.db import get_accounts, get_connection
+
+            stats: dict = {
+                "home_fetched": 0,
+                "home_new": 0,
+                "tier1_fetched": 0,
+                "tier1_new": 0,
+                "processed": 0,
+                "enriched": 0,
+            }
+            if fetch_home:
+                fetched, new = fetch_and_store(source="home", count=100)
+                stats["home_fetched"] = fetched
+                stats["home_new"] = new
+            if fetch_tier1:
+                with get_connection() as conn:
+                    tier1 = get_accounts(conn, tier=1)
+                for account in tier1:
+                    try:
+                        fetched, new = fetch_and_store(
+                            source="user",
+                            handle=account["handle"],
+                            count=20,
+                        )
+                        stats["tier1_fetched"] += fetched
+                        stats["tier1_new"] += new
+                    except Exception:
+                        pass
+            if process:
+                results = process_unprocessed(limit=100)
+                stats["processed"] = len(results)
+            if enrich:
+                results = enrich_high_signal(limit=20)
+                stats["enriched"] = len(results)
+            return stats
+
+        return run_full_cycle
+
+    raise AttributeError(f"module 'twag.processor' has no attribute {name!r}")

--- a/twag/scorer/__init__.py
+++ b/twag/scorer/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "EnrichmentResult",
     "MediaAnalysisResult",
     "TriageResult",
+    "VisionResult",
     "XArticleSummaryResult",
     "_call_llm",
     "_call_llm_vision",
@@ -37,5 +38,48 @@ __all__ = [
     "summarize_document_text",
     "summarize_tweet",
     "summarize_x_article",
+    "triage_tweet",
     "triage_tweets_batch",
 ]
+
+
+def __getattr__(name: str):
+    if name == "VisionResult":
+        from twag._compat import _deprecated
+
+        _deprecated("twag.scorer.VisionResult", "twag.scorer.MediaAnalysisResult")
+        return MediaAnalysisResult
+
+    if name == "triage_tweet":
+        from twag._compat import _deprecated
+
+        _deprecated("twag.scorer.triage_tweet", "twag.scorer.triage_tweets_batch")
+
+        def triage_tweet(
+            tweet_id: str,
+            tweet_text: str,
+            handle: str,
+            model: str | None = None,
+            provider: str | None = None,
+        ) -> TriageResult:
+            """Deprecated single-tweet triage — wraps triage_tweets_batch."""
+            results = triage_tweets_batch(
+                [{"id": tweet_id, "text": tweet_text, "handle": handle}],
+                model=model,
+                provider=provider,
+            )
+            return (
+                results[0]
+                if results
+                else TriageResult(
+                    tweet_id=tweet_id,
+                    score=0.0,
+                    categories=[],
+                    summary="",
+                    tickers=[],
+                )
+            )
+
+        return triage_tweet
+
+    raise AttributeError(f"module 'twag.scorer' has no attribute {name!r}")

--- a/twag/web/tweet_utils.py
+++ b/twag/web/tweet_utils.py
@@ -1,6 +1,7 @@
 """Shared tweet content utilities."""
 
 import html
+import re as _re
 from datetime import datetime
 from typing import Any
 
@@ -56,3 +57,57 @@ def quote_embed_from_row(row) -> dict[str, Any]:
         "content": decode_html_entities(row["content"]),
         "created_at": created_at.isoformat() if created_at else None,
     }
+
+
+# Backward-compatibility shims (removed in v0.2, will be deleted in v0.3)
+_TWEET_URL_RE = _re.compile(
+    r"https?://(?:www\.)?(?:mobile\.)?(?:x|twitter)\.com/(?:i/(?:web/)?|[^/]+/)?status/(\d+)(?:\?[^\s]+)?",
+    _re.IGNORECASE,
+)
+
+
+def extract_tweet_links(text: str) -> list[tuple[str, str]]:
+    """Deprecated: use twag.link_utils functions directly."""
+    from twag._compat import _deprecated
+
+    _deprecated(
+        "twag.web.tweet_utils.extract_tweet_links",
+        "twag.link_utils.normalize_tweet_links",
+    )
+    return [(m.group(1), m.group(0)) for m in _TWEET_URL_RE.finditer(text)]
+
+
+def remove_tweet_links(
+    text: str,
+    links: list[tuple[str, str]],
+    remove_ids: set[str],
+) -> str:
+    """Deprecated: use twag.link_utils.remove_urls_from_text directly."""
+    from twag._compat import _deprecated
+
+    from ..link_utils import remove_urls_from_text
+
+    _deprecated(
+        "twag.web.tweet_utils.remove_tweet_links",
+        "twag.link_utils.remove_urls_from_text",
+    )
+    urls_to_remove: set[str] = set()
+    for tweet_id, url in links:
+        if tweet_id in remove_ids:
+            urls_to_remove.add(url)
+    cleaned = remove_urls_from_text(text, urls_to_remove)
+    cleaned = _re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
+def parse_tweet_id_from_url(url: str | None) -> str | None:
+    """Deprecated: use twag.link_utils.parse_tweet_status_id directly."""
+    from twag._compat import _deprecated
+
+    from ..link_utils import parse_tweet_status_id
+
+    _deprecated(
+        "twag.web.tweet_utils.parse_tweet_id_from_url",
+        "twag.link_utils.parse_tweet_status_id",
+    )
+    return parse_tweet_status_id(url)


### PR DESCRIPTION
## Summary
- Add deprecation-warning shims for all public APIs removed in commit 125a579 (dead-code cleanup)
- Shims cover: `twag.models` package, `twag.config.get_memory_dir`/`get_workspace_path`, `twag.scorer.VisionResult`/`triage_tweet`, `twag.processor.run_full_cycle`, and `twag.web.tweet_utils.extract_tweet_links`/`remove_tweet_links`/`parse_tweet_id_from_url`
- Each shim re-exports or wraps the replacement API and emits a `DeprecationWarning` directing users to the new location, with planned removal in v0.3

## Test plan
- [x] 15 new tests in `tests/test_backward_compat.py` verify all shims are importable and emit `DeprecationWarning`
- [x] API surface snapshot tests catch accidental removals from `__all__`
- [x] All pre-commit checks pass (ruff format, ruff check, ty check, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)