### PR TITLE
fix: security hardening — 4 foot-gun fixes

### DIFF
--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -8,13 +8,132 @@ from fastapi.testclient import TestClient
 
 from twag.db import get_connection, init_db, insert_tweet, update_tweet_processing
 from twag.db.accounts import get_accounts, upsert_account
-from twag.db.search import get_feed_tweets, search_tweets
+from twag.db.search import get_feed_tweets, sanitize_fts5_query, search_tweets
+from twag.notifier import format_alert
 from twag.web.app import create_app
 from twag.web.routes.context import (
     ALLOWED_COMMANDS,
+    _resolve_command,
     _run_command,
+    _validate_arguments,
     _validate_command_template,
 )
+
+# --- HTML injection tests (notifier) ---
+
+
+class TestHTMLEscaping:
+    def test_escapes_angle_brackets_in_content(self):
+        msg = format_alert(
+            tweet_id="123",
+            author_handle="user",
+            content="<script>alert('xss')</script>",
+            category="macro",
+            summary="test summary",
+        )
+        assert "<script>" not in msg
+        assert "&lt;script&gt;" in msg
+
+    def test_escapes_ampersand_in_content(self):
+        msg = format_alert(
+            tweet_id="123",
+            author_handle="user",
+            content="AT&T earnings beat",
+            category="equities",
+            summary="test",
+        )
+        assert "AT&amp;T" in msg
+
+    def test_escapes_author_handle(self):
+        msg = format_alert(
+            tweet_id="123",
+            author_handle="<b>evil</b>",
+            content="hello",
+            category="macro",
+            summary="test",
+        )
+        assert "<b>" not in msg
+        assert "&lt;b&gt;" in msg
+
+    def test_escapes_summary(self):
+        msg = format_alert(
+            tweet_id="123",
+            author_handle="user",
+            content="hello",
+            category="macro",
+            summary='<a href="http://evil.com">click</a>',
+        )
+        assert "<a href" not in msg
+        assert "&lt;a href" in msg
+
+    def test_preserves_normal_content(self):
+        msg = format_alert(
+            tweet_id="123",
+            author_handle="realuser",
+            content="Fed holds rates steady at 5.25%",
+            category="fed_policy",
+            summary="Rate decision hold",
+        )
+        assert "realuser" in msg
+        assert "Fed holds rates steady" in msg
+        assert "Rate decision hold" in msg
+
+    def test_empty_summary_no_crash(self):
+        msg = format_alert(
+            tweet_id="123",
+            author_handle="user",
+            content="test",
+            category="macro",
+            summary="",
+        )
+        assert "user" in msg
+
+
+# --- FTS5 query sanitization tests ---
+
+
+class TestFTS5Sanitization:
+    def test_strips_braces(self):
+        assert sanitize_fts5_query("test {injection}") == "test injection"
+
+    def test_strips_brackets(self):
+        assert sanitize_fts5_query("test [column]") == "test column"
+
+    def test_strips_parens(self):
+        assert sanitize_fts5_query("test (nested)") == "test nested"
+
+    def test_strips_caret(self):
+        assert sanitize_fts5_query("^test") == "test"
+
+    def test_preserves_normal_query(self):
+        assert sanitize_fts5_query("fed rate hike") == "fed rate hike"
+
+    def test_preserves_quoted_phrase(self):
+        result = sanitize_fts5_query('"interest rate"')
+        assert '"interest rate"' in result
+
+    def test_preserves_prefix_wildcard(self):
+        assert sanitize_fts5_query("earn*") == "earn*"
+
+    def test_preserves_and_or_not(self):
+        assert sanitize_fts5_query("fed AND rate NOT hike") == "fed AND rate NOT hike"
+
+    def test_empty_after_sanitization_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            sanitize_fts5_query("{}[]()^")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            sanitize_fts5_query("   ")
+
+    def test_search_tweets_catches_bad_fts_query(self, tmp_path):
+        """Malformed FTS5 queries return ValueError, not sqlite3.OperationalError."""
+        db_path = _create_fts_db(tmp_path)
+        with get_connection(db_path, readonly=True) as conn:
+            # Pure structural chars get sanitized to empty, raising ValueError
+            with pytest.raises(ValueError, match="empty"):
+                search_tweets(conn, "{}[]()")
+
 
 # --- Command template validation tests ---
 
@@ -100,6 +219,68 @@ class TestRunCommandValidation:
         _, stderr, code = asyncio.run(_run_command("echo hello; rm -rf /"))
         assert code == -1
         assert "metacharacters" in stderr
