### PR TITLE
fix: security hardening — HTML injection, SQL allowlist, OpenAPI docs

### DIFF
--- a/twag/db/tweets.py
+++ b/twag/db/tweets.py
@@ -323,9 +323,21 @@ def _merge_duplicate_retweet_metadata(
     updates = ["is_retweet = CASE WHEN is_retweet = 0 THEN 1 ELSE is_retweet END"]
     params: list[Any] = []
 
+    _COALESCE_ALLOWED_COLUMNS = frozenset(
+        {
+            "retweeted_by_handle",
+            "retweeted_by_name",
+            "original_tweet_id",
+            "original_author_handle",
+            "original_author_name",
+        },
+    )
+
     def _coalesce_if_present(column: str, value: str | None) -> None:
         if value is None:
             return
+        if column not in _COALESCE_ALLOWED_COLUMNS:
+            raise ValueError(f"Column {column!r} not in allowlist for SQL interpolation")
         updates.append(f"{column} = COALESCE({column}, ?)")
         params.append(value)
 

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -1,5 +1,6 @@
 """Telegram notifications for high-signal tweets."""
 
+import html
 import logging
 import os
 from datetime import datetime
@@ -75,6 +76,11 @@ def format_alert(
     tickers: list[str] | None = None,
 ) -> str:
     """Format a high-signal alert message."""
+    # HTML-escape user-controlled fields to prevent injection in Telegram HTML mode
+    author_handle = html.escape(author_handle)
+    content = html.escape(content)
+    summary = html.escape(summary) if summary else summary
+
     # Truncate content for preview
     preview = content[:150] + "..." if len(content) > 150 else content
 
@@ -96,7 +102,8 @@ def format_alert(
         lines.append(f"📊 {summary}")
 
     if tickers:
-        lines.append(f"💡 Tickers: {', '.join(tickers)}")
+        safe_tickers = [html.escape(t) for t in tickers]
+        lines.append(f"💡 Tickers: {', '.join(safe_tickers)}")
 
     url = get_tweet_url(tweet_id, author_handle)
     lines.append(f"🔗 {url}")

--- a/twag/web/app.py
+++ b/twag/web/app.py
@@ -1,6 +1,7 @@
 """FastAPI application for twag web interface."""
 
 import html
+import logging
 import os
 import time
 from pathlib import Path
@@ -16,6 +17,8 @@ from ..db import init_db
 from ..metrics import get_collector
 from .routes import context, metrics, prompts, reactions, tweets
 
+log = logging.getLogger(__name__)
+
 # Paths
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
@@ -23,10 +26,18 @@ FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
+    dev_mode = os.environ.get("TWAG_DEV") == "1"
+
+    # Disable OpenAPI docs in production to avoid exposing unauthenticated API surface
+    docs_url = "/docs" if dev_mode else None
+    redoc_url = "/redoc" if dev_mode else None
+
     app = FastAPI(
         title="Twag",
         description="Twitter aggregator web interface",
         version="0.1.0",
+        docs_url=docs_url,
+        redoc_url=redoc_url,
     )
 
     app.state.db_path = get_database_path()
@@ -64,9 +75,14 @@ def create_app() -> FastAPI:
     app.include_router(context.router, prefix="/api")
     app.include_router(metrics.router, prefix="/api")
 
-    # In dev mode (TWAG_DEV=1), skip SPA serving — Vite dev server handles frontend
-    dev_mode = os.environ.get("TWAG_DEV") == "1"
+    # Warn about unauthenticated endpoints
+    if not dev_mode:
+        log.warning(
+            "Twag web server has NO authentication on any endpoint. "
+            "Avoid binding to 0.0.0.0 in production — restrict to 127.0.0.1.",
+        )
 
+    # In dev mode (TWAG_DEV=1), skip SPA serving — Vite dev server handles frontend
     if not dev_mode and (FRONTEND_DIST / "index.html").exists():
         # Production: serve built SPA
         app.mount(


### PR DESCRIPTION
## Summary
- **Telegram HTML injection**: HTML-escape user-controlled fields (`author_handle`, `content`, `summary`, `tickers`) in `format_alert()` before sending with `parse_mode=HTML` — malicious tweet text could previously inject formatting or links
- **SQL column allowlist**: Add `frozenset` allowlist to `_coalesce_if_present()` to guard against future misuse of its column-name interpolation into SQL
- **OpenAPI docs disabled in production**: Set `docs_url=None` and `redoc_url=None` unless `TWAG_DEV=1` — prevents exposing unauthenticated API surface via `/docs` and `/redoc`
- **Startup warning**: Log a warning when running in production about unauthenticated endpoints and `0.0.0.0` binding risk

## Test plan
- [x] `ruff format` + `ruff check` pass
- [x] `ty check` passes (no diagnostics)
- [x] Full test suite passes (`pytest tests/ -q`)

Nightshift-Task: security-footgun
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)