### PR TITLE
security: fix 6 foot-gun anti-patterns

### DIFF
--- a/twag/cli/web.py
+++ b/twag/cli/web.py
@@ -8,7 +8,7 @@ from ._console import console
 
 
 @click.command()
-@click.option("--host", "-h", default="0.0.0.0", help="Host to bind to")
+@click.option("--host", "-h", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", "-p", default=5173, help="Port to bind to")
 @click.option("--reload/--no-reload", default=True, help="Auto-reload on code changes")
 @click.option("--dev", is_flag=True, default=False, help="Dev mode: start Vite + FastAPI with HMR")

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ipaddress
 import re
+import socket
 from dataclasses import dataclass
 from functools import lru_cache
 from threading import Lock
@@ -26,6 +28,21 @@ _SHORT_URL_GET_TIMEOUT_SECONDS = 1.5
 _MAX_NETWORK_EXPANSION_ATTEMPTS = 512
 _network_expansion_attempts = 0
 _network_expansion_lock = Lock()
+
+
+def _is_private_ip(hostname: str) -> bool:
+    """Return True if hostname resolves to a private/internal IP address."""
+    try:
+        addr = ipaddress.ip_address(hostname)
+    except ValueError:
+        try:
+            resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+            if not resolved:
+                return False
+            addr = ipaddress.ip_address(resolved[0][4][0])
+        except (socket.gaierror, OSError, ValueError):
+            return False
+    return addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved
 
 
 @dataclass
@@ -114,6 +131,9 @@ def _expand_short_url(url: str) -> str:
             response = httpx.request(method, cleaned, headers=headers, timeout=timeout, follow_redirects=True)
             resolved = clean_url_candidate(str(response.url) or cleaned)
             if resolved:
+                resolved_host = _domain_for(resolved).split(":")[0]
+                if resolved_host and _is_private_ip(resolved_host):
+                    return cleaned
                 return resolved
         except Exception:
             continue

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -5,11 +5,25 @@ import random
 import time
 from collections.abc import Callable
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+_ALLOWED_IMAGE_DOMAINS = frozenset({"pbs.twimg.com", "ton.twimg.com", "abs.twimg.com"})
+
+
+def _validate_image_url(url: str) -> None:
+    """Reject image URLs outside the Twitter CDN allowlist and non-https schemes."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("https",):
+        raise ValueError(f"Blocked image URL with scheme '{parsed.scheme}': only https is allowed")
+    host = (parsed.hostname or "").lower()
+    if host not in _ALLOWED_IMAGE_DOMAINS:
+        raise ValueError(f"Blocked image URL from untrusted domain '{host}'")
+
 
 _T = TypeVar("_T")
 
@@ -95,6 +109,7 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
 
 def _call_anthropic_vision(model: str, image_url: str, prompt: str, max_tokens: int = 1024) -> str:
     """Call Anthropic API with image and return text response."""
+    _validate_image_url(image_url)
     client = get_anthropic_client()
     response = client.messages.create(
         model=model,
@@ -126,6 +141,7 @@ def _call_gemini_vision(model: str, image_url: str, prompt: str, max_tokens: int
     import httpx
     from google.genai import types
 
+    _validate_image_url(image_url)
     client = get_gemini_client()
 
     # Fetch image

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -31,13 +31,11 @@ router = APIRouter(tags=["context"])
 ALLOWED_COMMANDS = frozenset(
     {
         "bird",
-        "cat",
         "echo",
         "grep",
         "head",
         "jq",
         "rg",
-        "sed",
         "tail",
         "twag",
         "wc",
@@ -45,7 +43,7 @@ ALLOWED_COMMANDS = frozenset(
 )
 
 # Shell metacharacters that enable injection when present in a template
-_DANGEROUS_PATTERN = re.compile(r"[;|&`$><\n]")
+_DANGEROUS_PATTERN = re.compile(r"[;|&`$><!\n]")
 
 
 def _validate_command_template(template: str) -> None:


### PR DESCRIPTION
## Summary

- **Default bind address**: `0.0.0.0` → `127.0.0.1` in `twag/cli/web.py` — prevents exposing unauthenticated endpoints to the network
- **SSRF guard (link expansion)**: Added `_is_private_ip()` in `twag/link_utils.py` that rejects RFC-1918, loopback, link-local, and reserved IPs after short URL expansion resolves
- **SSRF guard (image fetch)**: Added Twitter CDN domain allowlist (`pbs.twimg.com`, `ton.twimg.com`, `abs.twimg.com`) and https-only scheme check in `twag/scorer/llm_client.py` vision functions
- **Context command hardening**: Removed `cat` and `sed` from `ALLOWED_COMMANDS` (arbitrary file read/write); added `!` to `_DANGEROUS_PATTERN` regex in `twag/web/routes/context.py`

## Test plan

- [x] All existing tests pass (`uv run pytest` — 100%)
- [x] `ruff check` and `ruff format` clean
- [ ] Manual: verify `twag web` binds to localhost by default
- [ ] Manual: verify context commands reject `cat` and `sed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)