+
+
+# --- Argument validation tests ---
+
+
+class TestArgumentValidation:
+    def test_rejects_absolute_path_for_cat(self):
+        err = _validate_arguments("cat", ["/etc/passwd"])
+        assert err is not None
+        assert "Absolute paths" in err
+
+    def test_rejects_absolute_path_for_grep(self):
+        err = _validate_arguments("grep", ["-r", "password", "/etc/"])
+        assert err is not None
+        assert "Absolute paths" in err
+
+    def test_rejects_path_traversal(self):
+        err = _validate_arguments("cat", ["../../etc/passwd"])
+        assert err is not None
+        assert "traversal" in err
+
+    def test_allows_relative_path(self):
+        err = _validate_arguments("cat", ["data/tweets.json"])
+        assert err is None
+
+    def test_allows_flags(self):
+        err = _validate_arguments("grep", ["-i", "pattern", "file.txt"])
+        assert err is None
+
+    def test_no_restrictions_on_echo(self):
+        err = _validate_arguments("echo", ["/etc/passwd"])
+        assert err is None
+
+    def test_no_restrictions_on_twag(self):
+        err = _validate_arguments("twag", ["/some/path"])
+        assert err is None
+
+    def test_run_command_blocks_absolute_path_at_runtime(self):
+        _, stderr, code = asyncio.run(_run_command("cat /etc/passwd"))
+        assert code == -1
+        assert "Absolute paths" in stderr
+
+    def test_run_command_blocks_traversal_at_runtime(self):
+        _, stderr, code = asyncio.run(_run_command("head ../../etc/shadow"))
+        assert code == -1
+        assert "traversal" in stderr
+
+
+# --- Resolve command tests ---
+
+
+class TestResolveCommand:
+    def test_resolves_echo(self):
+        path = _resolve_command("echo")
+        assert path is not None
+        assert path.startswith("/")
+
+    def test_rejects_unknown_command(self):
+        assert _resolve_command("python3") is None
+
+    def test_rejects_empty(self):
+        assert _resolve_command("") is None
 
 
 # --- API endpoint validation tests ---
@@ -286,3 +467,21 @@ class TestCORSConfig:
         # Should list explicit methods, not wildcard
         assert "*" not in allowed
         assert "GET" in allowed
+
+
+# --- Web server defaults test ---
+
+
+class TestWebServerDefaults:
+    def test_default_host_is_localhost(self):
+        from twag.cli.web import web
+
+        # Click params are accessible via the command's params list
+        host_param = next(p for p in web.params if p.name == "host")
+        assert host_param.default == "127.0.0.1"
+
+    def test_default_reload_is_false(self):
+        from twag.cli.web import web
+
+        reload_param = next(p for p in web.params if p.name == "reload")
+        assert reload_param.default is False

--- a/twag/cli/web.py
+++ b/twag/cli/web.py
@@ -8,9 +8,9 @@ from ._console import console
 
 
 @click.command()
