### PR TITLE
feat: logging quality audit — add loggers and replace silent exception handlers

### DIFF
--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -1,5 +1,7 @@
 """CLI entry point for twag."""
 
+import logging
+
 import rich_click as click
 
 from .. import __version__
@@ -30,8 +32,15 @@ from .analyze import _print_status_analysis as _print_status_analysis
 
 @click.group()
 @click.version_option(version=__version__)
-def cli():
+@click.option("-v", "--verbose", is_flag=True, help="Enable debug logging.")
+def cli(verbose: bool) -> None:
     """Twitter aggregator for market-relevant signals."""
+    level = logging.DEBUG if verbose else logging.WARNING
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    logging.getLogger("twag").setLevel(level)
 
 
 # Register commands

--- a/twag/config.py
+++ b/twag/config.py
@@ -2,9 +2,12 @@
 
 import copy
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 # Application name for XDG paths
 APP_NAME = "twag"
@@ -106,6 +109,7 @@ def load_config() -> dict[str, Any]:
         mtime = config_path.stat().st_mtime
     except OSError:
         # Config file doesn't exist — use defaults.
+        log.debug("Config file not found at %s, using defaults", config_path)
         mtime = 0.0
 
     if _config_cache is not None and _config_cache[0] == mtime:
@@ -113,6 +117,7 @@ def load_config() -> dict[str, Any]:
 
     config = DEFAULT_CONFIG.copy()
     if mtime > 0:
+        log.debug("Loading config from %s", config_path)
         with open(config_path) as f:
             user_config = json.load(f)
             config = deep_merge(config, user_config)

--- a/twag/db/maintenance.py
+++ b/twag/db/maintenance.py
@@ -1,5 +1,6 @@
 """Database maintenance operations: dump, restore, prune."""
 
+import logging
 import re
 import shutil
 import sqlite3
@@ -8,6 +9,8 @@ from pathlib import Path
 
 from ..config import get_database_path
 from .connection import rebuild_fts
+
+log = logging.getLogger(__name__)
 
 # FTS shadow table suffixes and related object names to filter during dump
 _FTS_TABLE = "tweets_fts"
@@ -148,6 +151,7 @@ def restore_sql(
     # Backup existing database
     if backup and db_path.exists():
         backup_path = db_path.with_suffix(".db.bak")
+        log.info("Backing up existing database to %s", backup_path)
         shutil.copy2(db_path, backup_path)
 
     # Remove existing database
@@ -176,11 +180,13 @@ def restore_sql(
 
         return {"tweets": tweet_count, "accounts": account_count, "fts": fts_count}
     except Exception:
+        log.exception("Database restore failed, attempting to recover from backup")
         conn.close()
         # Attempt to restore backup on failure
         if backup:
             backup_path = db_path.with_suffix(".db.bak")
             if backup_path.exists():
+                log.info("Restoring backup from %s", backup_path)
                 if db_path.exists():
                     db_path.unlink()
                 shutil.copy2(backup_path, db_path)

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from functools import lru_cache
@@ -9,6 +10,8 @@ from threading import Lock
 from urllib.parse import urlparse
 
 import httpx
+
+log = logging.getLogger(__name__)
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -116,6 +119,7 @@ def _expand_short_url(url: str) -> str:
             if resolved:
                 return resolved
         except Exception:
+            log.warning("URL expansion failed for %s (%s)", cleaned, method, exc_info=True)
             continue
     return cleaned
 

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -158,6 +158,7 @@ def _analyze_media_items(
         try:
             result = analyze_media(url, model=vision_model, provider=vision_provider)
         except Exception:
+            log.warning("Media analysis failed for %s", url, exc_info=True)
             continue
 
         item["kind"] = result.kind
@@ -209,6 +210,7 @@ def _merge_document_media(media_items: list[dict[str, Any]]) -> bool:
     try:
         combined_summary = summarize_document_text(combined_text)
     except Exception:
+        log.warning("Document summarization failed, using fallback", exc_info=True)
         combined_summary = (media_items[doc_entries[0][1]].get("prose_summary") or "").strip()
 
     primary_idx = doc_entries[0][1]

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -1,6 +1,7 @@
 """LLM client infrastructure: provider dispatch, retry logic, JSON parsing."""
 
 import json
+import logging
 import random
 import time
 from collections.abc import Callable
@@ -10,6 +11,8 @@ from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+log = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
@@ -190,11 +193,19 @@ def _with_retry(fn: Callable[[], _T]) -> _T:
             if "not set" in msg and "api" in msg:
                 raise
             if retries and attempt >= retries:
+                log.warning("LLM call failed after %d attempts, giving up", attempt, exc_info=True)
                 raise
 
             delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
             if jitter:
                 delay = max(0.0, delay * (1 + random.uniform(-jitter, jitter)))
+            log.warning(
+                "LLM call failed (attempt %d/%d), retrying in %.1fs: %s",
+                attempt,
+                retries,
+                delay,
+                exc,
+            )
             time.sleep(delay)
 
 

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -1,5 +1,6 @@
 """Scoring, triage, enrichment, and analysis functions."""
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -14,6 +15,8 @@ from .prompts import (
     MEDIA_PROMPT,
     SUMMARIZE_PROMPT,
 )
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -227,6 +230,12 @@ def summarize_x_article(
             data = _parse_json_response(text)
             break
         except Exception:
+            log.warning(
+                "Article summarization failed with %s/%s, trying next candidate",
+                cand_provider,
+                cand_model,
+                exc_info=True,
+            )
             continue
 
     if data is None:

--- a/twag/web/app.py
+++ b/twag/web/app.py
@@ -1,6 +1,7 @@
 """FastAPI application for twag web interface."""
 
 import html
+import logging
 import os
 import time
 from pathlib import Path
@@ -21,8 +22,18 @@ TEMPLATES_DIR = Path(__file__).parent / "templates"
 FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
 
 
+log = logging.getLogger(__name__)
+
+
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    logging.getLogger("twag").setLevel(logging.INFO)
+    log.info("Creating twag web application")
+
     app = FastAPI(
         title="Twag",
         description="Twitter aggregator web interface",


### PR DESCRIPTION
## Summary
- Configure root `twag` logger in CLI entry point (`cli/__init__.py`) with `--verbose/-v` flag for DEBUG output, and in web app (`web/app.py`) with INFO-level defaults
- Add `log = logging.getLogger(__name__)` to 6 modules that perform critical work but had no logging: `scorer/llm_client.py`, `scorer/scoring.py`, `link_utils.py`, `config.py`, `db/maintenance.py`, `web/app.py`
- Replace 5 bare `except Exception: pass/continue` blocks with `log.warning`/`log.exception` calls in media analysis, document summarization, LLM retries, URL expansion, and article summarization

## Test plan
- [x] `uv run ruff format` — all files unchanged
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ty check` — all checks passed
- [x] `uv run pytest` — all tests pass
- [ ] Verify `twag --verbose fetch` produces debug-level output
- [ ] Verify web app logs at INFO level on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Nightshift-Task: logging-audit
Nightshift-Ref: https://github.com/marcus/nightshift