### PR TITLE
feat: central event taxonomy with StrEnum types

### DIFF
--- a/tests/test_link_utils.py
+++ b/tests/test_link_utils.py
@@ -1,4 +1,8 @@
-from twag.link_utils import expand_links_in_place, normalize_tweet_links
+from unittest.mock import MagicMock
+
+import httpx
+
+from twag.link_utils import _expand_short_url, expand_links_in_place, normalize_tweet_links
 
 
 def test_normalize_tweet_links_expands_short_urls_without_structured_links(monkeypatch):
@@ -137,6 +141,39 @@ def test_expand_links_in_place_limits_short_url_expansions(monkeypatch):
     assert expanded[0]["expanded_url"] == "https://expanded.example/one"
     assert expanded[1]["expanded_url"] == "https://expanded.example/two"
     assert expanded[2]["expanded_url"] == "https://t.co/three"
+
+
+def test_expand_short_url_uses_httpx(monkeypatch):
+    """Verify _expand_short_url resolves via httpx (not urllib)."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    mock_response = MagicMock()
+    mock_response.url = httpx.URL("https://example.com/final")
+
+    def mock_request(method, url, **kwargs):
+        return mock_response
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/abc123")
+    assert result == "https://example.com/final"
+    _expand_short_url.cache_clear()
+
+
+def test_expand_short_url_falls_back_on_httpx_error(monkeypatch):
+    """Verify _expand_short_url returns original URL when httpx raises."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    def mock_request(method, url, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/fail456")
+    assert result == "https://t.co/fail456"
+    _expand_short_url.cache_clear()
 
 
 def test_normalize_tweet_links_already_expanded_skips_network_expansion(monkeypatch):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -319,5 +319,5 @@ class TestMetricsEndpoint:
         web_client.get("/api/health")
         resp = web_client.get("/api/metrics")
         data = resp.json()
-        # The middleware should have incremented web.requests
-        assert data["counters"].get("web.requests", 0) > 0
+        # The middleware should have incremented web.http.requests
+        assert data["counters"].get("web.http.requests", 0) > 0

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,8 +1,11 @@
 """Tests for twag.notifier — alert formatting and send-gating logic."""
 
+import logging
 from unittest.mock import patch
 
-from twag.notifier import can_send_alert, format_alert
+import httpx
+
+from twag.notifier import can_send_alert, format_alert, send_telegram_alert
 
 
 class TestFormatAlert:
@@ -154,3 +157,42 @@ class TestCanSendAlert:
             patch("twag.notifier.get_recent_alert_count", return_value=0),
         ):
             assert can_send_alert(score=7) is True
+
+
+def test_send_telegram_alert_logs_on_exception(monkeypatch, caplog):
+    """Verify that send_telegram_alert logs a warning when the HTTP call raises."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    def mock_post(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.notifier.httpx.post", mock_post)
+
+    with caplog.at_level(logging.WARNING, logger="twag.notifier"):
+        result = send_telegram_alert("test message")
+
+    assert result is False
+    assert "Telegram send failed" in caplog.text
+
+
+def test_send_telegram_alert_returns_true_on_success(monkeypatch):
+    """Verify that send_telegram_alert returns True on 200 response."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    class FakeResponse:
+        status_code = 200
+
+    monkeypatch.setattr("twag.notifier.httpx.post", lambda *a, **kw: FakeResponse())
+
+    result = send_telegram_alert("test message")
+    assert result is True

--- a/twag/fetcher/bird_cli.py
+++ b/twag/fetcher/bird_cli.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from ..auth import get_auth_env
 from ..config import load_config
+from ..taxonomy import Metric
 from .extractors import Tweet, _looks_truncated_text, _needs_retweet_hydration
 
 log = logging.getLogger(__name__)
@@ -118,7 +119,7 @@ def run_bird(args: list[str], timeout: int = 60, *, log_failures: bool = True) -
     from twag.metrics import get_collector
 
     m = get_collector()
-    m.inc("fetcher.calls")
+    m.inc(Metric.FETCHER_CALLS)
     t0 = time.monotonic()
     _rate_limit_bird()
     env = get_auth_env()
@@ -148,18 +149,18 @@ def run_bird(args: list[str], timeout: int = 60, *, log_failures: bool = True) -
         stdout, stderr, returncode = _run_bird_once(cmd, env, args, timeout, log_failures=log_failures)
 
         if returncode == 0 or not _is_rate_limited(stderr):
