### PR TITLE
feat: versioned schema evolution framework

### DIFF
--- a/tests/test_schema_evolution.py
+++ b/tests/test_schema_evolution.py
@@ -1,0 +1,179 @@
+"""Tests for the versioned schema migration framework."""
+
+import sqlite3
+
+import pytest
+
+from twag.db.connection import get_connection, init_db
+from twag.db.migrations import (
+    TARGET_VERSION,
+    check_schema,
+    get_schema_version,
+    run_migrations,
+    set_schema_version,
+)
+from twag.db.schema import SCHEMA
+
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    """Create a fully initialized database via init_db."""
+    db_path = tmp_path / "test.db"
+    init_db(db_path)
+    with get_connection(db_path) as conn:
+        yield conn
+
+
+@pytest.fixture
+def bare_db(tmp_path):
+    """Create a database with only the base SCHEMA applied (version 0)."""
+    db_path = tmp_path / "bare.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+class TestFreshInit:
+    """Tests for a freshly initialized database."""
+
+    def test_sets_target_version(self, fresh_db):
+        version = get_schema_version(fresh_db)
+        assert version == TARGET_VERSION
+
+    def test_target_version_is_positive(self):
+        assert TARGET_VERSION >= 1
+
+    def test_all_expected_tables_exist(self, fresh_db):
+        cursor = fresh_db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+        tables = {row[0] for row in cursor.fetchall()}
+        expected = {
+            "tweets",
+            "accounts",
+            "narratives",
+            "tweet_narratives",
+            "fetch_log",
+            "reactions",
+            "prompts",
+            "prompt_history",
+            "context_commands",
+            "alert_log",
+            "metrics",
+        }
+        assert expected.issubset(tables)
+
+    def test_schema_check_passes(self, fresh_db):
+        result = check_schema(fresh_db)
+        assert result["ok"] is True
+        assert result["version_ok"] is True
+        assert result["missing_tables"] == []
+        assert result["missing_columns"] == {}
+
+
+class TestMigrationFromZero:
+    """Tests for migrating from version 0 to latest."""
+
+    def test_bare_db_starts_at_version_zero(self, bare_db):
+        assert get_schema_version(bare_db) == 0
+
+    def test_migration_reaches_target(self, bare_db):
+        new_version = run_migrations(bare_db)
+        assert new_version == TARGET_VERSION
+
+    def test_migration_adds_alert_log(self, bare_db):
+        # alert_log is already in SCHEMA, but migration should still succeed
+        run_migrations(bare_db)
+        cursor = bare_db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='alert_log'")
+        assert cursor.fetchone() is not None
+
+    def test_migration_adds_metrics(self, bare_db):
+        run_migrations(bare_db)
+        cursor = bare_db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='metrics'")
+        assert cursor.fetchone() is not None
+
+    def test_migration_creates_indexes(self, bare_db):
+        run_migrations(bare_db)
+        cursor = bare_db.execute("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_tweets_reply'")
+        assert cursor.fetchone() is not None
+
+
+class TestIdempotency:
+    """Running migrations multiple times should be safe."""
+
+    def test_double_run_same_version(self, bare_db):
+        run_migrations(bare_db)
+        v1 = get_schema_version(bare_db)
+        # Run again
+        run_migrations(bare_db)
+        v2 = get_schema_version(bare_db)
+        assert v1 == v2 == TARGET_VERSION
+
+    def test_idempotent_on_fresh_db(self, fresh_db):
+        """init_db already ran migrations; running again should be a no-op."""
+        v_before = get_schema_version(fresh_db)
+        run_migrations(fresh_db)
+        v_after = get_schema_version(fresh_db)
+        assert v_before == v_after == TARGET_VERSION
+
+
+class TestSchemaCheck:
+    """Tests for the schema drift detection."""
+
+    def test_clean_db_no_drift(self, fresh_db):
+        result = check_schema(fresh_db)
+        assert result["ok"] is True
+
+    def test_detects_version_mismatch(self, fresh_db):
+        set_schema_version(fresh_db, 0)
+        result = check_schema(fresh_db)
+        assert result["version_ok"] is False
+        assert result["ok"] is False
+
+    def test_detects_missing_table(self, fresh_db):
+        fresh_db.execute("DROP TABLE IF EXISTS metrics")
+        result = check_schema(fresh_db)
+        assert "metrics" in result["missing_tables"]
+        assert result["ok"] is False
+
+    def test_detects_missing_column(self, tmp_path):
+        """Create a DB with a stripped-down tweets table to detect missing columns."""
+        db_path = tmp_path / "stripped.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        # Minimal tweets table missing many columns
+        conn.execute("CREATE TABLE tweets (id TEXT PRIMARY KEY, author_handle TEXT, content TEXT)")
+        # Create other required tables so only column drift is detected
+        conn.executescript("""
+            CREATE TABLE accounts (handle TEXT PRIMARY KEY);
+            CREATE TABLE narratives (id INTEGER PRIMARY KEY);
+            CREATE TABLE tweet_narratives (tweet_id TEXT, narrative_id INTEGER);
+            CREATE TABLE fetch_log (id INTEGER PRIMARY KEY);
+            CREATE TABLE reactions (id INTEGER PRIMARY KEY);
+            CREATE TABLE prompts (id INTEGER PRIMARY KEY);
+            CREATE TABLE prompt_history (id INTEGER PRIMARY KEY);
+            CREATE TABLE context_commands (id INTEGER PRIMARY KEY);
+            CREATE TABLE alert_log (id INTEGER PRIMARY KEY);
+            CREATE TABLE metrics (name TEXT);
+        """)
+        set_schema_version(conn, TARGET_VERSION)
+        conn.commit()
+
+        result = check_schema(conn)
+        assert result["version_ok"] is True
+        assert "tweets" in result["missing_columns"]
+        assert "created_at" in result["missing_columns"]["tweets"]
+        assert result["ok"] is False
+        conn.close()
+
+
+class TestVersionHelpers:
+    """Tests for get/set schema version."""
+
+    def test_roundtrip(self, bare_db):
+        set_schema_version(bare_db, 42)
+        assert get_schema_version(bare_db) == 42
+
+    def test_default_is_zero(self, bare_db):
+        assert get_schema_version(bare_db) == 0

