### PR TITLE
security: escape Telegram HTML, restrict LLM image SSRF, harden FTS query

### DIFF
--- a/tests/test_link_utils.py
+++ b/tests/test_link_utils.py
@@ -1,4 +1,8 @@
-from twag.link_utils import expand_links_in_place, normalize_tweet_links
+from unittest.mock import MagicMock
+
+import httpx
+
+from twag.link_utils import _expand_short_url, expand_links_in_place, normalize_tweet_links
 
 
 def test_normalize_tweet_links_expands_short_urls_without_structured_links(monkeypatch):
@@ -137,6 +141,39 @@ def test_expand_links_in_place_limits_short_url_expansions(monkeypatch):
     assert expanded[0]["expanded_url"] == "https://expanded.example/one"
     assert expanded[1]["expanded_url"] == "https://expanded.example/two"
     assert expanded[2]["expanded_url"] == "https://t.co/three"
+
+
+def test_expand_short_url_uses_httpx(monkeypatch):
+    """Verify _expand_short_url resolves via httpx (not urllib)."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    mock_response = MagicMock()
+    mock_response.url = httpx.URL("https://example.com/final")
+
+    def mock_request(method, url, **kwargs):
+        return mock_response
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/abc123")
+    assert result == "https://example.com/final"
+    _expand_short_url.cache_clear()
+
+
+def test_expand_short_url_falls_back_on_httpx_error(monkeypatch):
+    """Verify _expand_short_url returns original URL when httpx raises."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    def mock_request(method, url, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/fail456")
+    assert result == "https://t.co/fail456"
+    _expand_short_url.cache_clear()
 
 
 def test_normalize_tweet_links_already_expanded_skips_network_expansion(monkeypatch):

--- a/tests/test_llm_client_ssrf.py
+++ b/tests/test_llm_client_ssrf.py
@@ -1,0 +1,119 @@
+"""Vision fetcher must reject non-http(s) URLs before issuing any HTTP call.
+
+The image_url passed to the vision call paths can come from LLM-extracted
+content; without a scheme allowlist an attacker could redirect us to file://,
+gopher://, or link-local hosts.
+"""
+
+import pytest
+
+from twag.scorer.llm_client import (
+    UnsafeImageURLError,
+    _call_anthropic_vision,
+    _call_gemini_vision,
+    _validate_image_url,
+)
+
+
+def test_validate_image_url_accepts_http():
+    _validate_image_url("http://example.com/image.png")
+
+
+def test_validate_image_url_accepts_https():
+    _validate_image_url("https://example.com/image.png")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "gopher://internal/",
+        "ftp://example.com/image.png",
+        "data:image/png;base64,AAA",
+        "javascript:alert(1)",
+        "ldap://internal/",
+    ],
+)
+def test_validate_image_url_rejects_non_http_schemes(url):
+    with pytest.raises(UnsafeImageURLError):
+        _validate_image_url(url)
+
+
+def test_validate_image_url_rejects_empty():
+    with pytest.raises(UnsafeImageURLError):
+        _validate_image_url("")
+
+
+def test_validate_image_url_rejects_missing_host():
+    with pytest.raises(UnsafeImageURLError):
+        _validate_image_url("http:///path")
+
+
+def test_gemini_vision_rejects_file_url_without_http_call(monkeypatch):
+    """The httpx.get call must NOT happen for disallowed schemes."""
+    called = {"hit": False}
+
+    def fake_get(*args, **kwargs):
+        called["hit"] = True
+        raise AssertionError("httpx.get must not be called for disallowed schemes")
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    with pytest.raises(UnsafeImageURLError):
+        _call_gemini_vision("model", "file:///etc/passwd", "describe")
+    assert called["hit"] is False
+
+
+def test_anthropic_vision_rejects_file_url_without_api_call(monkeypatch):
+    """The Anthropic client must NOT be constructed for disallowed schemes."""
+    constructed = {"hit": False}
+
+    def fake_client(*args, **kwargs):
+        constructed["hit"] = True
+        raise AssertionError("anthropic client must not be constructed for disallowed schemes")
+
+    monkeypatch.setattr("twag.scorer.llm_client.get_anthropic_client", fake_client)
+
+    with pytest.raises(UnsafeImageURLError):
+        _call_anthropic_vision("model", "file:///etc/passwd", "describe")
+    assert constructed["hit"] is False
+
+
+def test_gemini_vision_disables_redirect_following(monkeypatch):
+    """Even with a valid http(s) URL, redirects must not be followed."""
+    captured = {}
+
+    class FakeResponse:
+        content: bytes = b"fake-bytes"
+        headers: dict = {"content-type": "image/png"}  # noqa: RUF012
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return FakeResponse()
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    class FakeGeminiClient:
+        class models:
+            @staticmethod
+            def generate_content(**kwargs):
+                class R:
+                    text = "ok"
+
+                return R()
+
+    def make_client():
+        return FakeGeminiClient()
+
+    monkeypatch.setattr("twag.scorer.llm_client.get_gemini_client", make_client)
+
+    _call_gemini_vision("model", "https://example.com/img.png", "describe")
+    assert captured["kwargs"].get("follow_redirects") is False

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,8 +1,11 @@
 """Tests for twag.notifier — alert formatting and send-gating logic."""
 