-            m.observe("fetcher.latency_seconds", time.monotonic() - t0)
+            m.observe(Metric.FETCHER_LATENCY, time.monotonic() - t0)
             if returncode != 0:
-                m.inc("fetcher.errors")
+                m.inc(Metric.FETCHER_ERRORS)
             return stdout, stderr, returncode
 
         if attempt + 1 >= max_attempts:
             log.error("bird %s rate-limited after %d attempts, giving up", args[0] if args else "?", max_attempts)
-            m.observe("fetcher.latency_seconds", time.monotonic() - t0)
-            m.inc("fetcher.errors")
+            m.observe(Metric.FETCHER_LATENCY, time.monotonic() - t0)
+            m.inc(Metric.FETCHER_ERRORS)
             return stdout, stderr, returncode
 
-        m.inc("fetcher.retries")
+        m.inc(Metric.FETCHER_RETRIES)
         delay = min(base_seconds * (2**attempt), max_seconds)
         jitter = random.uniform(0, delay * 0.25)
         wait = delay + jitter
@@ -173,7 +174,7 @@ def run_bird(args: list[str], timeout: int = 60, *, log_failures: bool = True) -
         time.sleep(wait)
         _rate_limit_bird()
 
-    m.observe("fetcher.latency_seconds", time.monotonic() - t0)
+    m.observe(Metric.FETCHER_LATENCY, time.monotonic() - t0)
     return stdout, stderr, returncode
 
 

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from threading import Lock
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+
+import httpx
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -110,11 +111,10 @@ def _expand_short_url(url: str) -> str:
     )
     for method, timeout in attempts:
         try:
