### PR TITLE
fix: security hardening — bind localhost, SQL allowlist, path restriction

### DIFF
--- a/twag/cli/web.py
+++ b/twag/cli/web.py
@@ -8,7 +8,7 @@ from ._console import console
 
 
 @click.command()
-@click.option("--host", "-h", default="0.0.0.0", help="Host to bind to")
+@click.option("--host", "-h", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", "-p", default=5173, help="Port to bind to")
 @click.option("--reload/--no-reload", default=True, help="Auto-reload on code changes")
 @click.option("--dev", is_flag=True, default=False, help="Dev mode: start Vite + FastAPI with HMR")

--- a/twag/db/maintenance.py
+++ b/twag/db/maintenance.py
@@ -81,6 +81,63 @@ def _filter_fts_from_sql(sql: str) -> str:
     return "\n".join(output_lines)
 
 
+# SQL statement types allowed in restore dumps.
+# Anything not matching is rejected to prevent ATTACH, PRAGMA, LOAD_EXTENSION, etc.
+_ALLOWED_SQL_PREFIXES = re.compile(
+    r"^\s*("
+    r"BEGIN(\s+TRANSACTION)?"
+    r"|COMMIT"
+    r"|CREATE\s+(TABLE|INDEX|UNIQUE\s+INDEX|TRIGGER|VIEW)"
+    r"|DELETE\s+FROM"
+    r"|INSERT\s+(INTO|OR\s+REPLACE\s+INTO|OR\s+IGNORE\s+INTO)"
+    r"|UPDATE\s+"
+    r"|DROP\s+(TABLE|INDEX|TRIGGER|VIEW)\s+IF\s+EXISTS"
+    r"|ANALYZE"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _validate_restore_sql(sql: str) -> None:
+    """Validate that a SQL dump only contains safe DDL/DML statements.
+
+    Uses the same statement-level parsing as _filter_fts_from_sql to handle
+    multi-line statements with embedded semicolons (e.g. INSERT with JSON
+    values containing ';'). Raises ValueError if the dump contains statements
+    outside the allowlist (e.g. ATTACH, PRAGMA, LOAD_EXTENSION).
+    """
+    current_stmt_lines: list[str] = []
+    in_block = False
+
+    def _check_statement(stmt: str) -> None:
+        stripped = stmt.strip()
+        if not stripped:
+            return
+        if not _ALLOWED_SQL_PREFIXES.match(stripped):
+            preview = stripped[:80] + ("..." if len(stripped) > 80 else "")
+            raise ValueError(f"Disallowed SQL statement in restore dump: {preview}")
+
+    for line in sql.splitlines():
+        stripped = line.strip()
+        current_stmt_lines.append(line)
+
+        if not in_block and re.match(r"CREATE\s+TRIGGER\b", stripped, re.IGNORECASE):
+            in_block = True
+
+        if stripped.endswith(";"):
+            if in_block:
+                if stripped.upper() == "END;":
+                    _check_statement("\n".join(current_stmt_lines))
+                    current_stmt_lines = []
+                    in_block = False
+            else:
+                _check_statement("\n".join(current_stmt_lines))
+                current_stmt_lines = []
+
+    if current_stmt_lines:
+        _check_statement("\n".join(current_stmt_lines))
+
+
 def prune_old_tweets(conn: sqlite3.Connection, days: int = 14) -> int:
     """Delete tweets older than specified days. Returns count deleted."""
     cursor = conn.execute(
@@ -159,6 +216,11 @@ def restore_sql(
     # CREATE TRIGGER with embedded semicolons). We accumulate lines into
     # complete statements, then check each whole statement for FTS refs.
     filtered_sql = _filter_fts_from_sql(sql)
+
+    # Validate that the filtered SQL only contains expected DDL/DML.
+    # Reject dangerous statements that could escape the SQLite sandbox
+    # (e.g. ATTACH to overwrite files, PRAGMA to load extensions).
+    _validate_restore_sql(filtered_sql)
 
     # Execute the filtered SQL
     conn = sqlite3.connect(db_path)

--- a/twag/web/frontend/vite.config.ts
+++ b/twag/web/frontend/vite.config.ts
@@ -11,9 +11,9 @@ export default defineConfig({
     },
   },
   server: {
-    host: "0.0.0.0",
+    host: "127.0.0.1",
     port: 8080,
-    allowedHosts: true,
+    allowedHosts: ["localhost", "127.0.0.1"],
     proxy: {
       "/api": {
         target: "http://localhost:5173",

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import re
 import shlex
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -284,6 +285,47 @@ def _extract_tweet_variables(tweet_row) -> dict[str, str]:
     return variables
 
 
+def _get_allowed_paths() -> list[Path]:
+    """Return the list of directories that commands are allowed to read from."""
+    from ...config import get_data_dir
+
+    return [get_data_dir()]
+
+
+def _validate_file_paths(args: list[str]) -> str | None:
+    """Check that any file path arguments are within allowed directories.
+
+    Returns an error message if a disallowed path is found, None if OK.
+    Commands that read files (cat, grep, rg, head, tail, sed, wc) must
+    only access files under the twag data directory.
+    """
+    # Commands that take file path arguments
+    file_reading_commands = {"cat", "grep", "head", "rg", "sed", "tail", "wc"}
+    base_cmd = args[0].strip("{}")
+    if base_cmd not in file_reading_commands:
+        return None
+
+    allowed_dirs = _get_allowed_paths()
+
+    for arg in args[1:]:
+        # Skip flags (arguments starting with -)
+        if arg.startswith("-"):
+            continue
+        # Check if this looks like a file path (not a pattern/regex argument)
+        candidate = Path(arg)
+        try:
+            resolved = candidate.resolve()
+        except (OSError, ValueError):
+            continue
+        # Only validate arguments that look like existing paths or absolute paths
+        if not candidate.is_absolute() and not resolved.exists():
+            continue
+        if not any(resolved == d or d in resolved.parents for d in allowed_dirs):
+            return f"Path '{arg}' is outside the allowed data directory"
+
+    return None
+
+
 async def _run_command(command: str, timeout: float = 30.0) -> tuple[str, str, int]:
     """Run a command and return (stdout, stderr, returncode).
 
@@ -299,6 +341,9 @@ async def _run_command(command: str, timeout: float = 30.0) -> tuple[str, str, i
             return "", f"Command '{base_cmd}' is not in the allowed list", -1
         if _DANGEROUS_PATTERN.search(command):
             return "", "Command contains forbidden shell metacharacters", -1
+        path_error = _validate_file_paths(args)
+        if path_error:
+            return "", path_error, -1
         proc = await asyncio.create_subprocess_exec(
             *args,
             stdout=asyncio.subprocess.PIPE,
@@ -478,6 +523,9 @@ Return your analysis in a structured format."""
             "analysis": analysis,
         }
 
-    except Exception as e:
+    except Exception:
         log.exception("Context-enriched analysis failed for tweet %s", tweet_id)
-        raise HTTPException(status_code=500, detail=f"Analysis failed: {e!s}") from e
+        raise HTTPException(
+            status_code=500,
+            detail="Analysis failed due to an internal error",
+        ) from None


### PR DESCRIPTION
## Summary

Addresses 4 directly-fixable security foot-guns found during audit, plus 2 informational findings documented below.

### Fixes implemented

1. **Web server LAN exposure** (`twag/cli/web.py`): Default host changed from `0.0.0.0` to `127.0.0.1`. The unauthenticated FastAPI server no longer binds to all interfaces by default. Users who need LAN access can still pass `--host 0.0.0.0` explicitly.

2. **Vite DNS rebinding** (`twag/web/frontend/vite.config.ts`): Dev server host changed to `127.0.0.1` and `allowedHosts: true` replaced with explicit `["localhost", "127.0.0.1"]` allowlist, restoring DNS rebinding protection.

3. **SQL restore injection** (`twag/db/maintenance.py`): Added `_validate_restore_sql()` which parses statements using the same multi-line-aware logic as `_filter_fts_from_sql()` and rejects anything outside an explicit allowlist (INSERT, CREATE TABLE/INDEX/TRIGGER, BEGIN, COMMIT, etc.). Blocks ATTACH, PRAGMA, LOAD_EXTENSION, and other dangerous statements from user-supplied dump files.

4. **Arbitrary filesystem reads** (`twag/web/routes/context.py`): Added `_validate_file_paths()` to `_run_command()` so file-reading commands (cat, grep, rg, head, tail, sed, wc) can only access files under the twag data directory. Also sanitized the analyze endpoint error message to prevent leaking internal exception details.

### Informational findings (no code change)

5. **Auth tokens in /proc** (Finding 1): `bird` CLI receives `AUTH_TOKEN` and `CT0` as command-line arguments, making them visible in `/proc/<pid>/cmdline`. This is an upstream limitation of the `bird` CLI — mitigating it requires bird to support env-var or file-based credential passing.

6. **f-string SQL column interpolation** (Finding 2): Some queries use f-strings to interpolate column names (not user input). Safe today because the interpolated values come from hardcoded constants, but structurally fragile if those constants ever become user-controllable.

## Test plan

- [x] All existing tests pass (357 tests, 0 failures)
- [x] `ruff check`, `ruff format`, `ty check` all pass
- [ ] Verify `twag web` still serves on localhost
- [ ] Verify `twag web --host 0.0.0.0` still works for explicit LAN binding
- [ ] Verify `twag db restore` works with a valid dump
- [ ] Verify `twag db restore` rejects a dump containing `ATTACH DATABASE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)