### PR TITLE
docs: add docstrings to metrics and progress public APIs

### DIFF
--- a/twag/cli/_progress.py
+++ b/twag/cli/_progress.py
@@ -10,11 +10,17 @@ from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn
 class ProgressReporter(Protocol):
     """Protocol for reporting progress from CLI commands."""
 
-    def update_status(self, message: str) -> None: ...
+    def update_status(self, message: str) -> None:
+        """Update the displayed status message."""
+        ...
 
-    def advance(self, step: int = 1) -> None: ...
+    def advance(self, step: int = 1) -> None:
+        """Advance progress by *step* increments."""
+        ...
 
-    def set_total(self, total: int) -> None: ...
+    def set_total(self, total: int) -> None:
+        """Set the expected total number of steps."""
+        ...
 
 
 class RichProgressReporter:
@@ -28,18 +34,22 @@ class RichProgressReporter:
         self._total = 0
 
     def _description(self) -> str:
+        """Return the left-padded label for the progress bar."""
         return f"{self._label:<25s}"
 
     def update_status(self, message: str) -> None:
+        """Replace the progress bar label with *message*."""
         self._label = message
         self._progress.update(self._task_id, description=self._description())
 
     def advance(self, step: int = 1) -> None:
+        """Advance the progress bar by *step* increments (clamped to total)."""
         step = max(step, 0)
         self._count = min(self._total, self._count + step)
         self._progress.update(self._task_id, advance=step, description=self._description())
 
     def set_total(self, total: int) -> None:
+        """Set the expected total, floored to the current count."""
         total = max(total, self._count)
         self._total = total
         self._progress.update(self._task_id, total=total, description=self._description())

--- a/twag/metrics.py
+++ b/twag/metrics.py
@@ -44,6 +44,8 @@ LabelMap = Mapping[str, str]
 
 
 class HistogramSnapshot(TypedDict):
+    """Point-in-time summary statistics for a single histogram metric."""
+
     count: int
     min: float
     max: float
@@ -52,6 +54,8 @@ class HistogramSnapshot(TypedDict):
 
 
 class MetricsSnapshot(TypedDict):
+    """Snapshot of all counters and histograms in the collector."""
+
     counters: dict[str, float]
     histograms: dict[str, HistogramSnapshot]
 
@@ -112,12 +116,14 @@ class MetricsCollector:
     # -- Counters --
 
     def inc(self, name: str, value: float = 1.0) -> None:
+        """Increment a counter by *value* (default 1), creating it if needed."""
         with self._lock:
             if name not in self._counters:
                 self._counters[name] = _Counter()
             self._counters[name].value += value
 
     def counter_value(self, name: str) -> float:
+        """Return the current value of counter *name*, or 0.0 if unset."""
         with self._lock:
             c = self._counters.get(name)
             return c.value if c else 0.0
@@ -125,12 +131,14 @@ class MetricsCollector:
     # -- Gauges --
 
     def set_gauge(self, name: str, value: float) -> None:
+        """Set gauge *name* to *value*, creating it if needed."""
         with self._lock:
             if name not in self._gauges:
                 self._gauges[name] = _Gauge()
             self._gauges[name].value = value
 
     def gauge_value(self, name: str) -> float:
+        """Return the current value of gauge *name*, or 0.0 if unset."""
         with self._lock:
             g = self._gauges.get(name)
             return g.value if g else 0.0
@@ -138,12 +146,14 @@ class MetricsCollector:
     # -- Histograms --
 
     def observe(self, name: str, value: float) -> None:
+        """Record a histogram observation for *name*."""
         with self._lock:
             if name not in self._histograms:
                 self._histograms[name] = _Histogram()
             self._histograms[name].observe(value)
 
     def histogram_stats(self, name: str) -> dict[str, float]:
+        """Return computed statistics (count, total, mean, min, max, p50, p99) for histogram *name*."""
         with self._lock:
             h = self._histograms.get(name)
             if not h or h.count == 0:
@@ -163,6 +173,7 @@ class MetricsCollector:
     # -- Snapshot --
 
     def snapshot(self) -> dict[str, Any]:
+        """Return a full snapshot of all metrics including uptime, counters, gauges, and histograms."""
         with self._lock:
             result: dict[str, Any] = {
                 "uptime_seconds": time.monotonic() - self._start_time,
@@ -224,6 +235,7 @@ class MetricsCollector:
         return len(rows)
 
     def reset(self) -> None:
+        """Clear all counters, gauges, and histograms and restart the uptime clock."""
         with self._lock:
             self._counters.clear()
             self._gauges.clear()
@@ -256,12 +268,14 @@ def _label_key(name: str, labels: LabelMap | None = None) -> str:
 
 
 def counter(name: str, *, value: float = 1.0, labels: LabelMap | None = None) -> float:
+    """Increment counter *name* by *value* and return the new total."""
     key = _label_key(name, labels)
     _collector.inc(key, value)
     return _collector.counter_value(key)
 
 
 def histogram(name: str, value: float, *, labels: LabelMap | None = None) -> HistogramSnapshot:
+    """Record a histogram observation and return the updated snapshot."""
     key = _label_key(name, labels)
     _collector.observe(key, value)
     stats = _collector.histogram_stats(key)
@@ -276,6 +290,7 @@ def histogram(name: str, value: float, *, labels: LabelMap | None = None) -> His
 
 @contextmanager
 def timer(name: str, *, labels: LabelMap | None = None) -> Iterator[None]:
+    """Context manager that records elapsed wall-clock seconds to histogram *name*."""
     start = time.perf_counter()
     try:
         yield
@@ -284,6 +299,7 @@ def timer(name: str, *, labels: LabelMap | None = None) -> Iterator[None]:
 
 
 def get_all_metrics() -> MetricsSnapshot:
+    """Return a ``MetricsSnapshot`` of all counters and histograms."""
     snap = _collector.snapshot()
     counters = dict(snap["counters"])
     histograms: dict[str, HistogramSnapshot] = {}
@@ -299,6 +315,7 @@ def get_all_metrics() -> MetricsSnapshot:
 
 
 def dump_json(path: str | None = None) -> str:
+    """Serialize all metrics to JSON. Optionally write to *path*."""
     payload = json.dumps(get_all_metrics(), indent=2, sort_keys=True)
     if path is not None:
         with open(path, "w", encoding="utf-8") as handle:
@@ -307,4 +324,5 @@ def dump_json(path: str | None = None) -> str:
 
 
 def reset() -> None:
+    """Reset the global collector, clearing all recorded metrics."""
     _collector.reset()


### PR DESCRIPTION
## Summary
- Added Google-style docstrings to 16 undocumented public methods, TypedDicts, and convenience functions in `twag/metrics.py`
- Added docstrings to 6 protocol/implementation methods in `twag/cli/_progress.py`
- No behavioral changes; documentation only

## Test plan
- [x] `ruff format` — no changes needed
- [x] `ruff check` — all checks passed
- [x] `pytest -k "metric or progress"` — 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)