### PR TITLE
docs: semantic diff analysis for fixes-2026-04-03

### DIFF
--- a/tests/test_link_utils.py
+++ b/tests/test_link_utils.py
@@ -1,4 +1,8 @@
-from twag.link_utils import expand_links_in_place, normalize_tweet_links
+from unittest.mock import MagicMock
+
+import httpx
+
+from twag.link_utils import _expand_short_url, expand_links_in_place, normalize_tweet_links
 
 
 def test_normalize_tweet_links_expands_short_urls_without_structured_links(monkeypatch):
@@ -137,6 +141,39 @@ def test_expand_links_in_place_limits_short_url_expansions(monkeypatch):
     assert expanded[0]["expanded_url"] == "https://expanded.example/one"
     assert expanded[1]["expanded_url"] == "https://expanded.example/two"
     assert expanded[2]["expanded_url"] == "https://t.co/three"
+
+
+def test_expand_short_url_uses_httpx(monkeypatch):
+    """Verify _expand_short_url resolves via httpx (not urllib)."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    mock_response = MagicMock()
+    mock_response.url = httpx.URL("https://example.com/final")
+
+    def mock_request(method, url, **kwargs):
+        return mock_response
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/abc123")
+    assert result == "https://example.com/final"
+    _expand_short_url.cache_clear()
+
+
+def test_expand_short_url_falls_back_on_httpx_error(monkeypatch):
+    """Verify _expand_short_url returns original URL when httpx raises."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    def mock_request(method, url, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/fail456")
+    assert result == "https://t.co/fail456"
+    _expand_short_url.cache_clear()
 
 
 def test_normalize_tweet_links_already_expanded_skips_network_expansion(monkeypatch):

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,8 +1,11 @@
 """Tests for twag.notifier — alert formatting and send-gating logic."""
 
+import logging
 from unittest.mock import patch
 
-from twag.notifier import can_send_alert, format_alert
+import httpx
+
+from twag.notifier import can_send_alert, format_alert, send_telegram_alert
 
 
 class TestFormatAlert:
@@ -154,3 +157,42 @@ class TestCanSendAlert:
             patch("twag.notifier.get_recent_alert_count", return_value=0),
         ):
             assert can_send_alert(score=7) is True
+
+
+def test_send_telegram_alert_logs_on_exception(monkeypatch, caplog):
+    """Verify that send_telegram_alert logs a warning when the HTTP call raises."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    def mock_post(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.notifier.httpx.post", mock_post)
+
+    with caplog.at_level(logging.WARNING, logger="twag.notifier"):
+        result = send_telegram_alert("test message")
+
+    assert result is False
+    assert "Telegram send failed" in caplog.text
+
+
+def test_send_telegram_alert_returns_true_on_success(monkeypatch):
+    """Verify that send_telegram_alert returns True on 200 response."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    class FakeResponse:
+        status_code = 200
+
+    monkeypatch.setattr("twag.notifier.httpx.post", lambda *a, **kw: FakeResponse())
+
+    result = send_telegram_alert("test message")
+    assert result is True