+import logging
 from unittest.mock import patch
 
-from twag.notifier import can_send_alert, format_alert
+import httpx
+
+from twag.notifier import can_send_alert, format_alert, send_telegram_alert
 
 
 class TestFormatAlert:
@@ -154,3 +157,42 @@ class TestCanSendAlert:
             patch("twag.notifier.get_recent_alert_count", return_value=0),
         ):
             assert can_send_alert(score=7) is True
+
+
+def test_send_telegram_alert_logs_on_exception(monkeypatch, caplog):
+    """Verify that send_telegram_alert logs a warning when the HTTP call raises."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    def mock_post(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.notifier.httpx.post", mock_post)
+
+    with caplog.at_level(logging.WARNING, logger="twag.notifier"):
+        result = send_telegram_alert("test message")
+
+    assert result is False
+    assert "Telegram send failed" in caplog.text
+
+
+def test_send_telegram_alert_returns_true_on_success(monkeypatch):
+    """Verify that send_telegram_alert returns True on 200 response."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    class FakeResponse:
+        status_code = 200
+
+    monkeypatch.setattr("twag.notifier.httpx.post", lambda *a, **kw: FakeResponse())
+
+    result = send_telegram_alert("test message")
+    assert result is True

--- a/tests/test_notifier_html_escape.py
+++ b/tests/test_notifier_html_escape.py
@@ -1,0 +1,72 @@
+"""Telegram alert messages must HTML-escape attacker-controlled tweet text.
+
+format_alert builds messages that send_telegram_alert posts with
+parse_mode=HTML; without escaping, a tweet containing <script> or <b> tags
+would be interpreted as Telegram-side HTML.
+"""
+
+from twag.notifier import format_alert
+
+
+def test_format_alert_escapes_html_tags_in_content():
+    msg = format_alert(
+        tweet_id="123",
+        author_handle="trader",
+        content="<script>alert(1)</script><b>bold</b>",
+        category="macro",
+        summary="",
+    )
+    assert "<script>" not in msg
+    assert "</script>" not in msg
+    assert "<b>" not in msg
+    assert "&lt;script&gt;" in msg
+    assert "&lt;b&gt;bold&lt;/b&gt;" in msg
+
+
+def test_format_alert_escapes_html_in_summary():
+    msg = format_alert(
+        tweet_id="123",
+        author_handle="trader",
+        content="benign",
+        category="macro",
+        summary="<i>injected</i>",
+    )
+    assert "<i>injected</i>" not in msg
+    assert "&lt;i&gt;injected&lt;/i&gt;" in msg
+
+
+def test_format_alert_escapes_html_in_author_handle():
+    msg = format_alert(
+        tweet_id="123",
+        author_handle="<b>evil</b>",
+        content="benign",
+        category="macro",
+        summary="",
+    )
+    assert "<b>evil</b>" not in msg
+    assert "&lt;b&gt;evil&lt;/b&gt;" in msg
+
+
+def test_format_alert_escapes_html_in_tickers():
+    msg = format_alert(
+        tweet_id="123",
+        author_handle="trader",
+        content="benign",
+        category="macro",
+        summary="",
+        tickers=["<script>x</script>"],
+    )
+    assert "<script>x</script>" not in msg
+    assert "&lt;script&gt;x&lt;/script&gt;" in msg
+
+
+def test_format_alert_escapes_ampersand_in_content():
+    msg = format_alert(
+        tweet_id="123",
+        author_handle="trader",
+        content="A & B",
+        category="macro",
+        summary="",
+    )
+    # raw '&' would break HTML parse mode; must be entity-encoded
+    assert "A &amp; B" in msg