--- a/twag/cli/db_cmd.py
+++ b/twag/cli/db_cmd.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import rich_click as click
 
 from ..config import get_database_path
-from ..db import dump_sql, get_connection, init_db, rebuild_fts, restore_sql
+from ..db import check_schema, dump_sql, get_connection, init_db, rebuild_fts, restore_sql
+from ..db.migrations import TARGET_VERSION
 from ._console import console
 
 
@@ -144,4 +145,56 @@ def db_restore(input_file: str, force: bool):
         )
     except Exception as e:
         console.print(f"[red]Error restoring database: {e}[/red]")
+        sys.exit(1)
+
+
+@db.command("schema-version")
+def db_schema_version():
+    """Show current and target schema versions."""
+    db_file = get_database_path()
+    if not db_file.exists():
+        console.print("[red]Database not found.[/red]")
+        sys.exit(1)
+
+    with get_connection(readonly=True) as conn:
+        cursor = conn.execute("PRAGMA user_version")
+        current = cursor.fetchone()[0]
+
+    console.print(f"Current schema version: {current}")
+    console.print(f"Target schema version:  {TARGET_VERSION}")
+    if current < TARGET_VERSION:
+        console.print("[yellow]Database needs migration. Run: twag db init[/yellow]")
+    else:
+        console.print("[green]Schema is up to date.[/green]")
+
+
+@db.command("check")
+def db_check():
+    """Check database schema for drift against expected state."""
+    db_file = get_database_path()
+    if not db_file.exists():
+        console.print("[red]Database not found.[/red]")
+        sys.exit(1)
+
+    with get_connection(readonly=True) as conn:
+        result = check_schema(conn)
+
+    console.print(f"Schema version: {result['version_current']}/{result['version_target']}")
+
+    if not result["version_ok"]:
+        console.print(
+            f"[yellow]Version mismatch: have {result['version_current']}, need {result['version_target']}[/yellow]",
+        )
+
+    if result["missing_tables"]:
+        console.print(f"[red]Missing tables: {', '.join(result['missing_tables'])}[/red]")
+
+    if result["missing_columns"]:
+        for table, cols in result["missing_columns"].items():
+            console.print(f"[red]Missing columns in {table}: {', '.join(cols)}[/red]")
+
+    if result["ok"]:
+        console.print("[green]Schema check passed — no drift detected.[/green]")
+    else:
+        console.print("[yellow]Run 'twag db init' to apply pending migrations.[/yellow]")
         sys.exit(1)

