### PR TITLE
fix: httpx migration, notifier logging, type hints

### DIFF
--- a/tests/test_link_utils.py
+++ b/tests/test_link_utils.py
@@ -1,4 +1,8 @@
-from twag.link_utils import expand_links_in_place, normalize_tweet_links
+from unittest.mock import MagicMock
+
+import httpx
+
+from twag.link_utils import _expand_short_url, expand_links_in_place, normalize_tweet_links
 
 
 def test_normalize_tweet_links_expands_short_urls_without_structured_links(monkeypatch):
@@ -137,6 +141,39 @@ def test_expand_links_in_place_limits_short_url_expansions(monkeypatch):
     assert expanded[0]["expanded_url"] == "https://expanded.example/one"
     assert expanded[1]["expanded_url"] == "https://expanded.example/two"
     assert expanded[2]["expanded_url"] == "https://t.co/three"
+
+
+def test_expand_short_url_uses_httpx(monkeypatch):
+    """Verify _expand_short_url resolves via httpx (not urllib)."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    mock_response = MagicMock()
+    mock_response.url = httpx.URL("https://example.com/final")
+
+    def mock_request(method, url, **kwargs):
+        return mock_response
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/abc123")
+    assert result == "https://example.com/final"
+    _expand_short_url.cache_clear()
+
+
+def test_expand_short_url_falls_back_on_httpx_error(monkeypatch):
+    """Verify _expand_short_url returns original URL when httpx raises."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    def mock_request(method, url, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/fail456")
+    assert result == "https://t.co/fail456"
+    _expand_short_url.cache_clear()
 
 
 def test_normalize_tweet_links_already_expanded_skips_network_expansion(monkeypatch):

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,8 +1,11 @@
 """Tests for twag.notifier — alert formatting and send-gating logic."""
 
+import logging
 from unittest.mock import patch
 
-from twag.notifier import can_send_alert, format_alert
+import httpx
+
+from twag.notifier import can_send_alert, format_alert, send_telegram_alert
 
 
 class TestFormatAlert:
@@ -154,3 +157,42 @@ class TestCanSendAlert:
             patch("twag.notifier.get_recent_alert_count", return_value=0),
         ):
             assert can_send_alert(score=7) is True
+
+
+def test_send_telegram_alert_logs_on_exception(monkeypatch, caplog):
+    """Verify that send_telegram_alert logs a warning when the HTTP call raises."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    def mock_post(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.notifier.httpx.post", mock_post)
+
+    with caplog.at_level(logging.WARNING, logger="twag.notifier"):
+        result = send_telegram_alert("test message")
+
+    assert result is False
+    assert "Telegram send failed" in caplog.text
+
+
+def test_send_telegram_alert_returns_true_on_success(monkeypatch):
+    """Verify that send_telegram_alert returns True on 200 response."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    class FakeResponse:
+        status_code = 200
+
+    monkeypatch.setattr("twag.notifier.httpx.post", lambda *a, **kw: FakeResponse())
+
+    result = send_telegram_alert("test message")
+    assert result is True

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from threading import Lock
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+
+import httpx
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -110,11 +111,10 @@ def _expand_short_url(url: str) -> str:
     )
     for method, timeout in attempts:
         try:
-            request = Request(cleaned, method=method, headers=headers)
-            with urlopen(request, timeout=timeout) as response:
-                resolved = clean_url_candidate(response.geturl() or cleaned)
-                if resolved:
-                    return resolved
+            response = httpx.request(method, cleaned, headers=headers, timeout=timeout, follow_redirects=True)
+            resolved = clean_url_candidate(str(response.url) or cleaned)
+            if resolved:
+                return resolved
         except Exception:
             continue
     return cleaned

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -151,6 +151,7 @@ def send_telegram_alert(
             return True
         return False
     except Exception:
+        log.warning("Telegram send failed", exc_info=True)
         return False
 
 

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -3,12 +3,15 @@
 import json
 import random
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+_T = TypeVar("_T")
 
 
 def get_anthropic_client() -> Anthropic:
@@ -166,7 +169,7 @@ def _call_llm_vision(provider: str, model: str, image_url: str, prompt: str, max
     return _with_retry(_invoke)
 
 
-def _with_retry(fn):
+def _with_retry(fn: Callable[[], _T]) -> _T:
     from twag.metrics import get_collector
 
     m = get_collector()


### PR DESCRIPTION
## Summary

Three focused fixes bundled under one commit:

1. **httpx migration in `_expand_short_url`** — `twag/link_utils.py` replaces `urllib.request` (`Request` + `urlopen`) with `httpx.request(..., follow_redirects=True)`. This unifies the HTTP client library (the rest of the codebase already uses httpx) and simplifies redirect handling — httpx follows redirects natively instead of relying on urllib's implicit redirect behavior. The resolved URL is read from `response.url` rather than `response.geturl()`.

2. **Warning log on Telegram send failure** — `twag/notifier.py` `send_telegram_alert` previously swallowed exceptions silently (bare `except: return False`). Now logs `"Telegram send failed"` at WARNING level with `exc_info=True` so failures are observable in logs.

3. **Generic type signature for `_with_retry`** — `twag/scorer/llm_client.py` changes the retry wrapper from untyped `def _with_retry(fn)` to `def _with_retry(fn: Callable[[], _T]) -> _T`, preserving the return type of the wrapped callable through the retry loop.

## Tests added

- `test_expand_short_url_uses_httpx` — verifies `_expand_short_url` calls `httpx.request` and reads `response.url`
- `test_expand_short_url_falls_back_on_httpx_error` — verifies graceful fallback when httpx raises `ConnectError`
- `test_send_telegram_alert_logs_on_exception` — verifies WARNING log emission on send failure
- `test_send_telegram_alert_returns_true_on_success` — verifies True return on HTTP 200

## Files changed (5)

- `twag/link_utils.py` — swap urllib for httpx in `_expand_short_url`
- `twag/notifier.py` — add `log.warning` in exception handler
- `twag/scorer/llm_client.py` — add `TypeVar`, `Callable` imports; type `_with_retry`
- `tests/test_link_utils.py` — 2 new httpx tests
- `tests/test_notifier.py` — 2 new send_telegram_alert tests

## Test plan

- [x] `pytest tests/test_link_utils.py` — all pass
- [x] `pytest tests/test_notifier.py` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)