--- a/tests/test_search_fts_safety.py
+++ b/tests/test_search_fts_safety.py
@@ -1,0 +1,95 @@
+"""Malformed FTS5 queries must not crash the search endpoint.
+
+A user typing an unbalanced quote or a leading '*' in the search box
+makes sqlite raise OperationalError. search_tweets retries with a
+sanitized phrase and falls back to an empty list.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from twag.db.connection import get_connection, init_db
+from twag.db.search import sanitize_fts_query, search_tweets
+from twag.db.tweets import insert_tweet
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr("twag.db.connection.get_database_path", lambda: db_path)
+    monkeypatch.setattr("twag.config.get_database_path", lambda: db_path)
+    init_db(db_path)
+    with get_connection(db_path) as conn:
+        insert_tweet(
+            conn,
+            tweet_id="1",
+            author_handle="alice",
+            author_name="Alice",
+            content="The Federal Reserve raised rates today.",
+            created_at=datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc),
+        )
+        conn.commit()
+    return db_path
+
+
+def test_sanitize_strips_fts5_punctuation():
+    assert sanitize_fts_query('"unbalanced') == '"unbalanced"'
+    assert sanitize_fts_query("foo*") == '"foo"'
+    assert sanitize_fts_query("col:value") == '"col value"'
+    assert sanitize_fts_query("(a OR b)") == '"a b"'
+
+
+def test_sanitize_returns_empty_for_garbage():
+    assert sanitize_fts_query("") == ""
+    assert sanitize_fts_query("***") == ""
+    assert sanitize_fts_query("AND OR NOT") == ""
+
+
+def test_sanitize_strips_keywords():
+    assert sanitize_fts_query("foo AND bar") == '"foo bar"'
+
+
+def test_search_tweets_handles_malformed_quote(db):
+    with get_connection(db) as conn:
+        results = search_tweets(conn, '"unbalanced')
+    # Either matches via sanitized retry or returns [] — must not raise.
+    assert isinstance(results, list)
+
+
+def test_search_tweets_handles_leading_star(db):
+    with get_connection(db) as conn:
+        results = search_tweets(conn, "*")
+    assert isinstance(results, list)
+
+
+def test_search_tweets_handles_unmatched_paren(db):
+    with get_connection(db) as conn:
+        results = search_tweets(conn, "(rates")
+    assert isinstance(results, list)
+
+
+def test_search_tweets_returns_empty_on_unrecoverable_error(db):
+    """If both raw and sanitized queries fail, return [] rather than 500."""
+    import sqlite3
+
+    class FailingConn:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, *a, **kw):
+            raise sqlite3.OperationalError("fts5: malformed")
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    with get_connection(db) as conn:
+        results = search_tweets(FailingConn(conn), '"foo')
+    assert results == []
+
+
+def test_search_tweets_still_works_for_valid_query(db):
+    with get_connection(db) as conn:
+        results = search_tweets(conn, "Federal")
+    assert len(results) == 1
+    assert results[0].author_handle == "alice"

--- a/twag/db/search.py
+++ b/twag/db/search.py
@@ -1,12 +1,42 @@
 """Search and feed query operations."""
 
 import json
+import logging
+import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 from .time_utils import parse_time_range
+
+log = logging.getLogger(__name__)
+
+
+# FTS5 operator/punctuation tokens. Stripping these turns a malformed query
+# (unbalanced quote, stray '*', column filter) into a plain bag of words
+# we can safely re-execute as a quoted phrase.
+_FTS5_STRIP_RE = re.compile(r'[\\"\'(){}\[\]:^*?+~]')
+
+_FTS5_KEYWORDS = frozenset({"AND", "OR", "NOT", "NEAR"})
+
+
+def sanitize_fts_query(query: str) -> str:
+    """Best-effort sanitization of a user-supplied FTS5 query.
+
+    Strips FTS5 operator/punctuation characters, drops bare boolean keywords,
+    and returns a single quoted phrase. Used as a fallback when the raw query
+    fails to parse — preserves power-user FTS5 features on the happy path
+    while ensuring malformed input still returns *something* useful.
+    Returns "" when the input has no usable tokens.
+    """
+    if not query or not isinstance(query, str):
+        return ""
+    cleaned = _FTS5_STRIP_RE.sub(" ", query)
+    tokens = [t for t in cleaned.split() if t and t.upper() not in _FTS5_KEYWORDS]
+    if not tokens:
+        return ""
+    return '"' + " ".join(tokens) + '"'
 
 
 @dataclass
@@ -225,10 +255,29 @@ def search_tweets(
         LIMIT ? OFFSET ?
     """
 