--- a/twag/db/__init__.py
+++ b/twag/db/__init__.py
@@ -28,6 +28,7 @@ from .maintenance import (
     prune_old_tweets,
     restore_sql,
 )
+from .migrations import TARGET_VERSION, check_schema, get_schema_version
 from .narratives import (
     archive_stale_narratives,
     get_active_narratives,
@@ -94,6 +95,7 @@ __all__ = [
     "EQUITY_KEYWORDS",
     "FTS_SCHEMA",
     "SCHEMA",
+    "TARGET_VERSION",
     "ContextCommand",
     "FeedTweet",
     "Prompt",
@@ -105,6 +107,7 @@ __all__ = [
     "apply_account_decay",
     "archive_stale_narratives",
     "boost_account",
+    "check_schema",
     "delete_context_command",
     "delete_reaction",
     "demote_account",
@@ -127,6 +130,7 @@ __all__ = [
     "get_reactions_summary",
     "get_reactions_with_tweets",
     "get_recent_alert_count",
+    "get_schema_version",
     "get_tweet_by_id",
     "get_tweet_stats",
     "get_tweets_by_ids",

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -78,97 +78,14 @@ def commit_with_retry(conn: sqlite3.Connection) -> None:
 
 
 def _run_migrations(conn: sqlite3.Connection) -> None:
-    """Run schema migrations for existing databases."""
+    """Run versioned schema migrations, then FTS init and prompt seeding."""
+    from .migrations import run_migrations
     from .prompts import seed_prompts
 
-    # Check tweets table columns
-    cursor = conn.execute("PRAGMA table_info(tweets)")
-    tweet_columns = {row[1] for row in cursor.fetchall()}
+    run_migrations(conn)
 
-    if "bookmarked" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN bookmarked INTEGER DEFAULT 0")
-        conn.execute("ALTER TABLE tweets ADD COLUMN bookmarked_at TIMESTAMP")
-
-    if "content_summary" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN content_summary TEXT")
-
-    if "media_items" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN media_items TEXT")
-
-    if "analysis_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN analysis_json TEXT")
-
-    if "is_retweet" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN is_retweet INTEGER DEFAULT 0")
-
-    if "retweeted_by_handle" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN retweeted_by_handle TEXT")
-
-    if "retweeted_by_name" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN retweeted_by_name TEXT")
-
-    if "original_tweet_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_tweet_id TEXT")
-
-    if "original_author_handle" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_author_handle TEXT")
-
-    if "original_author_name" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_author_name TEXT")
-
-    if "original_content" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN original_content TEXT")
-
-    if "is_x_article" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN is_x_article INTEGER DEFAULT 0")
-
-    if "article_title" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_title TEXT")
-
-    if "article_preview" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_preview TEXT")
-
-    if "article_text" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_text TEXT")
-
-    if "article_summary_short" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_summary_short TEXT")
-
-    if "article_primary_points_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_primary_points_json TEXT")
-
-    if "article_action_items_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_action_items_json TEXT")
-
-    if "article_top_visual_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_top_visual_json TEXT")
-
-    if "article_processed_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN article_processed_at TIMESTAMP")
-
-    if "links_json" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN links_json TEXT")
-
-    if "in_reply_to_tweet_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN in_reply_to_tweet_id TEXT")
-
-    if "conversation_id" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN conversation_id TEXT")
-
-    if "links_expanded_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN links_expanded_at TIMESTAMP")
-
-    if "quote_reprocessed_at" not in tweet_columns:
-        conn.execute("ALTER TABLE tweets ADD COLUMN quote_reprocessed_at TIMESTAMP")
-
-    # Check accounts table columns
-    cursor = conn.execute("PRAGMA table_info(accounts)")
-    account_columns = {row[1] for row in cursor.fetchall()}
-
-    if "last_fetched_at" not in account_columns:
-        conn.execute("ALTER TABLE accounts ADD COLUMN last_fetched_at TIMESTAMP")
-
-    # Initialize FTS5 if not present
+    # Initialize FTS5 if not present (idempotent, kept outside versioned
+    # migrations because it uses executescript which auto-commits)
     _init_fts(conn)
 
     # Seed prompts if table exists but is empty