--- a/tmp/semantic-diff-2026-04-03.md
+++ b/tmp/semantic-diff-2026-04-03.md
@@ -1,0 +1,90 @@
+# Semantic Diff Explainer — `td-review/fixes-2026-04-03`
+
+**Branch:** `td-review/fixes-2026-04-03` (1 commit: `c5a5117`)
+**Base:** `main`
+**Files changed:** 5 | **Lines:** +93 / −10
+
+---
+
+## Change Themes
+
+### 1. httpx Migration in URL Expansion (`twag/link_utils.py`)
+
+**Intent:** Replace `urllib.request` (stdlib) with `httpx` for short-URL expansion in `_expand_short_url`.
+
+**What changed:**
+- Removed `from urllib.request import Request, urlopen`; added `import httpx`
+- Replaced `Request` + `urlopen` with `httpx.request(method, url, headers=..., timeout=..., follow_redirects=True)`
+- Response URL accessed via `str(response.url)` instead of `response.geturl()`
+
+**Semantic impact:** Positive. `httpx` is already a project dependency (used in notifier and web client code), so this unifies the HTTP stack. `follow_redirects=True` explicitly enables redirect following, which was implicit with `urlopen`. The error handling (`except Exception: continue`) is preserved, maintaining the same fallback behavior.
+
+**Verdict:** ✅ Correct — consolidates HTTP library usage with no behavioral regression.
+
+---
+
+### 2. Notifier Logging Fix (`twag/notifier.py`)
+
+**Intent:** Restore observability to the `send_telegram_alert` exception handler.
+
+**What changed:**
+- Added `log.warning("Telegram send failed", exc_info=True)` inside the bare `except Exception` block that previously silently returned `False`.
+
+**Semantic impact:** This is a P0-level fix. The previous code swallowed all exceptions without any trace, making Telegram delivery failures invisible. The `exc_info=True` parameter ensures the full traceback is captured in logs, enabling diagnosis of network errors, auth failures, or API changes.
+
+**Verdict:** ✅ Correct — restores observability without changing control flow. The function still returns `False` on failure, so callers are unaffected.
+
+---
+
+### 3. Type Hints for `_with_retry` (`twag/scorer/llm_client.py`)
+
+**Intent:** Add generic type annotations to the retry wrapper function.
+
+**What changed:**
+- Added `from collections.abc import Callable` and `from typing import TypeVar`
+- Defined `_T = TypeVar("_T")`
+- Changed signature from `def _with_retry(fn)` to `def _with_retry(fn: Callable[[], _T]) -> _T`
+
+**Semantic impact:** Pure type-level change — no runtime behavior change. The annotation correctly expresses that `_with_retry` preserves the return type of the wrapped callable. This enables downstream type checkers to infer return types through the retry wrapper.
+
+**Verdict:** ✅ Correct — improves type safety with zero runtime risk.
+
+---
+
+### 4. New Tests for httpx Migration (`tests/test_link_utils.py`)
+
+**Intent:** Validate that `_expand_short_url` works correctly with the new `httpx` backend.
+
+**Tests added:**
+- `test_expand_short_url_uses_httpx` — Mocks `httpx.request` to return a redirect target, asserts the expanded URL is returned. Verifies the httpx integration path works.
+- `test_expand_short_url_falls_back_on_httpx_error` — Mocks `httpx.request` to raise `httpx.ConnectError`, asserts the original URL is returned unchanged. Verifies graceful degradation.
+
+Both tests properly clear the `lru_cache` before and after execution and reset the network expansion attempt counter.
+
+**Verdict:** ✅ Correct — good coverage of happy path and error path for the httpx migration.
+
+---
+
+### 5. New Tests for Notifier Logging (`tests/test_notifier.py`)
+
+**Intent:** Validate `send_telegram_alert` behavior on success and failure.
+
+**Tests added:**
+- `test_send_telegram_alert_logs_on_exception` — Mocks `httpx.post` to raise `ConnectError`, captures log output, asserts `"Telegram send failed"` appears in logs and function returns `False`. Directly validates the P0-3 logging fix.
+- `test_send_telegram_alert_returns_true_on_success` — Mocks `httpx.post` to return a 200 response, asserts function returns `True`. Validates the happy path.
+
+**Verdict:** ✅ Correct — tests directly cover the notifier logging fix and confirm existing success behavior.
+
+---
+
+## Summary
+
+| # | Theme | Files | Verdict |
+|---|-------|-------|---------|
+| 1 | httpx migration | `twag/link_utils.py` | ✅ Correct |
+| 2 | Notifier logging fix | `twag/notifier.py` | ✅ Correct |
+| 3 | Type hints | `twag/scorer/llm_client.py` | ✅ Correct |
+| 4 | httpx migration tests | `tests/test_link_utils.py` | ✅ Correct |
+| 5 | Notifier logging tests | `tests/test_notifier.py` | ✅ Correct |
+
+**No regressions found.** All changes are additive improvements: unified HTTP stack, restored observability, improved type safety, and new test coverage.

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from threading import Lock
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+
+import httpx
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -110,11 +111,10 @@ def _expand_short_url(url: str) -> str:
     )
     for method, timeout in attempts:
         try:
-            request = Request(cleaned, method=method, headers=headers)
-            with urlopen(request, timeout=timeout) as response:
-                resolved = clean_url_candidate(response.geturl() or cleaned)
-                if resolved:
-                    return resolved
+            response = httpx.request(method, cleaned, headers=headers, timeout=timeout, follow_redirects=True)
+            resolved = clean_url_candidate(str(response.url) or cleaned)
+            if resolved:
+                return resolved
         except Exception:
             continue
     return cleaned

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -151,6 +151,7 @@ def send_telegram_alert(
             return True
         return False
     except Exception:
+        log.warning("Telegram send failed", exc_info=True)
         return False
 
 

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -3,12 +3,15 @@
 import json
 import random
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+_T = TypeVar("_T")
 
 
 def get_anthropic_client() -> Anthropic:
@@ -166,7 +169,7 @@ def _call_llm_vision(provider: str, model: str, image_url: str, prompt: str, max
     return _with_retry(_invoke)
 
 
-def _with_retry(fn):
+def _with_retry(fn: Callable[[], _T]) -> _T:
     from twag.metrics import get_collector
 
     m = get_collector()


### PR DESCRIPTION
## Summary
- Adds `tmp/semantic-diff-2026-04-03.md` analyzing the 5-file diff on `td-review/fixes-2026-04-03`
- Categorizes changes: httpx migration, notifier logging fix, type hints, and 4 new tests
- No regressions found — all changes are improvements or neutral

## Test plan
- [x] Existing tests pass (`pytest tests/test_link_utils.py tests/test_notifier.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)