### PR TITLE
feat: add commit-msg hook enforcing conventional commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,4 +167,8 @@ If command behavior changes, update `README.md` and `SKILL.md` in the same PR.
 - Keep commits focused and atomic
 - Run formatting/lint/tests before committing
 - Don't commit temporary artifacts unless explicitly requested
-- Write descriptive commit messages
+- Use [Conventional Commits](https://www.conventionalcommits.org/) format: `type(scope): description`
+  - Allowed types: `feat`, `fix`, `docs`, `chore`, `perf`, `refactor`, `test`, `ci`, `build`, `style`, `revert`
+  - Description must start with a lowercase letter
+  - Subject line max 72 characters
+  - A `commit-msg` hook enforces this automatically (symlinked from `scripts/hooks/commit-msg`)

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit_msg_file="$1"
+first_line=$(head -n1 "$commit_msg_file")
+
+merge_re="^Merge "
+fixup_re="^(fixup|squash)! "
+conv_re="^(feat|fix|docs|chore|perf|refactor|test|ci|build|style|revert)(\([a-zA-Z0-9_-]+\))?!?: [a-z]"
+
+# Allow merge commits
+if [[ "$first_line" =~ $merge_re ]]; then
+    exit 0
+fi
+
+# Allow fixup/squash commits
+if [[ "$first_line" =~ $fixup_re ]]; then
+    exit 0
+fi
+
+if ! [[ "$first_line" =~ $conv_re ]]; then
+    echo "ERROR: Commit message does not follow Conventional Commits format."
+    echo ""
+    echo "Expected: type(scope): description"
+    echo "  or:     type: description"
+    echo ""
+    echo "Allowed types: feat, fix, docs, chore, perf, refactor, test, ci, build, style, revert"
+    echo "Description must start with a lowercase letter."
+    echo ""
+    echo "Examples:"
+    echo "  feat(scorer): add batch scoring support"
+    echo "  fix: resolve duplicate tweet handling"
+    echo "  docs: update installation guide"
+    echo ""
+    echo "Got: $first_line"
+    exit 1
+fi
+
+# Enforce 72-char subject line
+if [ ${#first_line} -gt 72 ]; then
+    echo "ERROR: Subject line is ${#first_line} characters (max 72)."
+    echo "Got: $first_line"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Create `scripts/hooks/commit-msg` to enforce Conventional Commits format (the `.git/hooks/commit-msg` symlink already existed as a dangling link)
- Validates type prefix, lowercase description, and 72-char subject limit
- Allows merge/fixup/squash commits to pass through
- Update `CLAUDE.md` to document the commit message convention

## Test plan
- [x] Verified hook accepts valid conventional commit messages (with/without scope, with breaking change `!`)
- [x] Verified hook rejects non-conventional messages, uppercase descriptions, unknown types
- [x] Verified 72-char limit enforcement
- [x] Verified merge and fixup/squash commits pass through

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/home/clifton/code/twag
task-type: commit-normalize
task-title: Commit Message Normalizer
iterations: 1
duration: 3m47s
nightshift:metadata -->