-@click.option("--host", "-h", default="0.0.0.0", help="Host to bind to")
+@click.option("--host", "-h", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", "-p", default=5173, help="Port to bind to")
-@click.option("--reload/--no-reload", default=True, help="Auto-reload on code changes")
+@click.option("--reload/--no-reload", default=False, help="Auto-reload on code changes")
 @click.option("--dev", is_flag=True, default=False, help="Dev mode: start Vite + FastAPI with HMR")
 def web(host: str, port: int, reload: bool, dev: bool):
     """Start the web interface server."""

--- a/twag/db/search.py
+++ b/twag/db/search.py
@@ -1,12 +1,16 @@
 """Search and feed query operations."""
 
 import json
+import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 from .time_utils import parse_time_range
+
+# FTS5 operators that are valid in queries — strip anything else that looks structural
+_FTS5_UNSAFE_PATTERN = re.compile(r"[{}()\[\]^]")
 
 
 @dataclass
@@ -94,6 +98,21 @@ EQUITY_KEYWORDS = {
 }
 
 
+def sanitize_fts5_query(query: str) -> str:
+    """Sanitize a user-supplied FTS5 query string.
+
+    Strips characters that can cause FTS5 parse errors or unexpected behaviour
+    (braces, brackets, carets) while preserving legitimate search operators
+    (AND, OR, NOT, quoted phrases, prefix wildcards).
+
+    Raises ValueError if the query is empty after sanitization.
+    """
+    cleaned = _FTS5_UNSAFE_PATTERN.sub("", query).strip()
+    if not cleaned:
+        raise ValueError("Search query is empty after sanitization")
+    return cleaned
+
+
 def query_suggests_equity_context(query: str) -> bool:
     """Check if a search query suggests equity-relevant context."""
     query_lower = query.lower()
@@ -138,6 +157,9 @@ def search_tweets(
     Returns:
         List of SearchResult objects
     """
+    # Sanitize user-supplied FTS5 query
+    query = sanitize_fts5_query(query)
+
     # Parse time_range if provided
     if time_range:
         parsed_since, parsed_until = parse_time_range(time_range)
@@ -225,7 +247,10 @@ def search_tweets(
         LIMIT ? OFFSET ?
     """
 
-    cursor = conn.execute(sql, params)
+    try:
+        cursor = conn.execute(sql, params)
+    except sqlite3.OperationalError as exc:
+        raise ValueError(f"Invalid search query: {query!r}") from exc
     results = []
 
     for row in cursor.fetchall():

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -1,5 +1,6 @@
 """Telegram notifications for high-signal tweets."""
 
+import html
 import logging
 import os
 from datetime import datetime
@@ -75,6 +76,11 @@ def format_alert(
     tickers: list[str] | None = None,
 ) -> str:
     """Format a high-signal alert message."""
+    # HTML-escape user-controlled fields to prevent injection via parse_mode=HTML
+    author_handle = html.escape(author_handle)
+    content = html.escape(content)
+    summary = html.escape(summary) if summary else summary
+
     # Truncate content for preview
     preview = content[:150] + "..." if len(content) > 150 else content
 

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import re
 import shlex
+import shutil
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -284,6 +285,29 @@ def _extract_tweet_variables(tweet_row) -> dict[str, str]:
     return variables
 
 
+def _resolve_command(name: str) -> str | None:
+    """Resolve an allowed command name to its absolute path via shutil.which()."""
+    if name not in ALLOWED_COMMANDS:
+        return None
+    return shutil.which(name)
+
+
+# Commands whose arguments may reference file paths — block absolute paths
+# and path-traversal sequences to prevent arbitrary file reads.
+_FILE_READING_COMMANDS = frozenset({"cat", "head", "tail", "grep", "sed", "rg"})
+
+
+def _validate_arguments(base_cmd: str, args: list[str]) -> str | None:
+    """Validate command arguments. Returns an error message or None if OK."""
+    if base_cmd in _FILE_READING_COMMANDS:
+        for arg in args:
+            if arg.startswith("/"):
+                return f"Absolute paths are not allowed as arguments to '{base_cmd}'"
+            if ".." in arg:
+                return f"Path traversal ('..') is not allowed in arguments to '{base_cmd}'"
+    return None
+
+
 async def _run_command(command: str, timeout: float = 30.0) -> tuple[str, str, int]:
     """Run a command and return (stdout, stderr, returncode).
 
@@ -299,6 +323,18 @@ async def _run_command(command: str, timeout: float = 30.0) -> tuple[str, str, i
             return "", f"Command '{base_cmd}' is not in the allowed list", -1
         if _DANGEROUS_PATTERN.search(command):
             return "", "Command contains forbidden shell metacharacters", -1
+
+        # Validate arguments for file-reading commands
+        arg_error = _validate_arguments(base_cmd, args[1:])
+        if arg_error:
+            return "", arg_error, -1
+
+        # Resolve to absolute path to avoid PATH manipulation
+        abs_path = _resolve_command(base_cmd)
+        if not abs_path:
+            return "", f"Command '{base_cmd}' not found on system", -1
+        args[0] = abs_path
+
         proc = await asyncio.create_subprocess_exec(
             *args,
             stdout=asyncio.subprocess.PIPE,


### PR DESCRIPTION
## Summary
- **HTML injection in Telegram alerts**: HTML-escape `author_handle`, `content`, and `summary` in `format_alert()` before interpolation into `parse_mode=HTML` messages
- **FTS5 query injection**: Add `sanitize_fts5_query()` to strip dangerous syntax chars (`{}[]()^`) and wrap FTS5 execute in `try/except sqlite3.OperationalError` to surface clean `ValueError` instead of leaking DB internals
- **Context command hardening**: Resolve allowed commands to absolute paths via `shutil.which()`, block absolute path arguments and `..` traversal for file-reading commands (`cat`, `grep`, `head`, `tail`, `sed`, `rg`)
- **Unsafe web server defaults**: Change default host from `0.0.0.0` to `127.0.0.1` and default reload from `True` to `False`

## Test plan
- [x] 59 tests in `tests/test_security_hardening.py` covering all 4 fixes
- [x] HTML escaping: angle brackets, ampersands, author handles, summaries
- [x] FTS5 sanitization: strips dangerous chars, preserves valid operators, rejects empty queries
- [x] Argument validation: blocks absolute paths, path traversal, allows relative paths and flags
- [x] Command resolution: resolves to absolute paths, rejects unknown commands
- [x] Web defaults: verifies Click parameter defaults
- [x] Full test suite passes (273 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)