### PR TITLE
fix: add loggers and replace silent exception swallowing across pipeline

### DIFF
--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -1,5 +1,7 @@
 """CLI entry point for twag."""
 
+import logging
+
 import rich_click as click
 
 from .. import __version__
@@ -26,6 +28,11 @@ from .analyze import _analysis_wrap_width as _analysis_wrap_width
 from .analyze import _echo_labeled as _echo_labeled
 from .analyze import _echo_wrapped as _echo_wrapped
 from .analyze import _print_status_analysis as _print_status_analysis
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    level=logging.WARNING,
+)
 
 
 @click.group()

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
 from functools import lru_cache
@@ -9,6 +10,8 @@ from threading import Lock
 from urllib.parse import urlparse
 
 import httpx
+
+log = logging.getLogger(__name__)
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -116,6 +119,7 @@ def _expand_short_url(url: str) -> str:
             if resolved:
                 return resolved
         except Exception:
+            log.debug("URL expansion failed for %s via %s", cleaned, method, exc_info=True)
             continue
     return cleaned
 

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -37,7 +37,7 @@ def get_recent_alert_count() -> int:
         with get_connection() as conn:
             return _db_get_recent_alert_count(conn, minutes=60)
     except Exception:
-        log.warning("Failed to query alert log; allowing alert")
+        log.warning("Failed to query alert log; allowing alert", exc_info=True)
         return 0
 
 