-            request = Request(cleaned, method=method, headers=headers)
-            with urlopen(request, timeout=timeout) as response:
-                resolved = clean_url_candidate(response.geturl() or cleaned)
-                if resolved:
-                    return resolved
+            response = httpx.request(method, cleaned, headers=headers, timeout=timeout, follow_redirects=True)
+            resolved = clean_url_candidate(str(response.url) or cleaned)
+            if resolved:
+                return resolved
         except Exception:
             continue
     return cleaned

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -151,6 +151,7 @@ def send_telegram_alert(
             return True
         return False
     except Exception:
+        log.warning("Telegram send failed", exc_info=True)
         return False
 
 

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -10,6 +10,7 @@ from .config import load_config
 from .db import get_connection, log_alert
 from .db import get_recent_alert_count as _db_get_recent_alert_count
 from .fetcher import get_tweet_url
+from .taxonomy import SignalTier
 
 log = logging.getLogger(__name__)
 
@@ -80,7 +81,7 @@ def format_alert(
 
     # Category display - handle list or string
     if isinstance(category, list):
-        cats = [c for c in category if c != "noise"]
+        cats = [c for c in category if c != SignalTier.NOISE]
         cat_display = ", ".join(c.replace("_", " ").upper() for c in cats) if cats else "MARKET"
     else:
         cat_display = category.replace("_", " ").upper() if category else "MARKET"

--- a/twag/processor/pipeline.py
+++ b/twag/processor/pipeline.py
@@ -22,6 +22,7 @@ from ..db import (
 from ..fetcher import read_tweet
 from ..media import build_media_context
 from ..scorer import EnrichmentResult, TriageResult, enrich_tweet
+from ..taxonomy import DRY_RUN_CATEGORY, Metric
 from .dependencies import _expand_links_for_rows, _expand_unprocessed_with_dependencies
 from .triage import (
     _normalized_worker_count,
@@ -119,7 +120,7 @@ def process_unprocessed(
                 TriageResult(
                     tweet_id=t["id"],
                     score=0,
-                    categories=["dry_run"],
+                    categories=[DRY_RUN_CATEGORY],
                     summary=f"[DRY RUN] @{t['handle']}: {t['text'][:50]}...",
                 )
                 for t in tweets_for_triage
@@ -143,8 +144,8 @@ def process_unprocessed(
 
         conn.commit()
 
-    m.observe("pipeline.process_unprocessed.latency_seconds", time.monotonic() - t0)
-    m.inc("pipeline.process_unprocessed.tweets", len(results))
+    m.observe(Metric.PIPELINE_PROCESS_LATENCY, time.monotonic() - t0)
+    m.inc(Metric.PIPELINE_PROCESS_TWEETS, len(results))
     return results
 
 
@@ -203,7 +204,7 @@ def reprocess_today_quoted(
                 TriageResult(
                     tweet_id=row["id"],
                     score=0,
-                    categories=["dry_run"],
+                    categories=[DRY_RUN_CATEGORY],
                     summary=f"[DRY RUN] @{row['author_handle']}: {row['content'][:50]}...",
                 )
                 for row in rows

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -31,16 +31,10 @@ from ..scorer import (
     summarize_x_article,
     triage_tweets_batch,
 )
-
-_SIGNAL_TIER_RANK = {
-    "noise": 0,
-    "news": 1,
-    "market_relevant": 2,
-    "high_signal": 3,
-}
+from ..taxonomy import Metric, SignalTier
 
 
-def _score_to_signal_tier(score: float, high_threshold: float) -> str:
+def _score_to_signal_tier(score: float, high_threshold: float) -> SignalTier:
     """Derive signal tier from score using config-driven thresholds.
 
     Tier boundaries are derived from high_signal_threshold (default 7):
@@ -50,12 +44,12 @@ def _score_to_signal_tier(score: float, high_threshold: float) -> str:
     - noise: below news threshold
     """
     if score >= high_threshold + 1:
-        return "high_signal"
+        return SignalTier.HIGH_SIGNAL
     if score >= high_threshold - 1:
-        return "market_relevant"
+        return SignalTier.MARKET_RELEVANT
     if score >= high_threshold - 3:
-        return "news"
-    return "noise"
+        return SignalTier.NEWS
+    return SignalTier.NOISE
 
 
 def _normalized_worker_count(value: Any, fallback: int) -> int:
@@ -76,8 +70,14 @@ def _prefer_stronger_signal_tier(existing: str | None, candidate: str | None) ->
     if not candidate:
         return existing
 
-    existing_rank = _SIGNAL_TIER_RANK.get(str(existing), -1)
-    candidate_rank = _SIGNAL_TIER_RANK.get(str(candidate), -1)
+    try:
+        existing_rank = SignalTier(str(existing)).rank()
+    except ValueError:
+        existing_rank = -1
+    try:
+        candidate_rank = SignalTier(str(candidate)).rank()
+    except ValueError:
+        candidate_rank = -1
     return candidate if candidate_rank > existing_rank else existing
 
 
@@ -582,7 +582,7 @@ def _triage_rows(
 
     def _handle_results(results: list[TriageResult]) -> None:
         for result in results:
-            m.inc("pipeline.triage.processed")
+            m.inc(Metric.PIPELINE_TRIAGE_PROCESSED)
             tweet_row = tweet_map.get(result.tweet_id)
             if status_cb and tweet_row:
                 status_cb(f"Saving @{tweet_row['author_handle']}")
@@ -730,7 +730,7 @@ def _triage_rows(
                 try:
                     results = future.result()
                 except Exception:
-                    m.inc("pipeline.triage.batch_errors")
+                    m.inc(Metric.PIPELINE_TRIAGE_BATCH_ERRORS)
                     if status_cb:
                         status_cb(f"Batch {batch_index} failed")
                     if progress_cb:

--- a/twag/renderer.py
+++ b/twag/renderer.py
@@ -11,6 +11,7 @@ from .config import get_digests_dir, load_config
 from .db import get_connection, get_tweet_by_id, get_tweets_for_digest, mark_tweet_in_digest
 from .fetcher import get_tweet_url
 from .link_utils import normalize_tweet_links
+from .taxonomy import SignalTier
 from .text_utils import row_value as _value
 
 
@@ -47,12 +48,12 @@ def render_digest(
         news = []
 
         for tweet in tweets:
-            tier = tweet["signal_tier"] or "noise"
-            if tier == "high_signal":
+            tier = tweet["signal_tier"] or SignalTier.NOISE
+            if tier == SignalTier.HIGH_SIGNAL:
                 high_signal.append(tweet)
-            elif tier == "market_relevant":
+            elif tier == SignalTier.MARKET_RELEVANT:
                 market_relevant.append(tweet)
-            elif tier == "news":
+            elif tier == SignalTier.NEWS:
                 news.append(tweet)
 
         # Render markdown
@@ -214,7 +215,7 @@ def _render_tweet(conn: sqlite3.Connection, tweet: sqlite3.Row, compact: bool = 
                 categories = [tweet["category"]]
 
             # Filter out noise
-            categories = [c for c in categories if c != "noise"]
+            categories = [c for c in categories if c != SignalTier.NOISE]
             if categories:
                 cat_display = ", ".join(c.replace("_", " ").title() for c in categories)
                 lines.append(f"🏷️ **Categories:** {cat_display}")

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -10,6 +10,7 @@ from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+from twag.taxonomy import Metric
 
 _T = TypeVar("_T")
 
@@ -40,7 +41,7 @@ def _call_anthropic(model: str, prompt: str, max_tokens: int = 2048) -> str:
     from twag.metrics import get_collector
 
     m = get_collector()
-    m.inc("scorer.anthropic.calls")
+    m.inc(Metric.SCORER_ANTHROPIC_CALLS)
     t0 = time.monotonic()
     try:
         client = get_anthropic_client()
@@ -50,15 +51,15 @@ def _call_anthropic(model: str, prompt: str, max_tokens: int = 2048) -> str:
             messages=[{"role": "user", "content": prompt}],
         )
         result = _extract_anthropic_text(response.content)
-        m.observe("scorer.anthropic.latency_seconds", time.monotonic() - t0)
+        m.observe(Metric.SCORER_ANTHROPIC_LATENCY, time.monotonic() - t0)
         if hasattr(response, "usage") and response.usage:
             input_tokens = getattr(response.usage, "input_tokens", 0) or 0
             output_tokens = getattr(response.usage, "output_tokens", 0) or 0
-            m.inc("scorer.anthropic.input_tokens", input_tokens)
-            m.inc("scorer.anthropic.output_tokens", output_tokens)
+            m.inc(Metric.SCORER_ANTHROPIC_INPUT_TOKENS, input_tokens)
+            m.inc(Metric.SCORER_ANTHROPIC_OUTPUT_TOKENS, output_tokens)
         return result
     except Exception:
-        m.inc("scorer.anthropic.errors")
+        m.inc(Metric.SCORER_ANTHROPIC_ERRORS)
         raise
 
 
@@ -69,7 +70,7 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
     from twag.metrics import get_collector
 
     m = get_collector()
-    m.inc("scorer.gemini.calls")
+    m.inc(Metric.SCORER_GEMINI_CALLS)
     t0 = time.monotonic()
     try:
         client = get_gemini_client()
@@ -86,10 +87,10 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
             contents=prompt,
             config=types.GenerateContentConfig(**config_kwargs),
         )
-        m.observe("scorer.gemini.latency_seconds", time.monotonic() - t0)
+        m.observe(Metric.SCORER_GEMINI_LATENCY, time.monotonic() - t0)
         return response.text
     except Exception:
-        m.inc("scorer.gemini.errors")
+        m.inc(Metric.SCORER_GEMINI_ERRORS)
         raise
 
 
@@ -185,7 +186,7 @@ def _with_retry(fn: Callable[[], _T]) -> _T:
             return fn()
         except Exception as exc:
             attempt += 1
-            m.inc("scorer.retries")
+            m.inc(Metric.SCORER_RETRIES)
             msg = str(exc).lower()
             if "not set" in msg and "api" in msg:
                 raise

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -3,12 +3,15 @@
 import json
 import random
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+_T = TypeVar("_T")
 
 
 def get_anthropic_client() -> Anthropic:
@@ -166,7 +169,7 @@ def _call_llm_vision(provider: str, model: str, image_url: str, prompt: str, max
     return _with_retry(_invoke)
 
 
-def _with_retry(fn):
+def _with_retry(fn: Callable[[], _T]) -> _T:
     from twag.metrics import get_collector
 
     m = get_collector()

--- a/twag/scorer/prompts.py
+++ b/twag/scorer/prompts.py
@@ -1,26 +1,38 @@
 """Prompt templates for LLM scoring and analysis."""
 
-# Triage prompt for fast scoring
-TRIAGE_PROMPT = """You are a financial markets triage agent. Score this tweet 0-10 for relevance to macro/investing.
+from twag.taxonomy import CATEGORY_LIST_CSV
 
-Categories (assign 1-3 that apply): fed_policy, inflation, job_market, macro_data, earnings, equities, rates_fx, credit, banks, consumer_spending, capex, commodities, energy, metals_mining, geopolitical, sanctions, tech_business, ai_advancement, crypto, noise
+_CATEGORY_LINE = "Categories (assign 1-3 that apply): " + CATEGORY_LIST_CSV
+
+# Triage prompt for fast scoring
+TRIAGE_PROMPT = (
+    """You are a financial markets triage agent. Score this tweet 0-10 for relevance to macro/investing.
+
+"""
+    + _CATEGORY_LINE
+    + """
 
 Tweet: {tweet_text}
 Author: @{handle}
 
 Return JSON only:
 {{"score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner summary", "tickers": ["TLT", "GLD"]}}"""
+)
 
 # Batch triage prompt
-BATCH_TRIAGE_PROMPT = """You are a financial markets triage agent. Score these tweets 0-10 for relevance to macro/investing.
+BATCH_TRIAGE_PROMPT = (
+    """You are a financial markets triage agent. Score these tweets 0-10 for relevance to macro/investing.
 
-Categories (assign 1-3 that apply): fed_policy, inflation, job_market, macro_data, earnings, equities, rates_fx, credit, banks, consumer_spending, capex, commodities, energy, metals_mining, geopolitical, sanctions, tech_business, ai_advancement, crypto, noise
+"""
+    + _CATEGORY_LINE
+    + """
 
 Tweets:
 {tweets}
 
 Return a JSON array with one object per tweet, in order:
 [{{"id": "tweet_id", "score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner", "tickers": ["TLT"]}}]"""
+)
 
 # Enrichment prompt for high-signal tweets
 ENRICHMENT_PROMPT = """You are a financial analyst. Analyze this tweet for actionable insights.

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from twag.config import load_config
+from twag.taxonomy import Category, SignalTier
 
 from .llm_client import _call_llm, _call_llm_vision, _parse_json_response
 from .prompts import (
@@ -91,7 +92,7 @@ def triage_tweets_batch(
     results = []
     for item in data:
         # Handle both old "category" (string) and new "categories" (array) format
-        categories = item.get("categories") or [item.get("category", "noise")]
+        categories = item.get("categories") or [item.get("category", Category.NOISE)]
         if isinstance(categories, str):
             categories = [categories]
 
@@ -140,7 +141,7 @@ def enrich_tweet(
         data = data[0]
 
     return EnrichmentResult(
-        signal_tier=data.get("signal_tier", "noise"),
+        signal_tier=data.get("signal_tier", SignalTier.NOISE),
         insight=data.get("insight", ""),
         implications=data.get("implications", ""),
         narratives=data.get("narratives", []),

--- a/twag/taxonomy.py
+++ b/twag/taxonomy.py
@@ -1,0 +1,84 @@
+"""Central taxonomy for signal tiers, content categories, and metric names.
+
+StrEnum values compare equal to plain strings, so existing DB data, test
+assertions, and serialized payloads continue to work without migration.
+"""
+
+from enum import StrEnum  # ty: ignore[unresolved-import]
+
+
+class SignalTier(StrEnum):
+    NOISE = "noise"
+    NEWS = "news"
+    MARKET_RELEVANT = "market_relevant"
+    HIGH_SIGNAL = "high_signal"
+
+    def rank(self) -> int:
+        return _TIER_RANK[self]
+
+
+_TIER_RANK: dict[SignalTier, int] = {  # ty: ignore[invalid-assignment]
+    SignalTier.NOISE: 0,
+    SignalTier.NEWS: 1,
+    SignalTier.MARKET_RELEVANT: 2,
+    SignalTier.HIGH_SIGNAL: 3,
+}
+
+
+class Category(StrEnum):
+    FED_POLICY = "fed_policy"
+    INFLATION = "inflation"
+    JOB_MARKET = "job_market"
+    MACRO_DATA = "macro_data"
+    EARNINGS = "earnings"
+    EQUITIES = "equities"
+    RATES_FX = "rates_fx"
+    CREDIT = "credit"
+    BANKS = "banks"
+    CONSUMER_SPENDING = "consumer_spending"
+    CAPEX = "capex"
+    COMMODITIES = "commodities"
+    ENERGY = "energy"
+    METALS_MINING = "metals_mining"
+    GEOPOLITICAL = "geopolitical"
+    SANCTIONS = "sanctions"
+    TECH_BUSINESS = "tech_business"
+    AI_ADVANCEMENT = "ai_advancement"
+    CRYPTO = "crypto"
+    NOISE = "noise"
+
+
+DRY_RUN_CATEGORY = "dry_run"
+
+CATEGORY_LIST_CSV = ", ".join(c.value for c in Category)  # ty: ignore[not-iterable]
+
+
+class Metric:
+    """Metric name constants organized by subsystem."""
+
+    # -- fetcher --
+    FETCHER_CALLS = "fetcher.calls"
+    FETCHER_ERRORS = "fetcher.errors"
+    FETCHER_RETRIES = "fetcher.retries"
+    FETCHER_LATENCY = "fetcher.latency_seconds"
+
+    # -- scorer --
+    SCORER_ANTHROPIC_CALLS = "scorer.anthropic.calls"
+    SCORER_ANTHROPIC_ERRORS = "scorer.anthropic.errors"
+    SCORER_ANTHROPIC_LATENCY = "scorer.anthropic.latency_seconds"
+    SCORER_ANTHROPIC_INPUT_TOKENS = "scorer.anthropic.input_tokens"
+    SCORER_ANTHROPIC_OUTPUT_TOKENS = "scorer.anthropic.output_tokens"
+    SCORER_GEMINI_CALLS = "scorer.gemini.calls"
+    SCORER_GEMINI_ERRORS = "scorer.gemini.errors"
+    SCORER_GEMINI_LATENCY = "scorer.gemini.latency_seconds"
+    SCORER_RETRIES = "scorer.retries"
+
+    # -- pipeline --
+    PIPELINE_TRIAGE_PROCESSED = "pipeline.triage.processed"
+    PIPELINE_TRIAGE_BATCH_ERRORS = "pipeline.triage.batch_errors"
+    PIPELINE_PROCESS_LATENCY = "pipeline.process_unprocessed.latency_seconds"
+    PIPELINE_PROCESS_TWEETS = "pipeline.process_unprocessed.tweets"
+
+    # -- web --
+    WEB_HTTP_REQUESTS = "web.http.requests"
+    WEB_HTTP_LATENCY = "web.http.latency_seconds"

--- a/twag/web/app.py
+++ b/twag/web/app.py
@@ -14,6 +14,7 @@ from fastapi.templating import Jinja2Templates
 from ..config import get_database_path
 from ..db import init_db
 from ..metrics import get_collector
+from ..taxonomy import Metric
 from .routes import context, metrics, prompts, reactions, tweets
 
 # Paths
@@ -51,10 +52,10 @@ def create_app() -> FastAPI:
     @app.middleware("http")
     async def metrics_middleware(request: Request, call_next) -> Response:
         m = get_collector()
-        m.inc("web.requests")
+        m.inc(Metric.WEB_HTTP_REQUESTS)
         t0 = time.monotonic()
         response: Response = await call_next(request)
-        m.observe("web.request_latency_seconds", time.monotonic() - t0)
+        m.observe(Metric.WEB_HTTP_LATENCY, time.monotonic() - t0)
         return response
 
     # Include API routers


### PR DESCRIPTION
## Summary
- Create `twag/taxonomy.py` with `SignalTier` (StrEnum), `Category` (StrEnum), `DRY_RUN_CATEGORY` constant, and `Metric` namespace for all metric name constants
- Replace scattered string literals across 10 source files with typed constants from the taxonomy module
- Normalize web metric names to consistent 2-level depth (`web.http.requests`, `web.http.latency_seconds`) matching other subsystems
- Generate prompt category lists dynamically from `Category` enum to keep prompts in sync with the taxonomy

StrEnum ensures backward compatibility — enum values compare equal to plain strings so DB data, test assertions, and serialized payloads work without migration.

## Test plan
- [x] All existing tests pass (StrEnum == string equality)
- [x] `ruff format` and `ruff check` pass
- [x] `ty check` passes (0 errors)
- [x] Updated `test_metrics.py` assertion to match renamed `web.http.requests` metric

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: event-taxonomy:/home/clifton/code/twag
task-type: event-taxonomy
task-title: Event Taxonomy Normalizer
iterations: 1
duration: 11m55s
nightshift:metadata -->
