### PR TITLE
lint: enable D212, D413 docstring rules; remove redundant COM812

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ line-length = 120
 exclude = ["twag/_version.py"]
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF", "PIE", "RET505", "TC003", "TC006", "PERF401", "PLR5501", "PLR1730", "PLR1714", "PLR1711", "FURB110", "FURB188", "PLW1510", "PLW0108", "PLW2901", "EXE001", "FAST002", "COM812", "RET501", "D403", "D301", "TRY400"]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF", "PIE", "RET505", "TC003", "TC006", "PERF401", "PLR5501", "PLR1730", "PLR1714", "PLR1711", "FURB110", "FURB188", "PLW1510", "PLW0108", "PLW2901", "EXE001", "FAST002", "RET501", "D403", "D301", "D212", "D413", "TRY400"]
 ignore = [
     "E501",    # line too long (handled by formatter)
     "SIM105",  # contextlib.suppress — less readable for multi-line try blocks

--- a/twag/cli/search.py
+++ b/twag/cli/search.py
@@ -60,8 +60,7 @@ def search(
     order: str | None,
     fmt: str,
 ):
-    r"""
-    Search or browse tweets.
+    r"""Search or browse tweets.
 
     \b
     With QUERY: full-text search using FTS5 (default order: BM25 rank).

--- a/twag/config.py
+++ b/twag/config.py
@@ -142,8 +142,7 @@ def deep_merge(base: dict, override: dict) -> dict:
 
 
 def get_data_dir() -> Path:
-    """
-    Get the data directory for twag.
+    """Get the data directory for twag.
 
     Priority:
     1. TWAG_DATA_DIR environment variable

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -260,6 +260,7 @@ def get_connection(db_path: Path | None = None, readonly: bool = False) -> Itera
     Args:
         db_path: Path to database file. If None, uses default from config.
         readonly: If True, open in readonly mode to avoid write locks.
+
     """
     if db_path is None:
         db_path = get_database_path()

--- a/twag/db/maintenance.py
+++ b/twag/db/maintenance.py
@@ -107,6 +107,7 @@ def dump_sql(db_path: Path | None = None) -> Iterator[str]:
 
     Yields:
         Clean SQL statements suitable for executescript().
+
     """
     if db_path is None:
         db_path = get_database_path()
@@ -138,6 +139,7 @@ def restore_sql(
 
     Returns:
         Dict with counts: {"tweets": N, "accounts": N, "fts": N}
+
     """
     if db_path is None:
         db_path = get_database_path()

--- a/twag/db/search.py
+++ b/twag/db/search.py
@@ -117,8 +117,7 @@ def search_tweets(
     offset: int = 0,
     order_by: str = "rank",
 ) -> list[SearchResult]:
-    """
-    Search tweets using FTS5 full-text search.
+    """Search tweets using FTS5 full-text search.
 
     Args:
         query: FTS5 query string (supports AND, OR, NOT, phrases, prefixes)
@@ -137,6 +136,7 @@ def search_tweets(
 
     Returns:
         List of SearchResult objects
+
     """
     # Parse time_range if provided
     if time_range:

--- a/twag/db/time_utils.py
+++ b/twag/db/time_utils.py
@@ -24,8 +24,7 @@ def _get_et_offset() -> timedelta:
 
 
 def get_market_day_cutoff() -> datetime:
-    """
-    Get the previous market close (4pm ET) as a UTC datetime.
+    """Get the previous market close (4pm ET) as a UTC datetime.
 
     - Weekday before 4pm ET -> previous business day's 4pm
     - Weekday after 4pm ET -> same day's 4pm
@@ -67,8 +66,7 @@ def get_market_day_cutoff() -> datetime:
 
 
 def parse_time_range(spec: str) -> tuple[datetime | None, datetime | None]:
-    """
-    Parse a time range specification.
+    """Parse a time range specification.
 
     Supported formats:
     - "today" -> since previous market close (4pm ET)

--- a/twag/db/tweets.py
+++ b/twag/db/tweets.py
@@ -633,6 +633,7 @@ def get_processed_counts(conn: sqlite3.Connection) -> dict[str, int]:
 
     Returns:
         Dict with keys '1h', '24h', '7d' containing tweet counts.
+
     """
     cursor = conn.execute(
         """

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -247,8 +247,7 @@ def normalize_tweet_links(
     has_media: bool = False,
     already_expanded: bool = False,
 ) -> LinkNormalizationResult:
-    """
-    Normalize links for display and embedding rules.
+    """Normalize links for display and embedding rules.
 
     Rules:
     - Self tweet links are removed from display text.

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -70,6 +70,7 @@ def triage_tweets_batch(
         tweets: List of dicts with 'id', 'text', 'handle' keys
         model: Model to use (defaults to config triage_model)
         provider: Provider to use (defaults to config triage_provider)
+
     """
     if not tweets:
         return []

--- a/twag/tables.py
+++ b/twag/tables.py
@@ -11,6 +11,7 @@ def table_to_markdown(table: dict) -> str:
 
     Returns:
         Markdown-formatted table string with aligned columns
+
     """
     cols = table.get("columns", [])
     rows = table.get("rows", [])
@@ -30,6 +31,7 @@ def should_show_inline(table: dict, threshold: int = 10) -> bool:
 
     Returns:
         True if table should be shown inline, False for toggle
+
     """
     rows = table.get("rows", [])
     return len(rows) <= threshold

--- a/twag/web/routes/context.py
+++ b/twag/web/routes/context.py
@@ -325,8 +325,7 @@ async def test_context_command(
     name: str,
     test_req: TestCommandRequest,
 ) -> dict[str, Any]:
-    """
-    Test a context command with a sample tweet.
+    """Test a context command with a sample tweet.
 
     Substitutes tweet variables and runs the command.
     """
@@ -375,8 +374,7 @@ async def analyze_tweet_with_context(
     request: Request,
     tweet_id: str,
 ) -> dict[str, Any]:
-    """
-    Deep analyze a tweet with context injection from enabled commands.
+    """Deep analyze a tweet with context injection from enabled commands.
 
     Runs all enabled context commands, injects their output into the
     analysis prompt, and returns enriched analysis.

--- a/twag/web/routes/prompts.py
+++ b/twag/web/routes/prompts.py
@@ -133,8 +133,7 @@ async def rollback_to_version(
 
 @router.post("/prompts/tune")
 async def tune_prompt(request: Request, tune_req: TuneRequest) -> dict[str, Any]:
-    """
-    LLM-assisted prompt tuning based on user reactions.
+    """LLM-assisted prompt tuning based on user reactions.
 
     Analyzes user feedback (reactions) to suggest prompt improvements.
     """

--- a/twag/web/routes/reactions.py
+++ b/twag/web/routes/reactions.py
@@ -29,8 +29,7 @@ class ReactionCreate(BaseModel):
 
 @router.post("/react")
 async def create_reaction(request: Request, reaction: ReactionCreate) -> dict[str, Any]:
-    """
-    Create a reaction to a tweet.
+    """Create a reaction to a tweet.
 
     Reaction types:
     - '>>' : High importance - "This should be top-tier"
@@ -139,8 +138,7 @@ async def export_reactions(
     reaction_type: str | None = None,
     limit: int = 100,
 ) -> dict[str, Any]:
-    """
-    Export reactions with associated tweet data.
+    """Export reactions with associated tweet data.
     Useful for prompt tuning analysis.
     """
     import json

--- a/twag/web/routes/tweets.py
+++ b/twag/web/routes/tweets.py
@@ -139,8 +139,7 @@ async def list_tweets(
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     offset: Annotated[int, Query(ge=0)] = 0,
 ) -> dict[str, Any]:
-    """
-    Get paginated feed of processed tweets.
+    """Get paginated feed of processed tweets.
 
     Filters:
     - category: Filter by category (fed_policy, equities, etc.)


### PR DESCRIPTION
## Summary
- Enable 2 new ruff docstring rules (D212, D413) and auto-fix 20 violations across 14 files
- Remove COM812 (trailing comma enforcement) from `lint.select` — redundant when `ruff format` is active and produces a formatter-conflict warning
- All fixes are safe auto-fixes with no behavioral changes

## Test plan
- [x] `uv run ruff check .` passes clean
- [x] `uv run ruff format --check .` passes with no warnings
- [x] `uv run ty check` passes
- [x] `uv run pytest -q` passes (all 355 tests)

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)