@@ -147,7 +147,7 @@ def send_telegram_alert(
                     log_alert(conn, tweet_id=tweet_id, chat_id=chat_id)
                     conn.commit()
             except Exception:
-                log.warning("Failed to log alert to database")
+                log.warning("Failed to log alert to database", exc_info=True)
             return True
         return False
     except Exception:

--- a/twag/processor/storage.py
+++ b/twag/processor/storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -29,6 +30,8 @@ from .dependencies import (
     _fetch_quote_chain,
     _fetch_reply_chain,
 )
+
+log = logging.getLogger(__name__)
 
 
 def _store_tweets(
@@ -140,6 +143,7 @@ def _store_tweets(
     )
     conn.commit()
 
+    log.info("Stored %d/%d tweets from %s", new_count, fetched, source)
     return fetched, new_count
 
 

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -158,6 +158,7 @@ def _analyze_media_items(
         try:
             result = analyze_media(url, model=vision_model, provider=vision_provider)
         except Exception:
+            log.warning("Media analysis failed for %s", url, exc_info=True)
             continue
 
         item["kind"] = result.kind
@@ -209,6 +210,7 @@ def _merge_document_media(media_items: list[dict[str, Any]]) -> bool:
     try:
         combined_summary = summarize_document_text(combined_text)
     except Exception:
+        log.warning("Document summarization failed, using fallback", exc_info=True)
         combined_summary = (media_items[doc_entries[0][1]].get("prose_summary") or "").strip()
 
     primary_idx = doc_entries[0][1]

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -1,6 +1,7 @@
 """LLM client infrastructure: provider dispatch, retry logic, JSON parsing."""
 
 import json
+import logging
 import random
 import time
 from collections.abc import Callable
@@ -10,6 +11,8 @@ from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+log = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
@@ -59,6 +62,7 @@ def _call_anthropic(model: str, prompt: str, max_tokens: int = 2048) -> str:
         return result
     except Exception:
         m.inc("scorer.anthropic.errors")
+        log.warning("Anthropic call failed for model %s", model, exc_info=True)
         raise
 
 
@@ -90,6 +94,7 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
         return response.text
     except Exception:
         m.inc("scorer.gemini.errors")
+        log.warning("Gemini call failed for model %s", model, exc_info=True)
         raise
 
 
@@ -190,8 +195,10 @@ def _with_retry(fn: Callable[[], _T]) -> _T:
             if "not set" in msg and "api" in msg:
                 raise
             if retries and attempt >= retries:
+                log.warning("LLM retry exhausted after %d attempts", attempt, exc_info=True)
                 raise
 
+            log.debug("LLM retry attempt %d/%d: %s", attempt, retries, exc)
             delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
             if jitter:
                 delay = max(0.0, delay * (1 + random.uniform(-jitter, jitter)))

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -1,5 +1,6 @@
 """Scoring, triage, enrichment, and analysis functions."""
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -14,6 +15,8 @@ from .prompts import (
     MEDIA_PROMPT,
     SUMMARIZE_PROMPT,
 )
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -227,6 +230,12 @@ def summarize_x_article(
             data = _parse_json_response(text)
             break
         except Exception:
+            log.warning(
+                "Article summary failed with provider=%s model=%s, trying next",
+                cand_provider,
+                cand_model,
+                exc_info=True,
+            )
             continue
 
     if data is None:

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -1,6 +1,7 @@
 """Tweet feed API routes."""
 
 import json
+import logging
 import re
 from datetime import datetime
 from typing import Annotated, Any
@@ -15,6 +16,8 @@ from ..tweet_utils import (
     normalize_links_for_display,
     quote_embed_from_row,
 )
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(tags=["tweets"])
 MAX_QUOTE_DEPTH = 3
@@ -60,6 +63,7 @@ def _build_quote_embed(
             if isinstance(decoded, list):
                 links_json = [item for item in decoded if isinstance(item, dict)]
         except json.JSONDecodeError:
+            log.debug("Malformed links_json for tweet %s", row["id"])
             links_json = []
     normalized = normalize_links_for_display(
         tweet_id=row["id"],
@@ -108,6 +112,7 @@ def _build_quote_embed_from_cache(
             if isinstance(decoded, list):
                 links_json = [item for item in decoded if isinstance(item, dict)]
         except json.JSONDecodeError:
+            log.debug("Malformed links_json for tweet %s", row["id"])
             links_json = []
     normalized = normalize_links_for_display(
         tweet_id=row["id"],
@@ -244,7 +249,7 @@ async def list_tweets(
                                     if tid and tid != row["id"] and tid not in quote_cache:
                                         next_ids.add(tid)
                     except json.JSONDecodeError:
-                        pass
+                        log.debug("Malformed links_json for tweet %s", row["id"])
             ids_to_fetch = next_ids
 
         # Phase 3: Build response from cache
@@ -400,6 +405,7 @@ async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
                 if isinstance(decoded, list):
                     article_primary_points = [item for item in decoded if isinstance(item, dict)]
             except json.JSONDecodeError:
+                log.debug("Malformed article_primary_points_json for tweet %s", tweet["id"])
                 article_primary_points = []
 
         article_action_items = []
@@ -409,6 +415,7 @@ async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
                 if isinstance(decoded, list):
                     article_action_items = [item for item in decoded if isinstance(item, dict)]
             except json.JSONDecodeError:
+                log.debug("Malformed article_action_items_json for tweet %s", tweet["id"])
                 article_action_items = []
 
         article_top_visual = None
@@ -418,6 +425,7 @@ async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
                 if isinstance(decoded, dict):
                     article_top_visual = decoded
             except json.JSONDecodeError:
+                log.debug("Malformed article_top_visual_json for tweet %s", tweet["id"])
                 article_top_visual = None
 
         # Parse links from links_json
@@ -428,6 +436,7 @@ async def get_tweet(request: Request, tweet_id: str) -> dict[str, Any]:
                 if isinstance(decoded, list):
                     links = [item for item in decoded if isinstance(item, dict)]
             except json.JSONDecodeError:
+                log.debug("Malformed links_json for tweet %s", tweet["id"])
                 links = []
 
         # Normalize links for display (same as list endpoint)


### PR DESCRIPTION
## Summary

- Add `logging.getLogger(__name__)` to 6 modules lacking loggers: `llm_client.py`, `scoring.py`, `storage.py`, `link_utils.py`, `web/routes/tweets.py`, and `logging.basicConfig` in `cli/__init__.py`
- Replace 2 remaining bare `except Exception: pass/continue` blocks in `triage.py` with contextual `log.warning` calls including `exc_info=True`
- Add `log.warning` with `exc_info=True` to Anthropic/Gemini API error paths and retry exhaustion in `llm_client.py`, plus `log.debug` for retry attempts
- Add `log.warning` to article summary provider fallback loop in `scoring.py`
- Add `log.debug` for URL expansion failures in `link_utils.py`
- Add `exc_info=True` to 2 `notifier.py` warning calls that were catching broad exceptions without tracebacks
- Convert silent `except json.JSONDecodeError: pass` blocks to `log.debug` calls in `web/routes/tweets.py`
- Add INFO-level storage tracing in `storage.py`

## Test plan
- [x] All existing tests pass (`pytest -q` excluding pre-existing untracked test file)
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `ty check` passes
- [x] No control flow changes — only logging additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)