### PR TITLE
docs: standardize commit message format via Conventional Commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,4 +167,4 @@ If command behavior changes, update `README.md` and `SKILL.md` in the same PR.
 - Keep commits focused and atomic
 - Run formatting/lint/tests before committing
 - Don't commit temporary artifacts unless explicitly requested
-- Write descriptive commit messages
+- Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) — see `CONTRIBUTING.md` for allowed types and subject rules. AI-authored commits must use a conforming `<type>(<scope>): <subject>` prefix.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,64 @@ ruff check --fix .
 2. Create a feature branch: `git checkout -b my-feature`
 3. Make your changes
 4. Run tests and linting
-5. Commit with a descriptive message
+5. Commit with a descriptive message (see [Commit Message Format](#commit-message-format))
 6. Push and open a PR
+
+## Commit Message Format
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+### Subject line
+
+```
+<type>(<optional scope>): <imperative subject>
+```
+
+- **type** (required, lowercase): one of `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`, `build`, `ci`, `style`, `revert`
+- **scope** (optional): short noun identifying the affected area (e.g. `cli`, `db`, `fetcher`, `web`)
+- **subject** (required): imperative mood, no trailing period, keep under 72 characters total
+
+Examples:
+
+```
+feat(cli): add narratives list command
+fix: expand t.co links before storing
+docs: standardize commit message format
+refactor(db): extract connection helper
+```
+
+### Allowed types
+
+| Type | Use for |
+|------|---------|
+| `feat` | New user-facing feature |
+| `fix` | Bug fix |
+| `docs` | Documentation-only changes |
+| `chore` | Tooling, deps, version bumps, misc maintenance |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `perf` | Performance improvement |
+| `test` | Adding or fixing tests |
+| `build` | Build system or external dependency changes |
+| `ci` | CI configuration changes |
+| `style` | Formatting, whitespace (no behavior change) |
+| `revert` | Reverting a previous commit |
+
+### Body and footers
+
+- Optional body after a blank line explaining *why* (not *what*).
+- Optional footers/trailers like `Co-Authored-By:`, `Refs: #123`, `BREAKING CHANGE: ...`.
+- Merge commits and GitHub-generated commits are exempt.
+
+### Optional local hook
+
+A lightweight commit-msg hook ships in `scripts/commit-msg-hook.sh`. Install it locally to get format validation on every commit:
+
+```bash
+ln -s ../../scripts/commit-msg-hook.sh .git/hooks/commit-msg
+chmod +x scripts/commit-msg-hook.sh
+```
+
+The hook rejects non-conforming subjects, but skips merges, reverts, and fixups. CI does not enforce this yet.
 
 ## Documentation
 

--- a/scripts/commit-msg-hook.sh
+++ b/scripts/commit-msg-hook.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# commit-msg hook validating Conventional Commits format.
+#
+# Install locally:
+#   ln -s ../../scripts/commit-msg-hook.sh .git/hooks/commit-msg
+#   chmod +x scripts/commit-msg-hook.sh
+#
+# The hook reads the commit message file ($1) and rejects non-conforming
+# subjects. It skips merges, reverts, fixups, squashes, and empty messages.
+
+set -eu
+
+msg_file="${1:-}"
+if [ -z "$msg_file" ] || [ ! -f "$msg_file" ]; then
+    exit 0
+fi
+
+# First non-comment, non-empty line is the subject.
+subject="$(grep -v '^#' "$msg_file" | sed '/^[[:space:]]*$/d' | head -n 1 || true)"
+
+if [ -z "$subject" ]; then
+    exit 0
+fi
+
+# Skip exempt prefixes: merge commits, reverts, fixup!/squash!, GitHub web commits.
+case "$subject" in
+    "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"amend! "*)
+        exit 0
+        ;;
+esac
+
+# Allowed types: feat, fix, docs, chore, refactor, perf, test, build, ci, style, revert.
+# Grammar: type(scope)?!?: subject  —  subject non-empty, whole line under 72 chars.
+pattern='^(feat|fix|docs|chore|refactor|perf|test|build|ci|style|revert)(\([a-z0-9._/-]+\))?!?: [^ ].*$'
+
+if ! printf '%s' "$subject" | grep -Eq "$pattern"; then
+    cat >&2 <<EOF
+ERROR: commit subject does not follow Conventional Commits.
+
+  Got:      $subject
+
+  Expected: <type>(<optional scope>): <imperative subject>
+            Types: feat, fix, docs, chore, refactor, perf,
+                   test, build, ci, style, revert
+
+  Examples:
+    feat(cli): add narratives list command
+    fix: expand t.co links before storing
+    docs: standardize commit message format
+
+See CONTRIBUTING.md for the full spec.
+EOF
+    exit 1
+fi
+
+if [ "${#subject}" -gt 72 ]; then
+    echo "ERROR: commit subject is ${#subject} chars; keep it under 72." >&2
+    echo "  Subject: $subject" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Formally adopts [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for this repo (the de-facto style already used by most recent commits).
- Documents the subject-line grammar, allowed types, and scope rules in `CONTRIBUTING.md`.
- Updates `CLAUDE.md` so AI-authored commits must use a conforming `<type>(<scope>): <subject>` prefix.
- Adds an optional local `commit-msg` hook at `scripts/commit-msg-hook.sh` that validates format and caps subjects at 72 chars. Exempts merges, reverts, and fixups.

No history rewrites. No CI enforcement in this PR — the hook is opt-in so contributors can adopt it at their own pace; we can wire it into CI as a follow-up once the format is adopted.

## Install the hook (optional)

```bash
ln -s ../../scripts/commit-msg-hook.sh .git/hooks/commit-msg
chmod +x scripts/commit-msg-hook.sh
```

## Test plan

- [x] Hook passes conforming subjects (`feat(cli): ...`, `fix: ...`, `chore!: ...`)
- [x] Hook rejects non-conforming subjects (`Add thing without prefix`)
- [x] Hook exempts `Merge ...`, `Revert ...`, `fixup! ...`, `squash! ...`
- [x] `ruff check .` passes
- [x] `ty check` passes
- [x] `pytest` passes (via pre-commit hook)

Nightshift-Task: commit-normalize
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/home/clifton/code/twag
task-type: commit-normalize
task-title: Commit Message Normalizer
iterations: 1
duration: 3m48s
nightshift:metadata -->
