### PR TITLE
feat: add structured logging across pipeline

### DIFF
--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -1,5 +1,7 @@
 """CLI entry point for twag."""
 
+import logging
+
 import rich_click as click
 
 from .. import __version__
@@ -30,8 +32,13 @@ from .analyze import _print_status_analysis as _print_status_analysis
 
 @click.group()
 @click.version_option(version=__version__)
-def cli():
+@click.option("-v", "--verbose", is_flag=True, help="Enable verbose (DEBUG) logging output.")
+def cli(verbose: bool) -> None:
     """Twitter aggregator for market-relevant signals."""
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.WARNING,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
 
 
 # Register commands

--- a/twag/fetcher/extractors.py
+++ b/twag/fetcher/extractors.py
@@ -1,6 +1,7 @@
 """Tweet parsing and extraction from bird CLI JSON payloads."""
 
 import html
+import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -8,6 +9,8 @@ from typing import Any
 
 from ..text_utils import looks_truncated_text as _looks_truncated_text
 from ..text_utils import sanitize_nested_strings, sanitize_text
+
+log = logging.getLogger(__name__)
 
 
 @dataclass

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from functools import lru_cache
@@ -9,6 +10,8 @@ from threading import Lock
 from urllib.parse import urlparse
 
 import httpx
+
+log = logging.getLogger(__name__)
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -109,6 +112,7 @@ def _expand_short_url(url: str) -> str:
         ("HEAD", _SHORT_URL_HEAD_TIMEOUT_SECONDS),
         ("GET", _SHORT_URL_GET_TIMEOUT_SECONDS),
     )
+    log.debug("Expanding short URL %s", cleaned)
     for method, timeout in attempts:
         try:
             response = httpx.request(method, cleaned, headers=headers, timeout=timeout, follow_redirects=True)
@@ -116,6 +120,7 @@ def _expand_short_url(url: str) -> str:
             if resolved:
                 return resolved
         except Exception:
+            log.warning("URL expansion %s failed for %s", method, cleaned, exc_info=True)
             continue
     return cleaned
 

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -37,7 +37,7 @@ def get_recent_alert_count() -> int:
         with get_connection() as conn:
             return _db_get_recent_alert_count(conn, minutes=60)
     except Exception:
-        log.warning("Failed to query alert log; allowing alert")
+        log.warning("Failed to query alert log; allowing alert", exc_info=True)
         return 0
 
 