@@ -177,42 +94,6 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
         seeded = seed_prompts(conn)
         if seeded > 0:
             conn.commit()
-
-    # Create alert_log table if not present (for notification rate limiting)
-    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='alert_log'")
-    if not cursor.fetchone():
-        conn.execute("""
-            CREATE TABLE IF NOT EXISTS alert_log (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                tweet_id TEXT,
-                sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                chat_id TEXT,
-                FOREIGN KEY (tweet_id) REFERENCES tweets(id)
-            )
-        """)
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_alert_log_sent ON alert_log(sent_at DESC)")
-
-    # Ensure performance indexes exist on existing databases
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tweets_processed_score "
-        "ON tweets(processed_at, relevance_score DESC, created_at DESC)",
-    )
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_tweets_author ON tweets(author_handle)")
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_tweets_signal_tier ON tweets(signal_tier)")
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_tweets_bookmarked ON tweets(bookmarked) WHERE bookmarked = 1")
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tweets_quote ON tweets(quote_tweet_id) WHERE quote_tweet_id IS NOT NULL",
-    )
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tweets_reply "
-        "ON tweets(in_reply_to_tweet_id) WHERE in_reply_to_tweet_id IS NOT NULL",
-    )
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_fetch_log_endpoint ON fetch_log(endpoint, executed_at DESC)")
-
-    # Ensure metrics table exists
-    from ..metrics import ensure_metrics_table
-
-    ensure_metrics_table(conn)
 
 
 def _init_fts(conn: sqlite3.Connection) -> None:

--- a/twag/db/migrations.py
+++ b/twag/db/migrations.py
@@ -1,0 +1,285 @@
+"""Versioned schema migration framework using PRAGMA user_version.
+
+Each migration is a (version, description, callable) entry. Migrations run
+in order when the database's user_version is below the target version.
+SQLite lacks ALTER TABLE ... IF NOT EXISTS, so column additions use
+try/except to stay idempotent.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections.abc import Callable
+
+log = logging.getLogger(__name__)
+
+# Type alias for a migration entry
+Migration = tuple[int, str, list[str]]
+
+# ---------------------------------------------------------------------------
+# Migration registry — append-only, never reorder or delete entries.
+# Each entry: (version, description, sql_statements)
+# SQL statements are executed in order. For ALTER TABLE, wrap with
+# _safe_alter() at runtime since SQLite does not support IF NOT EXISTS.
+# ---------------------------------------------------------------------------
+
+_ALTER_COLUMNS_V1: list[tuple[str, str]] = [
+    # tweets table columns
+    ("tweets", "bookmarked INTEGER DEFAULT 0"),
+    ("tweets", "bookmarked_at TIMESTAMP"),
+    ("tweets", "content_summary TEXT"),
+    ("tweets", "media_items TEXT"),
+    ("tweets", "analysis_json TEXT"),
+    ("tweets", "is_retweet INTEGER DEFAULT 0"),
+    ("tweets", "retweeted_by_handle TEXT"),
+    ("tweets", "retweeted_by_name TEXT"),
+    ("tweets", "original_tweet_id TEXT"),
+    ("tweets", "original_author_handle TEXT"),
+    ("tweets", "original_author_name TEXT"),
+    ("tweets", "original_content TEXT"),
+    ("tweets", "is_x_article INTEGER DEFAULT 0"),
+    ("tweets", "article_title TEXT"),
+    ("tweets", "article_preview TEXT"),
+    ("tweets", "article_text TEXT"),
+    ("tweets", "article_summary_short TEXT"),
+    ("tweets", "article_primary_points_json TEXT"),
+    ("tweets", "article_action_items_json TEXT"),
+    ("tweets", "article_top_visual_json TEXT"),
+    ("tweets", "article_processed_at TIMESTAMP"),
+    ("tweets", "links_json TEXT"),
+    ("tweets", "in_reply_to_tweet_id TEXT"),
+    ("tweets", "conversation_id TEXT"),
+    ("tweets", "links_expanded_at TIMESTAMP"),
+    ("tweets", "quote_reprocessed_at TIMESTAMP"),
+    # accounts table columns
+    ("accounts", "last_fetched_at TIMESTAMP"),
+]
+
+# SQL statements that are safe to run idempotently (CREATE IF NOT EXISTS)
+_IDEMPOTENT_SQL_V1: list[str] = [
+    # alert_log table
+    """CREATE TABLE IF NOT EXISTS alert_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        tweet_id TEXT,
+        sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        chat_id TEXT,
+        FOREIGN KEY (tweet_id) REFERENCES tweets(id)
+    )""",
+    "CREATE INDEX IF NOT EXISTS idx_alert_log_sent ON alert_log(sent_at DESC)",
+    # Performance indexes
+    (
+        "CREATE INDEX IF NOT EXISTS idx_tweets_processed_score "
+        "ON tweets(processed_at, relevance_score DESC, created_at DESC)"
+    ),
+    "CREATE INDEX IF NOT EXISTS idx_tweets_author ON tweets(author_handle)",
+    "CREATE INDEX IF NOT EXISTS idx_tweets_signal_tier ON tweets(signal_tier)",
+    "CREATE INDEX IF NOT EXISTS idx_tweets_bookmarked ON tweets(bookmarked) WHERE bookmarked = 1",
+    ("CREATE INDEX IF NOT EXISTS idx_tweets_quote ON tweets(quote_tweet_id) WHERE quote_tweet_id IS NOT NULL"),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_tweets_reply "
+        "ON tweets(in_reply_to_tweet_id) WHERE in_reply_to_tweet_id IS NOT NULL"
+    ),
+    "CREATE INDEX IF NOT EXISTS idx_fetch_log_endpoint ON fetch_log(endpoint, executed_at DESC)",
+    # Metrics table
+    """CREATE TABLE IF NOT EXISTS metrics (
+        name TEXT NOT NULL,
+        type TEXT NOT NULL,
+        value REAL NOT NULL,
+        labels_json TEXT,
+        recorded_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    )""",
+    "CREATE INDEX IF NOT EXISTS idx_metrics_name ON metrics(name, recorded_at DESC)",
+]
+
+
+def _safe_alter(conn: sqlite3.Connection, table: str, column_def: str) -> None:
+    """Add a column to a table, ignoring 'duplicate column' errors."""
+    try:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column_def}")
+    except sqlite3.OperationalError as e:
+        if "duplicate column" not in str(e).lower():
+            raise
+
+
+def _run_v1(conn: sqlite3.Connection) -> None:
+    """Version 1: consolidate all existing ad-hoc migrations."""
+    for table, col_def in _ALTER_COLUMNS_V1:
+        _safe_alter(conn, table, col_def)
+
+    for sql in _IDEMPOTENT_SQL_V1:
+        conn.execute(sql)
+
+
+# ---------------------------------------------------------------------------
+# Registry: list of (version, description, callable)
+# ---------------------------------------------------------------------------
+
+MigrationEntry = tuple[int, str, Callable[[sqlite3.Connection], None]]
+
+MIGRATIONS: list[MigrationEntry] = [
+    (1, "Consolidate ad-hoc column additions, indexes, alert_log, and metrics table", _run_v1),
+]
+
+# The target version is the highest version in the registry
+TARGET_VERSION: int = MIGRATIONS[-1][0] if MIGRATIONS else 0
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_schema_version(conn: sqlite3.Connection) -> int:
+    """Return the current PRAGMA user_version."""
+    cursor = conn.execute("PRAGMA user_version")
+    return cursor.fetchone()[0]
+
+
+def set_schema_version(conn: sqlite3.Connection, version: int) -> None:
+    """Set PRAGMA user_version (not parameterized — SQLite limitation)."""
+    conn.execute(f"PRAGMA user_version = {int(version)}")
+
+
+def run_migrations(conn: sqlite3.Connection) -> int:
+    """Run all pending migrations and return the new schema version.
+
+    Migrations are executed in version order. After each migration the
+    user_version is bumped so that a crash mid-sequence resumes correctly.
+    """
+    current = get_schema_version(conn)
+
+    for version, description, fn in MIGRATIONS:
+        if current >= version:
+            continue
+        log.info("Running migration v%d: %s", version, description)
+        fn(conn)
+        set_schema_version(conn, version)
+        current = version
+
+    return current
+
+
+def check_schema(conn: sqlite3.Connection) -> dict:
+    """Compare expected schema against live database.
+
+    Returns a dict with keys:
+    - version_current: int
+    - version_target: int
+    - version_ok: bool
+    - missing_tables: list[str]
+    - missing_columns: dict[str, list[str]]  (table -> column names)
+    - ok: bool  (True if everything matches)
+    """
+    version_current = get_schema_version(conn)
+    version_ok = version_current >= TARGET_VERSION
+
+    # Expected tables (from SCHEMA + migrations)
+    expected_tables = {
+        "tweets",
+        "accounts",
+        "narratives",
+        "tweet_narratives",
+        "fetch_log",
+        "reactions",
+        "prompts",
+        "prompt_history",
+        "context_commands",
+        "alert_log",
+        "metrics",
+    }
+
+    # Get actual tables
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+    actual_tables = {row[0] for row in cursor.fetchall()}
+    # Exclude FTS internal tables
+    actual_tables = {t for t in actual_tables if not t.startswith("tweets_fts")}
+
+    missing_tables = sorted(expected_tables - actual_tables)
+
+    # Expected columns per table (only check tables that exist)
+    expected_columns: dict[str, set[str]] = {
+        "tweets": {
+            "id",
+            "author_handle",
+            "author_name",
+            "content",
+            "created_at",
+            "first_seen_at",
+            "source",
+            "processed_at",
+            "relevance_score",
+            "category",
+            "summary",
+            "content_summary",
+            "signal_tier",
+            "tickers",
+            "analysis_json",
+            "has_quote",
+            "quote_tweet_id",
+            "in_reply_to_tweet_id",
+            "conversation_id",
+            "has_media",
+            "media_analysis",
+            "media_items",
+            "has_link",
+            "links_json",
+            "link_summary",
+            "is_x_article",
+            "article_title",
+            "article_preview",
+            "article_text",
+            "article_summary_short",
+            "article_primary_points_json",
+            "article_action_items_json",
+            "article_top_visual_json",
+            "article_processed_at",
+            "links_expanded_at",
+            "quote_reprocessed_at",
+            "is_retweet",
+            "retweeted_by_handle",
+            "retweeted_by_name",
+            "original_tweet_id",
+            "original_author_handle",
+            "original_author_name",
+            "original_content",
+            "included_in_digest",
+            "bookmarked",
+            "bookmarked_at",
+        },
+        "accounts": {
+            "handle",
+            "display_name",
+            "tier",
+            "weight",
+            "category",
+            "tweets_seen",
+            "tweets_kept",
+            "avg_relevance_score",
+            "last_high_signal_at",
+            "last_fetched_at",
+            "added_at",
+            "auto_promoted",
+            "muted",
+        },
+    }
+
+    missing_columns: dict[str, list[str]] = {}
+    for table, cols in expected_columns.items():
+        if table in actual_tables:
+            cursor = conn.execute(f"PRAGMA table_info({table})")
+            actual_cols = {row[1] for row in cursor.fetchall()}
+            missing = sorted(cols - actual_cols)
+            if missing:
+                missing_columns[table] = missing
+
+    ok = version_ok and not missing_tables and not missing_columns
+
+    return {
+        "version_current": version_current,
+        "version_target": TARGET_VERSION,
+        "version_ok": version_ok,
+        "missing_tables": missing_tables,
+        "missing_columns": missing_columns,
+        "ok": ok,
+    }


### PR DESCRIPTION
## Summary
- Replace 130+ lines of ad-hoc column-presence migration checks in `_run_migrations()` with a PRAGMA `user_version`-based migration registry in `twag/db/migrations.py`
- Add `twag db schema-version` and `twag db check` CLI subcommands for inspecting schema version and detecting drift (missing tables, columns, version mismatch)
- Add 17 unit tests covering fresh init, migration from v0, idempotency, and drift detection

## Test plan
- [x] `uv run pytest tests/test_schema_evolution.py` — 17 tests pass
- [x] `uv run pytest` — all 372 tests pass
- [x] `uv run ruff check` and `uv run ruff format` clean
- [x] `uv run ty check` clean
- [ ] Manual: `twag db schema-version` prints current/target versions
- [ ] Manual: `twag db check` reports no drift on initialized DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)