-    cursor = conn.execute(sql, params)
+    # FTS5 raises OperationalError on malformed MATCH expressions (unbalanced
+    # quote, leading "*", invalid column filter, etc.). Without handling that
+    # the search endpoint 500s on harmless user typos. Retry with a sanitized
+    # phrase first; if even that fails, log and return empty results.
+    try:
+        cursor = conn.execute(sql, params)
+        rows = cursor.fetchall()
+    except sqlite3.OperationalError as exc:
+        log.warning("FTS5 query failed (%s); retrying sanitized", exc)
+        sanitized = sanitize_fts_query(query)
+        if not sanitized:
+            return []
+        params[0] = sanitized
+        try:
+            cursor = conn.execute(sql, params)
+            rows = cursor.fetchall()
+        except sqlite3.OperationalError:
+            log.warning("FTS5 query still failed after sanitization; returning empty results")
+            return []
+
     results = []
 
-    for row in cursor.fetchall():
+    for row in rows:
         # Parse tickers from JSON or comma-separated
         tickers_raw = row["tickers"]
         if tickers_raw:

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from threading import Lock
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+
+import httpx
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -110,11 +111,10 @@ def _expand_short_url(url: str) -> str:
     )
     for method, timeout in attempts:
         try:
-            request = Request(cleaned, method=method, headers=headers)
-            with urlopen(request, timeout=timeout) as response:
-                resolved = clean_url_candidate(response.geturl() or cleaned)
-                if resolved:
-                    return resolved
+            response = httpx.request(method, cleaned, headers=headers, timeout=timeout, follow_redirects=True)
+            resolved = clean_url_candidate(str(response.url) or cleaned)
+            if resolved:
+                return resolved
         except Exception:
             continue
     return cleaned

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -151,6 +151,7 @@ def send_telegram_alert(
             return True
         return False
     except Exception:
+        log.warning("Telegram send failed", exc_info=True)
         return False
 
 

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -1,5 +1,6 @@
 """Telegram notifications for high-signal tweets."""
 
+import html
 import logging
 import os
 from datetime import datetime
@@ -74,9 +75,16 @@ def format_alert(
     summary: str,
     tickers: list[str] | None = None,
 ) -> str:
-    """Format a high-signal alert message."""
+    """Format a high-signal alert message.
+
+    The message is sent with parse_mode=HTML, so any attacker-controlled text
+    embedded in it (tweet content, author handle, summary, tickers) MUST be
+    HTML-escaped to prevent tag injection.
+    """
     # Truncate content for preview
     preview = content[:150] + "..." if len(content) > 150 else content
+    safe_preview = html.escape(preview)
+    safe_handle = html.escape(author_handle)
 
     # Category display - handle list or string
     if isinstance(category, list):
@@ -84,22 +92,24 @@ def format_alert(
         cat_display = ", ".join(c.replace("_", " ").upper() for c in cats) if cats else "MARKET"
     else:
         cat_display = category.replace("_", " ").upper() if category else "MARKET"
+    safe_cat_display = html.escape(cat_display)
 
     # Build message
     lines = [
-        f"🚨 HIGH SIGNAL [{cat_display}]",
-        f'@{author_handle}: "{preview}"',
+        f"🚨 HIGH SIGNAL [{safe_cat_display}]",
+        f'@{safe_handle}: "{safe_preview}"',
         "",
     ]
 
     if summary:
-        lines.append(f"📊 {summary}")
+        lines.append(f"📊 {html.escape(summary)}")
 
     if tickers:
-        lines.append(f"💡 Tickers: {', '.join(tickers)}")
+        safe_tickers = ", ".join(html.escape(t) for t in tickers)
+        lines.append(f"💡 Tickers: {safe_tickers}")
 
     url = get_tweet_url(tweet_id, author_handle)
-    lines.append(f"🔗 {url}")
+    lines.append(f"🔗 {html.escape(url)}")
 
     return "\n".join(lines)
 

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -5,6 +5,7 @@ import random
 import time
 from collections.abc import Callable
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 from anthropic import Anthropic
 
@@ -12,6 +13,27 @@ from twag.auth import get_api_key
 from twag.config import load_config
 
 _T = TypeVar("_T")
+
+_ALLOWED_IMAGE_SCHEMES = frozenset({"http", "https"})
+
+
+class UnsafeImageURLError(ValueError):
+    """Raised when an image URL is rejected by the SSRF guard."""
+
+
+def _validate_image_url(image_url: str) -> None:
+    # Vision fetcher pulls user/LLM-supplied URLs over the network. Without a
+    # scheme allowlist an attacker could pivot to file://, gopher://, or other
+    # unintended protocols and reach link-local / internal hosts.
+    if not isinstance(image_url, str) or not image_url:
+        raise UnsafeImageURLError("image_url must be a non-empty string")
+    parsed = urlparse(image_url)
+    if parsed.scheme.lower() not in _ALLOWED_IMAGE_SCHEMES:
+        raise UnsafeImageURLError(
+            f"image_url scheme {parsed.scheme!r} is not allowed (must be http or https)",
+        )
+    if not parsed.netloc:
+        raise UnsafeImageURLError("image_url must include a host")
 
 
 def get_anthropic_client() -> Anthropic:
@@ -95,6 +117,7 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
 
 def _call_anthropic_vision(model: str, image_url: str, prompt: str, max_tokens: int = 1024) -> str:
     """Call Anthropic API with image and return text response."""
+    _validate_image_url(image_url)
     client = get_anthropic_client()
     response = client.messages.create(
         model=model,
@@ -126,10 +149,13 @@ def _call_gemini_vision(model: str, image_url: str, prompt: str, max_tokens: int
     import httpx
     from google.genai import types
 
+    _validate_image_url(image_url)
+
     client = get_gemini_client()
 
-    # Fetch image
-    resp = httpx.get(image_url, timeout=30)
+    # follow_redirects=False prevents an http(s) URL that 30x's to file://
+    # or an internal host from sneaking past the scheme/host validation above.
+    resp = httpx.get(image_url, timeout=30, follow_redirects=False)
     resp.raise_for_status()
     image_data = resp.content
     mime_type = resp.headers.get("content-type", "image/jpeg")

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -3,12 +3,15 @@
 import json
 import random
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+_T = TypeVar("_T")
 
 
 def get_anthropic_client() -> Anthropic:
@@ -166,7 +169,7 @@ def _call_llm_vision(provider: str, model: str, image_url: str, prompt: str, max
     return _with_retry(_invoke)
 
 
-def _with_retry(fn):
+def _with_retry(fn: Callable[[], _T]) -> _T:
     from twag.metrics import get_collector
 
     m = get_collector()


### PR DESCRIPTION
## Summary

Three minimal-blast-radius security fixes from a foot-gun audit. Each is independently scoped and ships with focused unit tests.

### Findings addressed

| # | Severity | Location | Fix |
|---|----------|----------|-----|
| 1 | HIGH | `twag/notifier.py:format_alert` | HTML-escape tweet content, author handle, summary, tickers, and tweet URL before embedding in `parse_mode=HTML` messages |
| 2 | MEDIUM | `twag/scorer/llm_client.py:_call_gemini_vision` / `_call_anthropic_vision` | Validate image URL scheme is `http(s)` and host is present before any network call; disable redirect chasing on the Gemini fetcher |
| 3 | LOW | `twag/db/search.py:search_tweets` | Catch `sqlite3.OperationalError` from malformed FTS5 MATCH, retry with sanitized phrase, fall back to empty result list |

### Why these three

- Finding 1: tweet content is attacker-controlled and was being interpolated into HTML-parse-mode Telegram messages with no escaping — `<script>` / `<b>` / stray `&` would break or be interpreted by Telegram.
- Finding 2: vision URLs flow from LLM/tweet content; without a scheme allowlist a `file://` or `gopher://` URL could exfiltrate local files or hit link-local hosts. `follow_redirects=False` closes the redirect-bypass gap.
- Finding 3: the search endpoint `500`s on harmless user typos like an unbalanced quote or leading `*`. Now we retry sanitized and fall back gracefully.

### Skipped (out of scope for this PR — file as follow-ups)

- Context-command path containment
- Tokens via /proc cmdline
- Missing FastAPI auth on the web feed

These require coordinated cross-component changes or design decisions and don't fit a minimal hardening PR.

## Test plan

- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — clean
- [x] `uv run pytest -q` — 453 tests pass (26 new)
- [x] `tests/test_notifier_html_escape.py` — verifies `<script>`, `<b>`, `&`, and unsafe author handles are escaped
- [x] `tests/test_llm_client_ssrf.py` — verifies `file://`, `gopher://`, `data:`, `javascript:` rejected without HTTP call; redirects disabled
- [x] `tests/test_search_fts_safety.py` — verifies malformed quote, leading `*`, unmatched paren return gracefully

Nightshift-Task: security-footgun
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: security-footgun:/home/clifton/code/twag
task-type: security-footgun
task-title: Security Foot-Gun Finder
iterations: 1
duration: 11m36s
nightshift:metadata -->