@@ -147,7 +147,7 @@ def send_telegram_alert(
                     log_alert(conn, tweet_id=tweet_id, chat_id=chat_id)
                     conn.commit()
             except Exception:
-                log.warning("Failed to log alert to database")
+                log.error("Failed to log alert to database", exc_info=True)
             return True
         return False
     except Exception:

--- a/twag/processor/dependencies.py
+++ b/twag/processor/dependencies.py
@@ -218,6 +218,7 @@ def _expand_links_for_rows(
                     try:
                         _, expanded_links = future.result()
                     except Exception:
+                        log.warning("Link expansion failed for tweet %s", tweet_id, exc_info=True)
                         expanded_links = None
                     links_payload: list[dict[str, Any]] | str | None = (
                         expanded_links if expanded_links is not None else original_row["links_json"]
@@ -229,6 +230,7 @@ def _expand_links_for_rows(
                 try:
                     _, expanded_links = _expand_single_tweet_links(row)
                 except Exception:
+                    log.warning("Link expansion failed for tweet %s", tweet_id, exc_info=True)
                     expanded_links = None
                 links_payload = expanded_links if expanded_links is not None else row["links_json"]
                 update_tweet_links_expanded(conn, tweet_id, links_payload, expanded_at)

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -158,6 +158,7 @@ def _analyze_media_items(
         try:
             result = analyze_media(url, model=vision_model, provider=vision_provider)
         except Exception:
+            log.warning("Media analysis failed for %s", url, exc_info=True)
             continue
 
         item["kind"] = result.kind
@@ -209,6 +210,7 @@ def _merge_document_media(media_items: list[dict[str, Any]]) -> bool:
     try:
         combined_summary = summarize_document_text(combined_text)
     except Exception:
+        log.warning("Document summarization failed, using first page summary", exc_info=True)
         combined_summary = (media_items[doc_entries[0][1]].get("prose_summary") or "").strip()
 
     primary_idx = doc_entries[0][1]

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -1,6 +1,7 @@
 """LLM client infrastructure: provider dispatch, retry logic, JSON parsing."""
 
 import json
+import logging
 import random
 import time
 from collections.abc import Callable
@@ -11,6 +12,7 @@ from anthropic import Anthropic
 from twag.auth import get_api_key
 from twag.config import load_config
 
+log = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
@@ -39,6 +41,7 @@ def _call_anthropic(model: str, prompt: str, max_tokens: int = 2048) -> str:
     """Call Anthropic API and return text response."""
     from twag.metrics import get_collector
 
+    log.debug("Calling Anthropic model=%s", model)
     m = get_collector()
     m.inc("scorer.anthropic.calls")
     t0 = time.monotonic()
@@ -68,6 +71,7 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
 
     from twag.metrics import get_collector
 
+    log.debug("Calling Gemini model=%s", model)
     m = get_collector()
     m.inc("scorer.gemini.calls")
     t0 = time.monotonic()
@@ -195,6 +199,13 @@ def _with_retry(fn: Callable[[], _T]) -> _T:
             delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
             if jitter:
                 delay = max(0.0, delay * (1 + random.uniform(-jitter, jitter)))
+            log.warning(
+                "LLM call attempt %d failed (%s), retrying in %.1fs",
+                attempt,
+                type(exc).__name__,
+                delay,
+                exc_info=True,
+            )
             time.sleep(delay)
 
 

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -1,5 +1,6 @@
 """Scoring, triage, enrichment, and analysis functions."""
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -14,6 +15,8 @@ from .prompts import (
     MEDIA_PROMPT,
     SUMMARIZE_PROMPT,
 )
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -227,6 +230,7 @@ def summarize_x_article(
             data = _parse_json_response(text)
             break
         except Exception:
+            log.warning("Article summarization failed with %s/%s", cand_provider, cand_model, exc_info=True)
             continue
 
     if data is None:

--- a/twag/web/app.py
+++ b/twag/web/app.py
@@ -1,6 +1,7 @@
 """FastAPI application for twag web interface."""
 
 import html
+import logging
 import os
 import time
 from pathlib import Path
@@ -15,6 +16,8 @@ from ..config import get_database_path
 from ..db import init_db
 from ..metrics import get_collector
 from .routes import context, metrics, prompts, reactions, tweets
+
+log = logging.getLogger(__name__)
 
 # Paths
 TEMPLATES_DIR = Path(__file__).parent / "templates"

--- a/twag/web/routes/reactions.py
+++ b/twag/web/routes/reactions.py
@@ -1,5 +1,6 @@
 """Reaction API routes."""
 
+import logging
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -14,6 +15,8 @@ from ...db import (
     insert_reaction,
     mute_account,
 )
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["reactions"])
 

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -1,6 +1,7 @@
 """Tweet feed API routes."""
 
 import json
+import logging
 import re
 from datetime import datetime
 from typing import Annotated, Any
@@ -15,6 +16,8 @@ from ..tweet_utils import (
     normalize_links_for_display,
     quote_embed_from_row,
 )
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["tweets"])
 MAX_QUOTE_DEPTH = 3


### PR DESCRIPTION
## Summary
- Add `--verbose/-v` flag to CLI entry point that configures `logging.basicConfig`, so log output is no longer silently discarded during CLI usage
- Add `logging.getLogger(__name__)` to 8 high-impact modules that were missing loggers: `llm_client`, `scoring`, `link_utils`, `extractors`, `web/app`, `web/routes/tweets`, `web/routes/reactions`
- Replace bare `except Exception: pass/continue` blocks with `log.warning(..., exc_info=True)` in triage, scoring, link_utils, and dependencies modules so failures leave a diagnostic trail
- Add retry logging to `llm_client._with_retry` (attempt number, exception class, delay)
- Fix notifier.py: add `exc_info=True` to exception handlers, upgrade alert DB failure from WARNING to ERROR

## Test plan
- [x] All existing tests pass (`uv run pytest -q`)
- [x] `ruff check` passes on all modified files
- [ ] Verify `twag --verbose process` produces debug output
- [ ] Verify default (no flag) produces no output unless warnings occur

Nightshift-Task: logging-audit
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)