### PR TITLE
Add cost attribution estimator (twag costs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Defined in `twag/cli/`:
 - **Pipeline:** `fetch`, `process`, `analyze`, `digest`
 - **Accounts:** `list`, `add`, `promote`, `demote`, `mute`, `boost`, `decay`, `import`
 - **Query:** `search`, `narratives list`
-- **Maintenance:** `stats`, `prune`, `export`
+- **Maintenance:** `stats`, `prune`, `export`, `metrics`, `costs` (advisory USD estimate from token counters; supports `--since`, `--json`, `--pricing-file`)
 - **Config:** `show`, `path`, `set`
 - **Database:** `path`, `shell`, `init`, `rebuild-fts`, `dump`, `restore`
 - **Web:** `web`

--- a/README.md
+++ b/README.md
@@ -288,9 +288,10 @@ twag costs --pricing-file ~/my-pricing.json
 #### Cost estimation
 
 `twag costs` converts locally-tracked LLM token counters into a per-component USD
-estimate, grouped by provider (`scorer:gemini`, `scorer:anthropic`) plus
+estimate, grouped by provider/model (`scorer:gemini`, `scorer:anthropic`) plus
 non-priced rows for `fetcher`, `pipeline`, and `web`. Pricing comes from a
-built-in table; override per-model rates by writing `~/.twag/pricing.json`:
+built-in table; override per-model rates by writing
+`~/.config/twag/pricing.json`:
 
 ```json
 {
@@ -302,6 +303,12 @@ built-in table; override per-model rates by writing `~/.twag/pricing.json`:
   }
 }
 ```
+
+Counters are persisted to the twag SQLite database after every CLI command and
+when the web server shuts down, so `twag costs --since 24h` can report spend
+across many `fetch` / `process` runs. Each flush records only the **delta**
+since the previous flush from that process, which is what makes summing across
+multiple process lifetimes within the window return the true total.
 
 Estimates are advisory — they reflect tokens reported by the SDKs. Calls without
 SDK-reported usage data are not priced.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,33 @@ twag prune --days 14            # Delete old tweets
 twag prune --dry-run            # Preview prune
 
 twag export --days 7            # Export recent data
+
+twag costs                      # Estimated USD spend (last 24h, persisted metrics)
+twag costs --since live         # In-memory metrics only
+twag costs --since 7d --json    # Raw JSON output
+twag costs --pricing-file ~/my-pricing.json
 ```
+
+#### Cost estimation
+
+`twag costs` converts locally-tracked LLM token counters into a per-component USD
+estimate, grouped by provider (`scorer:gemini`, `scorer:anthropic`) plus
+non-priced rows for `fetcher`, `pipeline`, and `web`. Pricing comes from a
+built-in table; override per-model rates by writing `~/.twag/pricing.json`:
+
+```json
+{
+  "anthropic": {
+    "claude-opus-4-7": {"input_per_million_usd": 15.0, "output_per_million_usd": 75.0}
+  },
+  "gemini": {
+    "gemini-3-flash-preview": [0.30, 2.50]
+  }
+}
+```
+
+Estimates are advisory — they reflect tokens reported by the SDKs. Calls without
+SDK-reported usage data are not priced.
 
 ### Narratives
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,21 @@
 """Shared pytest fixtures for twag tests."""
 
+import os
 import sys
+import tempfile
 from pathlib import Path
 
 # Add the package to the path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def pytest_configure(config):
+    """Redirect twag's data dir to a per-session temp path.
+
+    Without this, tests that exercise the CLI or the metrics flush hook would
+    write to the user's real ``~/.local/share/twag`` database. Set it before
+    any twag module is imported by individual tests.
+    """
+    if not os.environ.get("TWAG_DATA_DIR"):
+        tmp_root = Path(tempfile.mkdtemp(prefix="twag-tests-"))
+        os.environ["TWAG_DATA_DIR"] = str(tmp_root)

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,0 +1,286 @@
+"""Tests for twag.costs and the `twag costs` CLI."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from twag import metrics
+from twag.cli import cli
+from twag.costs import (
+    Component,
+    derive_model_from_label,
+    estimate_costs,
+    load_pricing_overrides,
+    lookup_rate,
+    total_usd,
+)
+
+
+def setup_function():
+    metrics.reset()
+
+
+# ── Pricing lookup ──────────────────────────────────────────────────────
+
+
+def test_lookup_rate_exact_match():
+    rate = lookup_rate("anthropic", "claude-opus-4-7")
+    assert rate == (15.00, 75.00)
+
+
+def test_lookup_rate_substring_match():
+    # "gemini-3-flash-preview" is not in the table directly, but "gemini-3-flash" is
+    rate = lookup_rate("gemini", "gemini-3-flash-preview")
+    assert rate == (0.30, 2.50)
+
+
+def test_lookup_rate_longest_substring_wins():
+    # "gemini-2.5-pro-something" should pick "gemini-2.5-pro" (1.25, 10.0), not "gemini" (0.30, 2.50)
+    rate = lookup_rate("gemini", "gemini-2.5-pro-something")
+    assert rate == (1.25, 10.00)
+
+
+def test_lookup_rate_unknown_model():
+    rate = lookup_rate("openai", "gpt-7")
+    assert rate is None
+
+
+def test_lookup_rate_with_override():
+    override = {("anthropic", "claude-experimental"): (1.0, 2.0)}
+    rate = lookup_rate("anthropic", "claude-experimental", pricing=override)
+    assert rate == (1.0, 2.0)
+
+
+# ── derive_model_from_label ─────────────────────────────────────────────
+
+
+def test_derive_model_from_label_no_labels():
+    provider, model = derive_model_from_label("scorer.gemini.input_tokens")
+    assert provider == "gemini"
+    assert model is None
+
+
+def test_derive_model_from_label_with_model():
+    provider, model = derive_model_from_label("scorer.anthropic.output_tokens{model=claude-opus-4-7}")
+    assert provider == "anthropic"
+    assert model == "claude-opus-4-7"
+
+
+def test_derive_model_from_label_multiple_labels():
+    provider, model = derive_model_from_label("scorer.gemini.input_tokens{model=gemini-3-flash,role=triage}")
+    assert provider == "gemini"
+    assert model == "gemini-3-flash"
+
+
+# ── estimate_costs ──────────────────────────────────────────────────────
+
+
+def test_estimate_synthetic_snapshot_both_providers():
+    snapshot = {
+        "counters": {
+            "scorer.gemini.calls": 10,
+            "scorer.gemini.input_tokens": 100_000,
+            "scorer.gemini.output_tokens": 20_000,
+            "scorer.anthropic.calls": 5,
+            "scorer.anthropic.input_tokens": 50_000,
+            "scorer.anthropic.output_tokens": 10_000,
+        },
+        "histograms": {},
+    }
+    components = estimate_costs(
+        snapshot,
+        configured_models={"triage": "gemini-3-flash-preview", "enrichment": "claude-opus-4-7"},
+    )
+    by_name = {c.name: c for c in components}
+
+    assert "scorer:gemini" in by_name
+    # gemini-3-flash rates: (0.30, 2.50). 100k * 0.30/1M + 20k * 2.50/1M = 0.03 + 0.05 = 0.08
+    assert abs(by_name["scorer:gemini"].usd_estimate - 0.08) < 1e-6
+
+    assert "scorer:anthropic" in by_name
+    # claude-opus-4-7 rates: (15, 75). 50k * 15/1M + 10k * 75/1M = 0.75 + 0.75 = 1.50
+    assert abs(by_name["scorer:anthropic"].usd_estimate - 1.50) < 1e-6
+
+
+def test_estimate_unknown_model_returns_zero_with_note():
+    snapshot = {
+        "counters": {
+            "scorer.gemini.input_tokens{model=mystery-model-xyz}": 1_000_000,
+            "scorer.gemini.output_tokens{model=mystery-model-xyz}": 1_000_000,
+        },
+        "histograms": {},
+    }
+    components = estimate_costs(snapshot, configured_models={})
+    by_name = {c.name: c for c in components}
+    assert by_name["scorer:gemini"].usd_estimate == 0.0
+    assert "no pricing entry" in by_name["scorer:gemini"].notes
+
+
+def test_estimate_falls_back_to_configured_model():
+    snapshot = {
+        "counters": {
+            "scorer.gemini.input_tokens": 1_000_000,
+            "scorer.gemini.output_tokens": 1_000_000,
+        },
+        "histograms": {},
+    }
+    components = estimate_costs(
+        snapshot,
+        configured_models={"triage": "gemini-3-flash-preview", "enrichment": "claude-opus-4-7"},
+    )
+    by_name = {c.name: c for c in components}
+    # Should use gemini-3-flash rates: input=0.30, output=2.50 per 1M
+    expected = (1_000_000 * 0.30 + 1_000_000 * 2.50) / 1_000_000
+    assert abs(by_name["scorer:gemini"].usd_estimate - expected) < 1e-6
+
+
+def test_estimate_no_scorer_activity_still_emits_components():
+    snapshot = {"counters": {}, "histograms": {}}
+    components = estimate_costs(snapshot)
+    names = {c.name for c in components}
+    assert "scorer" in names
+    assert "fetcher" in names
+    assert "pipeline" in names
+    assert "web" in names
+
+
+def test_estimate_non_llm_components_have_notes():
+    snapshot = {
+        "counters": {
+            "fetcher.bird.calls": 12,
+            "web.requests": 99,
+        },
+        "histograms": {
+            "pipeline.batch_seconds": {"count": 3, "total": 12.5, "mean": 4.16, "min": 1, "max": 7, "p50": 4, "p99": 7},
+        },
+    }
+    components = estimate_costs(snapshot)
+    by_name = {c.name: c for c in components}
+    assert by_name["fetcher"].usd_estimate == 0.0
+    assert by_name["fetcher"].breakdown["calls"] == 12
+    assert "bird" in by_name["fetcher"].notes
+    assert by_name["web"].breakdown["requests"] == 99
+    assert by_name["pipeline"].breakdown["compute_seconds"] == 12.5
+
+
+# ── Pricing override file ───────────────────────────────────────────────
+
+
+def test_pricing_override_file_dict_format(tmp_path):
+    path = tmp_path / "pricing.json"
+    path.write_text(
+        json.dumps({"anthropic": {"claude-opus-4-7": {"input_per_million_usd": 1.0, "output_per_million_usd": 2.0}}}),
+    )
+    overrides = load_pricing_overrides(path)
+    assert overrides[("anthropic", "claude-opus-4-7")] == (1.0, 2.0)
+
+
+def test_pricing_override_file_list_format(tmp_path):
+    path = tmp_path / "pricing.json"
+    path.write_text(json.dumps({"gemini": {"gemini-3-pro": [9.0, 18.0]}}))
+    overrides = load_pricing_overrides(path)
+    assert overrides[("gemini", "gemini-3-pro")] == (9.0, 18.0)
+
+
+def test_pricing_override_file_missing_returns_empty(tmp_path):
+    overrides = load_pricing_overrides(tmp_path / "does_not_exist.json")
+    assert overrides == {}
+
+
+def test_pricing_override_changes_estimate():
+    snapshot = {
+        "counters": {
+            "scorer.anthropic.input_tokens{model=claude-opus-4-7}": 1_000_000,
+            "scorer.anthropic.output_tokens{model=claude-opus-4-7}": 0,
+        },
+        "histograms": {},
+    }
+    override = {("anthropic", "claude-opus-4-7"): (1.0, 0.0)}
+    components = estimate_costs(snapshot, pricing=override)
+    by_name = {c.name: c for c in components}
+    # 1M tokens * 1.0/M = 1.00
+    assert abs(by_name["scorer:anthropic"].usd_estimate - 1.0) < 1e-6
+
+
+# ── total_usd ───────────────────────────────────────────────────────────
+
+
+def test_total_usd_sums_components():
+    components = [
+        Component(name="a", usd_estimate=1.5),
+        Component(name="b", usd_estimate=2.25),
+        Component(name="c", usd_estimate=0.0),
+    ]
+    assert total_usd(components) == 3.75
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+
+
+def test_cli_costs_json_live():
+    """Live snapshot path: skips the SQLite query entirely."""
+    metrics.reset()
+    metrics.counter("scorer.gemini.input_tokens", value=1_000)
+    metrics.counter("scorer.gemini.output_tokens", value=500)
+
+    runner = CliRunner()
+    with patch("twag.cli.costs_cmd.load_config", return_value={"llm": {"triage_model": "gemini-3-flash-preview"}}):
+        result = runner.invoke(cli, ["costs", "--since", "live", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "components" in payload
+    assert "total_usd" in payload
+    assert payload["window"] == "live"
+
+    names = {c["name"] for c in payload["components"]}
+    assert "scorer:gemini" in names
+    assert "fetcher" in names
+    assert "pipeline" in names
+    assert "web" in names
+
+    gemini = next(c for c in payload["components"] if c["name"] == "scorer:gemini")
+    assert "input_tokens" in gemini["breakdown"]
+    assert "output_tokens" in gemini["breakdown"]
+
+
+def test_cli_costs_table_renders():
+    metrics.reset()
+    metrics.counter("scorer.anthropic.input_tokens", value=1_000)
+    metrics.counter("scorer.anthropic.output_tokens", value=500)
+
+    runner = CliRunner()
+    with patch("twag.cli.costs_cmd.load_config", return_value={"llm": {"enrichment_model": "claude-opus-4-7"}}):
+        # Force a wide terminal so Rich doesn't truncate the component name.
+        with patch.dict("os.environ", {"COLUMNS": "200"}):
+            result = runner.invoke(cli, ["costs", "--since", "live"])
+
+    assert result.exit_code == 0, result.output
+    assert "Estimated costs" in result.output
+    # The Rich table renders provider names; allow either full or truncated forms.
+    assert "scorer:anthropic" in result.output or "anthropic" in result.output
+    assert "TOTAL" in result.output
+
+
+def test_cli_costs_pricing_file_option(tmp_path):
+    metrics.reset()
+    metrics.counter("scorer.anthropic.input_tokens", value=1_000_000)
+    metrics.counter("scorer.anthropic.output_tokens", value=0)
+
+    pricing_file = tmp_path / "pricing.json"
+    pricing_file.write_text(
+        json.dumps({"anthropic": {"claude-opus-4-7": {"input_per_million_usd": 2.0, "output_per_million_usd": 0.0}}}),
+    )
+
+    runner = CliRunner()
+    with patch("twag.cli.costs_cmd.load_config", return_value={"llm": {"enrichment_model": "claude-opus-4-7"}}):
+        result = runner.invoke(cli, ["costs", "--since", "live", "--json", "--pricing-file", str(pricing_file)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    anthropic = next(c for c in payload["components"] if c["name"] == "scorer:anthropic")
+    # 1M tokens * 2.0/1M = 2.0
+    assert abs(anthropic["usd_estimate"] - 2.0) < 1e-6

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -3,20 +3,24 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from twag import metrics
 from twag.cli import cli
+from twag.cli.costs_cmd import _build_snapshot_from_db
 from twag.costs import (
     Component,
+    default_pricing_path,
     derive_model_from_label,
     estimate_costs,
     load_pricing_overrides,
     lookup_rate,
     total_usd,
 )
+from twag.metrics import MetricsCollector, ensure_metrics_table
 
 
 def setup_function():
@@ -284,3 +288,144 @@ def test_cli_costs_pricing_file_option(tmp_path):
     anthropic = next(c for c in payload["components"] if c["name"] == "scorer:anthropic")
     # 1M tokens * 2.0/1M = 2.0
     assert abs(anthropic["usd_estimate"] - 2.0) < 1e-6
+
+
+# ── Persisted counters: delta semantics across process lifetimes ─────────
+
+
+def test_flush_to_db_writes_delta_not_cumulative():
+    """Each flush should record only the delta since the previous flush.
+
+    Cumulative-snapshot rows would force a window-aggregator to choose between
+    SUM (double-counts within one process) or MAX (loses cross-process spend).
+    Storing deltas lets the window query be a simple SUM.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_metrics_table(conn)
+
+    m = MetricsCollector()
+    m.inc("scorer.gemini.input_tokens", 100)
+    m.flush_to_db(conn)
+
+    m.inc("scorer.gemini.input_tokens", 50)
+    m.flush_to_db(conn)
+
+    rows = conn.execute(
+        "SELECT value FROM metrics WHERE name = 'scorer.gemini.input_tokens' AND type = 'counter'",
+    ).fetchall()
+    values = [r["value"] for r in rows]
+    assert values == [100, 50], f"expected per-flush deltas, got {values}"
+    # Sum across rows should equal current cumulative value.
+    assert sum(values) == m.counter_value("scorer.gemini.input_tokens") == 150
+
+
+def test_flush_to_db_skips_unchanged_counters():
+    """A flush with no counter activity should not insert duplicate rows."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_metrics_table(conn)
+
+    m = MetricsCollector()
+    m.inc("scorer.anthropic.input_tokens", 25)
+    first = m.flush_to_db(conn)
+    second = m.flush_to_db(conn)
+    assert first == 1
+    assert second == 0
+
+
+def test_flush_summed_across_two_collectors_recovers_total():
+    """Cross-process scenario: two independent collectors that each flush.
+
+    The fix from review iteration 1: process A flushes 100 + 50, process B
+    starts fresh and flushes 30 — the window total must be 180, not 150 (the
+    old MAX-based reconstruction returned 150).
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_metrics_table(conn)
+
+    a = MetricsCollector()
+    a.inc("scorer.gemini.input_tokens", 100)
+    a.flush_to_db(conn)
+    a.inc("scorer.gemini.input_tokens", 50)
+    a.flush_to_db(conn)
+
+    b = MetricsCollector()
+    b.inc("scorer.gemini.input_tokens", 30)
+    b.flush_to_db(conn)
+
+    total = conn.execute(
+        "SELECT SUM(value) AS s FROM metrics WHERE name = 'scorer.gemini.input_tokens' AND type = 'counter'",
+    ).fetchone()["s"]
+    assert total == 180
+
+
+def test_build_snapshot_from_db_sums_cross_process_deltas(monkeypatch):
+    """End-to-end: the CLI window-aggregator returns the true cross-process sum."""
+    db_file = sqlite3.connect(":memory:")
+    db_file.row_factory = sqlite3.Row
+    ensure_metrics_table(db_file)
+
+    a = MetricsCollector()
+    a.inc("scorer.gemini.input_tokens{model=gemini-3-flash-preview}", 100)
+    a.flush_to_db(db_file)
+    a.inc("scorer.gemini.input_tokens{model=gemini-3-flash-preview}", 50)
+    a.flush_to_db(db_file)
+    b = MetricsCollector()
+    b.inc("scorer.gemini.input_tokens{model=gemini-3-flash-preview}", 30)
+    b.flush_to_db(db_file)
+
+    # Patch the connection helper so _build_snapshot_from_db sees our in-memory DB.
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _conn(**_kw):
+        yield db_file
+
+    monkeypatch.setattr("twag.cli.costs_cmd.get_connection", _conn)
+
+    from datetime import timedelta
+
+    snapshot = _build_snapshot_from_db(timedelta(days=1))
+    assert snapshot["counters"]["scorer.gemini.input_tokens{model=gemini-3-flash-preview}"] == 180
+
+
+# ── XDG path ────────────────────────────────────────────────────────────
+
+
+def test_default_pricing_path_is_xdg(monkeypatch, tmp_path):
+    """Default override file should live under XDG_CONFIG_HOME/twag/, not ~/.twag/."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    expected = tmp_path / "twag" / "pricing.json"
+    assert default_pricing_path() == expected
+
+
+# ── Labeled counters from llm_client are correctly attributed ───────────
+
+
+def test_labeled_counters_per_model_are_priced_independently():
+    """Two Gemini models in the same provider bucket should each price using
+    their own row in PRICING -- not collapse into a single configured default.
+    """
+    snapshot = {
+        "counters": {
+            # 1M input tokens on gemini-3-flash → 0.30 USD
+            "scorer.gemini.input_tokens{model=gemini-3-flash-preview}": 1_000_000,
+            "scorer.gemini.output_tokens{model=gemini-3-flash-preview}": 0,
+            # 1M input tokens on gemini-3-pro → 3.50 USD
+            "scorer.gemini.input_tokens{model=gemini-3-pro-preview}": 1_000_000,
+            "scorer.gemini.output_tokens{model=gemini-3-pro-preview}": 0,
+        },
+        "histograms": {},
+    }
+    components = estimate_costs(snapshot, configured_models={})
+    by_name = {c.name: c for c in components}
+    gemini = by_name["scorer:gemini"]
+    # 0.30 + 3.50 = 3.80
+    assert abs(gemini.usd_estimate - 3.80) < 1e-6
+    # And both models appear in the per-model breakdown
+    assert "gemini-3-flash-preview" in gemini.breakdown["models"]
+    assert "gemini-3-pro-preview" in gemini.breakdown["models"]
+    assert abs(gemini.breakdown["models"]["gemini-3-flash-preview"]["usd_estimate"] - 0.30) < 1e-6
+    assert abs(gemini.breakdown["models"]["gemini-3-pro-preview"]["usd_estimate"] - 3.50) < 1e-6

--- a/tests/test_link_utils.py
+++ b/tests/test_link_utils.py
@@ -1,4 +1,8 @@
-from twag.link_utils import expand_links_in_place, normalize_tweet_links
+from unittest.mock import MagicMock
+
+import httpx
+
+from twag.link_utils import _expand_short_url, expand_links_in_place, normalize_tweet_links
 
 
 def test_normalize_tweet_links_expands_short_urls_without_structured_links(monkeypatch):
@@ -137,6 +141,39 @@ def test_expand_links_in_place_limits_short_url_expansions(monkeypatch):
     assert expanded[0]["expanded_url"] == "https://expanded.example/one"
     assert expanded[1]["expanded_url"] == "https://expanded.example/two"
     assert expanded[2]["expanded_url"] == "https://t.co/three"
+
+
+def test_expand_short_url_uses_httpx(monkeypatch):
+    """Verify _expand_short_url resolves via httpx (not urllib)."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    mock_response = MagicMock()
+    mock_response.url = httpx.URL("https://example.com/final")
+
+    def mock_request(method, url, **kwargs):
+        return mock_response
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/abc123")
+    assert result == "https://example.com/final"
+    _expand_short_url.cache_clear()
+
+
+def test_expand_short_url_falls_back_on_httpx_error(monkeypatch):
+    """Verify _expand_short_url returns original URL when httpx raises."""
+    _expand_short_url.cache_clear()
+    monkeypatch.setattr("twag.link_utils._network_expansion_attempts", 0)
+
+    def mock_request(method, url, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.link_utils.httpx.request", mock_request)
+
+    result = _expand_short_url("https://t.co/fail456")
+    assert result == "https://t.co/fail456"
+    _expand_short_url.cache_clear()
 
 
 def test_normalize_tweet_links_already_expanded_skips_network_expansion(monkeypatch):

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,8 +1,11 @@
 """Tests for twag.notifier — alert formatting and send-gating logic."""
 
+import logging
 from unittest.mock import patch
 
-from twag.notifier import can_send_alert, format_alert
+import httpx
+
+from twag.notifier import can_send_alert, format_alert, send_telegram_alert
 
 
 class TestFormatAlert:
@@ -154,3 +157,42 @@ class TestCanSendAlert:
             patch("twag.notifier.get_recent_alert_count", return_value=0),
         ):
             assert can_send_alert(score=7) is True
+
+
+def test_send_telegram_alert_logs_on_exception(monkeypatch, caplog):
+    """Verify that send_telegram_alert logs a warning when the HTTP call raises."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    def mock_post(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("twag.notifier.httpx.post", mock_post)
+
+    with caplog.at_level(logging.WARNING, logger="twag.notifier"):
+        result = send_telegram_alert("test message")
+
+    assert result is False
+    assert "Telegram send failed" in caplog.text
+
+
+def test_send_telegram_alert_returns_true_on_success(monkeypatch):
+    """Verify that send_telegram_alert returns True on 200 response."""
+    monkeypatch.setattr(
+        "twag.notifier.load_config",
+        lambda: {"notifications": {"telegram_chat_id": "123"}},
+    )
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "123")
+
+    class FakeResponse:
+        status_code = 200
+
+    monkeypatch.setattr("twag.notifier.httpx.post", lambda *a, **kw: FakeResponse())
+
+    result = send_telegram_alert("test message")
+    assert result is True

--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -35,6 +35,17 @@ def cli():
     """Twitter aggregator for market-relevant signals."""
 
 
+@cli.result_callback()
+def _flush_metrics_after_command(_result, **_kwargs):
+    """Persist any in-memory metrics so ``twag costs --since`` can see them.
+
+    Runs after every subcommand. Failures are silent — see ``flush_metrics``.
+    """
+    from ..metrics import flush_metrics
+
+    flush_metrics()
+
+
 # Register commands
 cli.add_command(_init_mod.init)
 cli.add_command(_init_mod.doctor)

--- a/twag/cli/__init__.py
+++ b/twag/cli/__init__.py
@@ -12,6 +12,7 @@ from ..db import get_connection, get_tweet_by_id, get_unprocessed_tweets, init_d
 from . import accounts as _accounts_mod
 from . import analyze as _analyze_mod
 from . import config_cmd as _config_mod
+from . import costs_cmd as _costs_mod
 from . import db_cmd as _db_mod
 from . import digest as _digest_mod
 from . import fetch as _fetch_mod
@@ -51,6 +52,7 @@ cli.add_command(_db_mod.db)
 cli.add_command(_search_mod.search)
 cli.add_command(_web_mod.web)
 cli.add_command(_metrics_mod.metrics)
+cli.add_command(_costs_mod.costs)
 
 
 if __name__ == "__main__":

--- a/twag/cli/costs_cmd.py
+++ b/twag/cli/costs_cmd.py
@@ -25,11 +25,15 @@ from ._console import console
 def _build_snapshot_from_db(window: timedelta) -> dict[str, Any]:
     """Reconstruct a metrics snapshot from the persisted ``metrics`` table.
 
-    Counters are summed across rows in the window; histograms use the latest
-    flushed totals (since each flush writes the running total).
+    Counter rows are deltas (see ``MetricsCollector.flush_to_db``), so summing
+    them across the window recovers the true total — even across multiple
+    process lifetimes that flushed within the same window. Histograms use the
+    latest row in the window (each flushed snapshot is itself cumulative for
+    the writing process).
     """
     cutoff = datetime.now(timezone.utc) - window
-    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%fZ")
+    # Match the table's strftime format: %f is milliseconds in SQLite, fractional in Python.
+    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%S.") + f"{cutoff.microsecond // 1000:03d}Z"
 
     counters: dict[str, float] = defaultdict(float)
     histograms: dict[str, dict[str, float]] = {}
@@ -41,23 +45,20 @@ def _build_snapshot_from_db(window: timedelta) -> dict[str, Any]:
             (cutoff_iso,),
         ).fetchall()
 
-    last_counter: dict[str, float] = {}
     for row in rows:
         name = row["name"]
         kind = row["type"]
         value = row["value"]
         if kind == "counter":
-            # Each flush records the cumulative counter total; take max to avoid
-            # double-counting the same lifetime.
-            last_counter[name] = max(last_counter.get(name, 0.0), value)
+            counters[name] += value
         elif kind == "histogram" and row["labels_json"]:
             try:
                 stats = json.loads(row["labels_json"])
             except json.JSONDecodeError:
                 continue
+            # Latest histogram row in the window wins (rows are ordered ASC).
             histograms[name] = stats
 
-    counters.update(last_counter)
     return {"counters": dict(counters), "histograms": histograms}
 
 
@@ -82,7 +83,7 @@ def _component_to_dict(c: Component) -> dict[str, Any]:
     "--pricing-file",
     type=click.Path(dir_okay=False),
     default=None,
-    help="Path to pricing override JSON. Defaults to ~/.twag/pricing.json if present.",
+    help="Path to pricing override JSON. Defaults to ~/.config/twag/pricing.json if present.",
 )
 def costs(since: str, as_json: bool, pricing_file: str | None) -> None:
     """Estimate API costs by component from locally-tracked metrics."""

--- a/twag/cli/costs_cmd.py
+++ b/twag/cli/costs_cmd.py
@@ -1,0 +1,165 @@
+"""CLI command for cost attribution estimation."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import rich_click as click
+from rich.table import Table
+
+from ..config import load_config
+from ..costs import (
+    Component,
+    estimate_costs,
+    load_pricing_overrides,
+    total_usd,
+)
+from ..db import get_connection
+from ..metrics import ensure_metrics_table, get_collector
+from ._console import console
+
+
+def _build_snapshot_from_db(window: timedelta) -> dict[str, Any]:
+    """Reconstruct a metrics snapshot from the persisted ``metrics`` table.
+
+    Counters are summed across rows in the window; histograms use the latest
+    flushed totals (since each flush writes the running total).
+    """
+    cutoff = datetime.now(timezone.utc) - window
+    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%fZ")
+
+    counters: dict[str, float] = defaultdict(float)
+    histograms: dict[str, dict[str, float]] = {}
+
+    with get_connection(readonly=True) as conn:
+        ensure_metrics_table(conn)
+        rows = conn.execute(
+            "SELECT name, type, value, labels_json FROM metrics WHERE recorded_at >= ? ORDER BY recorded_at ASC",
+            (cutoff_iso,),
+        ).fetchall()
+
+    last_counter: dict[str, float] = {}
+    for row in rows:
+        name = row["name"]
+        kind = row["type"]
+        value = row["value"]
+        if kind == "counter":
+            # Each flush records the cumulative counter total; take max to avoid
+            # double-counting the same lifetime.
+            last_counter[name] = max(last_counter.get(name, 0.0), value)
+        elif kind == "histogram" and row["labels_json"]:
+            try:
+                stats = json.loads(row["labels_json"])
+            except json.JSONDecodeError:
+                continue
+            histograms[name] = stats
+
+    counters.update(last_counter)
+    return {"counters": dict(counters), "histograms": histograms}
+
+
+def _component_to_dict(c: Component) -> dict[str, Any]:
+    return {
+        "name": c.name,
+        "usd_estimate": c.usd_estimate,
+        "breakdown": c.breakdown,
+        "notes": c.notes,
+    }
+
+
+@click.command("costs")
+@click.option(
+    "--since",
+    "since",
+    default="24h",
+    help="Time window for persisted metrics (e.g., 1h, 24h, 7d). Use 'live' for in-memory only.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit raw estimate as JSON.")
+@click.option(
+    "--pricing-file",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Path to pricing override JSON. Defaults to ~/.twag/pricing.json if present.",
+)
+def costs(since: str, as_json: bool, pricing_file: str | None) -> None:
+    """Estimate API costs by component from locally-tracked metrics."""
+    if since == "live":
+        snapshot = get_collector().snapshot()
+    else:
+        try:
+            window = _parse_window(since)
+        except ValueError as e:
+            raise click.BadParameter(str(e), param_hint="--since") from e
+        snapshot = _build_snapshot_from_db(window)
+
+    overrides = load_pricing_overrides(pricing_file)
+
+    cfg = load_config().get("llm", {})
+    configured = {
+        "triage": cfg.get("triage_model"),
+        "enrichment": cfg.get("enrichment_model"),
+        "vision": cfg.get("vision_model"),
+    }
+
+    components = estimate_costs(snapshot, pricing=overrides or None, configured_models=configured)
+
+    if as_json:
+        payload = {
+            "window": since,
+            "total_usd": total_usd(components),
+            "components": [_component_to_dict(c) for c in components],
+        }
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    table = Table(title=f"Estimated costs ({since})")
+    table.add_column("Component", style="cyan")
+    table.add_column("Calls", justify="right")
+    table.add_column("Tokens (in)", justify="right")
+    table.add_column("Tokens (out)", justify="right")
+    table.add_column("USD", justify="right")
+    table.add_column("Notes", style="dim")
+
+    for c in components:
+        b = c.breakdown
+        calls = _fmt_int(b.get("calls", 0))
+        in_tokens = _fmt_int(b.get("input_tokens", 0))
+        out_tokens = _fmt_int(b.get("output_tokens", 0))
+        usd = f"${c.usd_estimate:,.4f}" if c.usd_estimate else "$0.0000"
+        table.add_row(c.name, calls, in_tokens, out_tokens, usd, c.notes or "")
+
+    table.add_section()
+    table.add_row("[bold]TOTAL[/bold]", "", "", "", f"[bold]${total_usd(components):,.4f}[/bold]", "")
+    console.print(table)
+    console.print(
+        "[dim]Estimates are advisory and based on locally-tracked token counters. "
+        "Calls without SDK-reported usage data are not priced.[/dim]",
+    )
+
+
+def _fmt_int(value: Any) -> str:
+    try:
+        return f"{int(float(value)):,}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _parse_window(spec: str) -> timedelta:
+    spec = spec.strip().lower()
+    if not spec:
+        raise ValueError("empty window")
+    unit = spec[-1]
+    try:
+        n = int(spec[:-1])
+    except ValueError as e:
+        raise ValueError(f"could not parse window '{spec}'; use forms like 1h, 24h, 7d") from e
+    if unit == "h":
+        return timedelta(hours=n)
+    if unit == "d":
+        return timedelta(days=n)
+    if unit == "m":
+        return timedelta(minutes=n)
+    raise ValueError(f"unsupported window unit '{unit}'; use m/h/d")

--- a/twag/costs.py
+++ b/twag/costs.py
@@ -2,7 +2,8 @@
 
 Translates locally-tracked metrics (token counters per LLM provider, call counts)
 into a per-component USD estimate. Pricing is configurable via the PRICING table
-or a user-supplied JSON file (default: ``~/.twag/pricing.json``).
+or a user-supplied JSON file (default: ``$XDG_CONFIG_HOME/twag/pricing.json``,
+i.e. ``~/.config/twag/pricing.json``).
 
 Estimates are advisory. Token counts come from the LLM SDKs' usage metadata when
 available; calls without usage data are not priced. Non-LLM components (fetcher,
@@ -15,6 +16,8 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from .config import APP_NAME, get_xdg_config_home
 
 if TYPE_CHECKING:
     import os
@@ -44,7 +47,9 @@ PRICING: dict[tuple[str, str], tuple[float, float]] = {
 }
 
 
-DEFAULT_PRICING_PATH = Path.home() / ".twag" / "pricing.json"
+def default_pricing_path() -> Path:
+    """Default location for a user pricing override file (XDG-compliant)."""
+    return get_xdg_config_home() / APP_NAME / "pricing.json"
 
 
 @dataclass
@@ -60,7 +65,7 @@ class Component:
 def _user_pricing_path(override: str | os.PathLike[str] | None = None) -> Path:
     if override is not None:
         return Path(override)
-    return DEFAULT_PRICING_PATH
+    return default_pricing_path()
 
 
 def load_pricing_overrides(path: str | os.PathLike[str] | None = None) -> dict[tuple[str, str], tuple[float, float]]:

--- a/twag/costs.py
+++ b/twag/costs.py
@@ -1,0 +1,334 @@
+"""Cost attribution estimator for twag.
+
+Translates locally-tracked metrics (token counters per LLM provider, call counts)
+into a per-component USD estimate. Pricing is configurable via the PRICING table
+or a user-supplied JSON file (default: ``~/.twag/pricing.json``).
+
+Estimates are advisory. Token counts come from the LLM SDKs' usage metadata when
+available; calls without usage data are not priced. Non-LLM components (fetcher,
+pipeline compute, web) are listed at $0 with an explanatory note.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import os
+
+# (provider, model_substring) -> (input_per_million_usd, output_per_million_usd)
+# Substring matching lets a single entry cover related model variants, and the
+# longest matching substring wins.
+PRICING: dict[tuple[str, str], tuple[float, float]] = {
+    # Gemini (USD per 1M tokens; published rates as of early 2026)
+    ("gemini", "gemini-3-pro"): (3.50, 21.00),
+    ("gemini", "gemini-3-flash"): (0.30, 2.50),
+    ("gemini", "gemini-3.1-pro"): (3.50, 21.00),
+    ("gemini", "gemini-3.1-flash"): (0.30, 2.50),
+    ("gemini", "gemini-2.5-pro"): (1.25, 10.00),
+    ("gemini", "gemini-2.5-flash"): (0.075, 0.30),
+    ("gemini", "gemini-2.0-flash"): (0.075, 0.30),
+    ("gemini", "gemini"): (0.30, 2.50),  # generic fallback
+    # Anthropic
+    ("anthropic", "claude-opus-4-7"): (15.00, 75.00),
+    ("anthropic", "claude-opus-4-6"): (15.00, 75.00),
+    ("anthropic", "claude-opus-4"): (15.00, 75.00),
+    ("anthropic", "claude-sonnet-4-6"): (3.00, 15.00),
+    ("anthropic", "claude-sonnet-4"): (3.00, 15.00),
+    ("anthropic", "claude-haiku-4-5"): (1.00, 5.00),
+    ("anthropic", "claude-haiku-4"): (1.00, 5.00),
+    ("anthropic", "claude"): (3.00, 15.00),  # generic fallback
+}
+
+
+DEFAULT_PRICING_PATH = Path.home() / ".twag" / "pricing.json"
+
+
+@dataclass
+class Component:
+    """A single component's cost attribution."""
+
+    name: str
+    usd_estimate: float = 0.0
+    breakdown: dict[str, Any] = field(default_factory=dict)
+    notes: str = ""
+
+
+def _user_pricing_path(override: str | os.PathLike[str] | None = None) -> Path:
+    if override is not None:
+        return Path(override)
+    return DEFAULT_PRICING_PATH
+
+
+def load_pricing_overrides(path: str | os.PathLike[str] | None = None) -> dict[tuple[str, str], tuple[float, float]]:
+    """Load pricing overrides from JSON file.
+
+    Format::
+
+        {
+          "gemini": {
+            "gemini-3-pro": {"input_per_million_usd": 3.5, "output_per_million_usd": 21.0}
+          },
+          "anthropic": {
+            "claude-haiku-4-5": [1.0, 5.0]
+          }
+        }
+    """
+    p = _user_pricing_path(path)
+    if not p.exists():
+        return {}
+    with open(p, encoding="utf-8") as f:
+        raw = json.load(f)
+
+    out: dict[tuple[str, str], tuple[float, float]] = {}
+    for provider, models in raw.items():
+        if not isinstance(models, dict):
+            continue
+        for model, rates in models.items():
+            if isinstance(rates, dict):
+                in_rate = float(rates.get("input_per_million_usd", 0.0))
+                out_rate = float(rates.get("output_per_million_usd", 0.0))
+            elif isinstance(rates, (list, tuple)) and len(rates) == 2:
+                in_rate = float(rates[0])
+                out_rate = float(rates[1])
+            else:
+                continue
+            out[(provider, model)] = (in_rate, out_rate)
+    return out
+
+
+def lookup_rate(
+    provider: str,
+    model: str,
+    pricing: dict[tuple[str, str], tuple[float, float]] | None = None,
+) -> tuple[float, float] | None:
+    """Look up (input_rate, output_rate) per million tokens.
+
+    Tries exact match first, then longest-substring match. Returns ``None`` if
+    no entry covers the model.
+    """
+    table = dict(PRICING)
+    if pricing:
+        table.update(pricing)
+
+    exact = table.get((provider, model))
+    if exact is not None:
+        return exact
+
+    candidates = [(key, rate) for key, rate in table.items() if key[0] == provider and key[1] in model]
+    if not candidates:
+        return None
+    # Longest substring match wins
+    candidates.sort(key=lambda item: len(item[0][1]), reverse=True)
+    return candidates[0][1]
+
+
+def derive_model_from_label(counter_name: str) -> tuple[str | None, str | None]:
+    """Extract provider/model from a labeled counter name like
+    ``scorer.gemini.input_tokens{model=gemini-3-pro}``.
+
+    Returns ``(provider, model)`` where either may be ``None`` if not present.
+    """
+    provider: str | None = None
+    model: str | None = None
+
+    base = counter_name.split("{", 1)[0]
+    parts = base.split(".")
+    if len(parts) >= 2 and parts[0] == "scorer":
+        provider = parts[1]
+
+    if "{" in counter_name and counter_name.endswith("}"):
+        labels_str = counter_name.split("{", 1)[1][:-1]
+        for entry in labels_str.split(","):
+            if "=" in entry:
+                k, v = entry.split("=", 1)
+                if k.strip() == "model":
+                    model = v.strip()
+                elif k.strip() == "provider" and provider is None:
+                    provider = v.strip()
+    return provider, model
+
+
+def _aggregate_provider_tokens(counters: dict[str, float]) -> dict[str, dict[str, dict[str, float]]]:
+    """Group token counts by provider and model.
+
+    Returns ``{provider: {model_or_'unknown': {'input': X, 'output': Y, 'calls': N}}}``.
+    Aggregates across both text and vision token counters.
+    """
+    by_provider: dict[str, dict[str, dict[str, float]]] = {}
+
+    for name, value in counters.items():
+        if not name.startswith("scorer."):
+            continue
+
+        provider, model = derive_model_from_label(name)
+        if provider is None:
+            continue
+
+        base = name.split("{", 1)[0]
+        suffix = base[len("scorer.") + len(provider) + 1 :] if base.startswith(f"scorer.{provider}.") else ""
+
+        if suffix in ("input_tokens", "vision_input_tokens"):
+            kind = "input"
+        elif suffix in ("output_tokens", "vision_output_tokens"):
+            kind = "output"
+        elif suffix in ("calls", "vision_calls"):
+            kind = "calls"
+        else:
+            continue
+
+        bucket = by_provider.setdefault(provider, {}).setdefault(
+            model or "unknown",
+            {"input": 0.0, "output": 0.0, "calls": 0.0},
+        )
+        bucket[kind] = bucket.get(kind, 0.0) + value
+
+    return by_provider
+
+
+def _resolve_model_for_provider(provider: str, configured: dict[str, str]) -> str | None:
+    """Pick a default model name for an unlabeled counter based on twag config."""
+    triage = configured.get("triage")
+    enrichment = configured.get("enrichment")
+    if triage and ((provider == "gemini" and "gemini" in triage) or (provider == "anthropic" and "claude" in triage)):
+        return triage
+    if enrichment and (
+        (provider == "gemini" and "gemini" in enrichment) or (provider == "anthropic" and "claude" in enrichment)
+    ):
+        return enrichment
+    return triage or enrichment
+
+
+def estimate_costs(
+    snapshot: dict[str, Any],
+    pricing: dict[tuple[str, str], tuple[float, float]] | None = None,
+    configured_models: dict[str, str] | None = None,
+) -> list[Component]:
+    """Estimate costs by component from a metrics snapshot.
+
+    ``snapshot`` should match ``MetricsCollector.snapshot()`` output: a dict with
+    ``counters`` and ``histograms`` keys.
+
+    ``configured_models`` maps role -> model name (e.g. ``{"triage": "gemini-3-flash-preview",
+    "enrichment": "claude-opus-4-7"}``). Used as a fallback when token counters
+    aren't model-labeled.
+    """
+    counters = snapshot.get("counters", {}) or {}
+    histograms = snapshot.get("histograms", {}) or {}
+    configured = configured_models or {}
+
+    components: list[Component] = []
+
+    # ── Scorer (LLM) components ────────────────────────────────────────────
+    by_provider = _aggregate_provider_tokens(counters)
+    for provider in sorted(by_provider):
+        provider_total = 0.0
+        provider_in_tokens = 0.0
+        provider_out_tokens = 0.0
+        provider_calls = 0.0
+        provider_breakdown: dict[str, Any] = {"models": {}}
+        provider_notes: list[str] = []
+
+        for model_name, totals in by_provider[provider].items():
+            in_tokens = totals.get("input", 0.0)
+            out_tokens = totals.get("output", 0.0)
+            calls = totals.get("calls", 0.0)
+
+            effective_model = (
+                model_name if model_name != "unknown" else _resolve_model_for_provider(provider, configured)
+            )
+            rate = lookup_rate(provider, effective_model, pricing) if effective_model else None
+
+            if rate is None:
+                cost = 0.0
+                if in_tokens or out_tokens:
+                    provider_notes.append(
+                        f"no pricing entry for model='{effective_model or 'unknown'}'; counted tokens but priced at $0",
+                    )
+            else:
+                in_rate, out_rate = rate
+                cost = (in_tokens * in_rate + out_tokens * out_rate) / 1_000_000.0
+                if model_name == "unknown" and effective_model:
+                    provider_notes.append(f"used configured default model '{effective_model}' for unlabeled counters")
+
+            provider_total += cost
+            provider_in_tokens += in_tokens
+            provider_out_tokens += out_tokens
+            provider_calls += calls
+            provider_breakdown["models"][model_name] = {
+                "input_tokens": in_tokens,
+                "output_tokens": out_tokens,
+                "calls": calls,
+                "usd_estimate": cost,
+                "rate_used": effective_model,
+            }
+
+        provider_breakdown["calls"] = provider_calls
+        provider_breakdown["input_tokens"] = provider_in_tokens
+        provider_breakdown["output_tokens"] = provider_out_tokens
+        components.append(
+            Component(
+                name=f"scorer:{provider}",
+                usd_estimate=round(provider_total, 6),
+                breakdown=provider_breakdown,
+                notes="; ".join(provider_notes),
+            ),
+        )
+
+    # If no scorer activity at all, still surface the component with $0
+    if not by_provider:
+        components.append(
+            Component(
+                name="scorer",
+                usd_estimate=0.0,
+                breakdown={"calls": 0, "input_tokens": 0, "output_tokens": 0},
+                notes="no LLM activity recorded in this snapshot",
+            ),
+        )
+
+    # ── Fetcher (bird CLI) — not priced ────────────────────────────────────
+    fetcher_calls = sum(v for k, v in counters.items() if k.startswith("fetcher.") and k.endswith(".calls"))
+    if fetcher_calls == 0:
+        fetcher_calls = sum(v for k, v in counters.items() if k.startswith("fetcher."))
+    components.append(
+        Component(
+            name="fetcher",
+            usd_estimate=0.0,
+            breakdown={"calls": fetcher_calls},
+            notes="bird CLI is local; no API spend tracked",
+        ),
+    )
+
+    # ── Pipeline compute — not priced ──────────────────────────────────────
+    pipeline_total = 0.0
+    for name, stats in histograms.items():
+        if name.startswith("pipeline."):
+            pipeline_total += stats.get("total", 0.0)
+    components.append(
+        Component(
+            name="pipeline",
+            usd_estimate=0.0,
+            breakdown={"compute_seconds": round(pipeline_total, 3)},
+            notes="local CPU only; not converted to USD",
+        ),
+    )
+
+    # ── Web — not priced ───────────────────────────────────────────────────
+    web_requests = counters.get("web.requests", 0.0)
+    components.append(
+        Component(
+            name="web",
+            usd_estimate=0.0,
+            breakdown={"requests": web_requests},
+            notes="self-hosted FastAPI; no API spend tracked",
+        ),
+    )
+
+    return components
+
+
+def total_usd(components: list[Component]) -> float:
+    return round(sum(c.usd_estimate for c in components), 6)

--- a/twag/link_utils.py
+++ b/twag/link_utils.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from functools import lru_cache
 from threading import Lock
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+
+import httpx
 
 _URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 _TRAILING_PUNCT_RE = re.compile(r"[)\],.?!:;]+$")
@@ -110,11 +111,10 @@ def _expand_short_url(url: str) -> str:
     )
     for method, timeout in attempts:
         try:
-            request = Request(cleaned, method=method, headers=headers)
-            with urlopen(request, timeout=timeout) as response:
-                resolved = clean_url_candidate(response.geturl() or cleaned)
-                if resolved:
-                    return resolved
+            response = httpx.request(method, cleaned, headers=headers, timeout=timeout, follow_redirects=True)
+            resolved = clean_url_candidate(str(response.url) or cleaned)
+            if resolved:
+                return resolved
         except Exception:
             continue
     return cleaned

--- a/twag/metrics.py
+++ b/twag/metrics.py
@@ -107,6 +107,8 @@ class MetricsCollector:
         self._counters: dict[str, _Counter] = {}
         self._gauges: dict[str, _Gauge] = {}
         self._histograms: dict[str, _Histogram] = {}
+        self._last_flushed_counters: dict[str, float] = {}
+        self._last_flushed_hist_counts: dict[str, int] = {}
         self._start_time = time.monotonic()
 
     # -- Counters --
@@ -204,30 +206,55 @@ class MetricsCollector:
     # -- Persistence --
 
     def flush_to_db(self, conn: sqlite3.Connection) -> int:
-        """Write current metrics to the metrics table. Returns rows written."""
-        snap = self.snapshot()
-        rows: list[tuple[str, str, float, str | None]] = []
+        """Persist deltas since last flush. Returns rows written.
 
-        for name, value in snap["counters"].items():
-            rows.append((name, "counter", value, None))
-        for name, value in snap["gauges"].items():
-            rows.append((name, "gauge", value, None))
-        for name, stats in snap["histograms"].items():
-            rows.append((name, "histogram", stats["mean"], json.dumps(stats)))
+        Counter rows store the *delta* between the current cumulative value and
+        the value at the previous flush from this collector instance. This lets
+        ``SUM(value)`` over a window across many process lifetimes recover the
+        true total — cumulative-counter rows would lose data on process
+        restart and double-count within a single process.
 
-        if rows:
-            conn.executemany(
-                "INSERT INTO metrics (name, type, value, labels_json) VALUES (?, ?, ?, ?)",
-                rows,
-            )
-            conn.commit()
-        return len(rows)
+        Histograms write a row only when the count has advanced. Gauges always
+        write the latest value (snapshot semantics).
+        """
+        with self._lock:
+            snap = self.snapshot()
+            rows: list[tuple[str, str, float, str | None]] = []
+
+            for name, value in snap["counters"].items():
+                last = self._last_flushed_counters.get(name, 0.0)
+                delta = value - last
+                if delta == 0:
+                    continue
+                rows.append((name, "counter", delta, None))
+                self._last_flushed_counters[name] = value
+
+            for name, value in snap["gauges"].items():
+                rows.append((name, "gauge", value, None))
+
+            for name, stats in snap["histograms"].items():
+                count = int(stats["count"])
+                last_count = self._last_flushed_hist_counts.get(name, 0)
+                if count <= last_count:
+                    continue
+                rows.append((name, "histogram", stats["mean"], json.dumps(stats)))
+                self._last_flushed_hist_counts[name] = count
+
+            if rows:
+                conn.executemany(
+                    "INSERT INTO metrics (name, type, value, labels_json) VALUES (?, ?, ?, ?)",
+                    rows,
+                )
+                conn.commit()
+            return len(rows)
 
     def reset(self) -> None:
         with self._lock:
             self._counters.clear()
             self._gauges.clear()
             self._histograms.clear()
+            self._last_flushed_counters.clear()
+            self._last_flushed_hist_counts.clear()
             self._start_time = time.monotonic()
 
 
@@ -308,3 +335,22 @@ def dump_json(path: str | None = None) -> str:
 
 def reset() -> None:
     _collector.reset()
+
+
+def flush_metrics() -> int:
+    """Persist the current in-memory metrics to the twag SQLite database.
+
+    Used by long-running CLI commands and the web layer to make in-memory
+    counters visible to ``twag costs --since <window>``. Errors are swallowed
+    (e.g. database missing or locked) so a flush failure never breaks the
+    user's command — the in-memory snapshot is still available for the
+    current process.
+    """
+    try:
+        from .db import get_connection
+
+        with get_connection() as conn:
+            ensure_metrics_table(conn)
+            return _collector.flush_to_db(conn)
+    except Exception:
+        return 0

--- a/twag/notifier.py
+++ b/twag/notifier.py
@@ -151,6 +151,7 @@ def send_telegram_alert(
             return True
         return False
     except Exception:
+        log.warning("Telegram send failed", exc_info=True)
         return False
 
 

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -3,12 +3,15 @@
 import json
 import random
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from anthropic import Anthropic
 
 from twag.auth import get_api_key
 from twag.config import load_config
+
+_T = TypeVar("_T")
 
 
 def get_anthropic_client() -> Anthropic:
@@ -166,7 +169,7 @@ def _call_llm_vision(provider: str, model: str, image_url: str, prompt: str, max
     return _with_retry(_invoke)
 
 
-def _with_retry(fn):
+def _with_retry(fn: Callable[[], _T]) -> _T:
     from twag.metrics import get_collector
 
     m = get_collector()

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -37,10 +37,10 @@ def _extract_anthropic_text(content_blocks: list[Any]) -> str:
 
 def _call_anthropic(model: str, prompt: str, max_tokens: int = 2048) -> str:
     """Call Anthropic API and return text response."""
-    from twag.metrics import get_collector
+    from twag import metrics
 
-    m = get_collector()
-    m.inc("scorer.anthropic.calls")
+    labels = {"model": model}
+    metrics.counter("scorer.anthropic.calls", labels=labels)
     t0 = time.monotonic()
     try:
         client = get_anthropic_client()
@@ -50,39 +50,67 @@ def _call_anthropic(model: str, prompt: str, max_tokens: int = 2048) -> str:
             messages=[{"role": "user", "content": prompt}],
         )
         result = _extract_anthropic_text(response.content)
-        m.observe("scorer.anthropic.latency_seconds", time.monotonic() - t0)
-        if hasattr(response, "usage") and response.usage:
-            input_tokens = getattr(response.usage, "input_tokens", 0) or 0
-            output_tokens = getattr(response.usage, "output_tokens", 0) or 0
-            m.inc("scorer.anthropic.input_tokens", input_tokens)
-            m.inc("scorer.anthropic.output_tokens", output_tokens)
+        metrics.histogram("scorer.anthropic.latency_seconds", time.monotonic() - t0, labels=labels)
+        _record_anthropic_usage(response, labels=labels)
         return result
     except Exception:
-        m.inc("scorer.anthropic.errors")
+        metrics.counter("scorer.anthropic.errors", labels=labels)
         raise
 
 
-def _record_gemini_usage(collector, response: Any, kind: str) -> None:
-    """Read response.usage_metadata and increment token counters."""
-    usage = getattr(response, "usage_metadata", None)
-    if not usage:
+def _record_anthropic_usage(response: Any, *, labels: dict[str, str], kind: str = "") -> None:
+    """Increment Anthropic input/output token counters from response.usage.
+
+    ``kind`` is an optional prefix on the counter suffix — pass ``"vision_"`` to
+    record into ``scorer.anthropic.vision_input_tokens`` / ``vision_output_tokens``.
+    """
+    from twag import metrics
+
+    try:
+        usage = getattr(response, "usage", None)
+        if not usage:
+            return
+        input_tokens = getattr(usage, "input_tokens", 0) or 0
+        output_tokens = getattr(usage, "output_tokens", 0) or 0
+        if input_tokens:
+            metrics.counter(f"scorer.anthropic.{kind}input_tokens", value=input_tokens, labels=labels)
+        if output_tokens:
+            metrics.counter(f"scorer.anthropic.{kind}output_tokens", value=output_tokens, labels=labels)
+    except Exception:
         return
-    input_tokens = getattr(usage, "prompt_token_count", 0) or 0
-    output_tokens = getattr(usage, "candidates_token_count", 0) or 0
-    if input_tokens:
-        collector.inc(f"scorer.gemini.{kind}input_tokens", input_tokens)
-    if output_tokens:
-        collector.inc(f"scorer.gemini.{kind}output_tokens", output_tokens)
+
+
+def _record_gemini_usage(response: Any, *, labels: dict[str, str], kind: str = "") -> None:
+    """Increment Gemini input/output token counters from response.usage_metadata.
+
+    Wrapped in a defensive try/except so a malformed response can't trigger the
+    outer error counter for an otherwise-successful call. ``kind`` lets callers
+    record vision-specific counters by passing ``"vision_"``.
+    """
+    from twag import metrics
+
+    try:
+        usage = getattr(response, "usage_metadata", None)
+        if not usage:
+            return
+        input_tokens = getattr(usage, "prompt_token_count", 0) or 0
+        output_tokens = getattr(usage, "candidates_token_count", 0) or 0
+        if input_tokens:
+            metrics.counter(f"scorer.gemini.{kind}input_tokens", value=input_tokens, labels=labels)
+        if output_tokens:
+            metrics.counter(f"scorer.gemini.{kind}output_tokens", value=output_tokens, labels=labels)
+    except Exception:
+        return
 
 
 def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str | None = None) -> str:
     """Call Gemini API and return text response."""
     from google.genai import types
 
-    from twag.metrics import get_collector
+    from twag import metrics
 
-    m = get_collector()
-    m.inc("scorer.gemini.calls")
+    labels = {"model": model}
+    metrics.counter("scorer.gemini.calls", labels=labels)
     t0 = time.monotonic()
     try:
         client = get_gemini_client()
@@ -99,20 +127,20 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
             contents=prompt,
             config=types.GenerateContentConfig(**config_kwargs),
         )
-        m.observe("scorer.gemini.latency_seconds", time.monotonic() - t0)
-        _record_gemini_usage(m, response, kind="")
+        metrics.histogram("scorer.gemini.latency_seconds", time.monotonic() - t0, labels=labels)
+        _record_gemini_usage(response, labels=labels)
         return response.text
     except Exception:
-        m.inc("scorer.gemini.errors")
+        metrics.counter("scorer.gemini.errors", labels=labels)
         raise
 
 
 def _call_anthropic_vision(model: str, image_url: str, prompt: str, max_tokens: int = 1024) -> str:
     """Call Anthropic API with image and return text response."""
-    from twag.metrics import get_collector
+    from twag import metrics
 
-    m = get_collector()
-    m.inc("scorer.anthropic.vision_calls")
+    labels = {"model": model}
+    metrics.counter("scorer.anthropic.vision_calls", labels=labels)
     t0 = time.monotonic()
     try:
         client = get_anthropic_client()
@@ -138,17 +166,11 @@ def _call_anthropic_vision(model: str, image_url: str, prompt: str, max_tokens: 
                 },
             ],
         )
-        m.observe("scorer.anthropic.vision_latency_seconds", time.monotonic() - t0)
-        if hasattr(response, "usage") and response.usage:
-            input_tokens = getattr(response.usage, "input_tokens", 0) or 0
-            output_tokens = getattr(response.usage, "output_tokens", 0) or 0
-            if input_tokens:
-                m.inc("scorer.anthropic.vision_input_tokens", input_tokens)
-            if output_tokens:
-                m.inc("scorer.anthropic.vision_output_tokens", output_tokens)
+        metrics.histogram("scorer.anthropic.vision_latency_seconds", time.monotonic() - t0, labels=labels)
+        _record_anthropic_usage(response, labels=labels, kind="vision_")
         return _extract_anthropic_text(response.content)
     except Exception:
-        m.inc("scorer.anthropic.vision_errors")
+        metrics.counter("scorer.anthropic.vision_errors", labels=labels)
         raise
 
 
@@ -157,10 +179,10 @@ def _call_gemini_vision(model: str, image_url: str, prompt: str, max_tokens: int
     import httpx
     from google.genai import types
 
-    from twag.metrics import get_collector
+    from twag import metrics
 
-    m = get_collector()
-    m.inc("scorer.gemini.vision_calls")
+    labels = {"model": model}
+    metrics.counter("scorer.gemini.vision_calls", labels=labels)
     t0 = time.monotonic()
     try:
         client = get_gemini_client()
@@ -181,11 +203,11 @@ def _call_gemini_vision(model: str, image_url: str, prompt: str, max_tokens: int
                 max_output_tokens=max_tokens,
             ),
         )
-        m.observe("scorer.gemini.vision_latency_seconds", time.monotonic() - t0)
-        _record_gemini_usage(m, response, kind="vision_")
+        metrics.histogram("scorer.gemini.vision_latency_seconds", time.monotonic() - t0, labels=labels)
+        _record_gemini_usage(response, labels=labels, kind="vision_")
         return response.text
     except Exception:
-        m.inc("scorer.gemini.vision_errors")
+        metrics.counter("scorer.gemini.vision_errors", labels=labels)
         raise
 
 

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -62,6 +62,19 @@ def _call_anthropic(model: str, prompt: str, max_tokens: int = 2048) -> str:
         raise
 
 
+def _record_gemini_usage(collector, response: Any, kind: str) -> None:
+    """Read response.usage_metadata and increment token counters."""
+    usage = getattr(response, "usage_metadata", None)
+    if not usage:
+        return
+    input_tokens = getattr(usage, "prompt_token_count", 0) or 0
+    output_tokens = getattr(usage, "candidates_token_count", 0) or 0
+    if input_tokens:
+        collector.inc(f"scorer.gemini.{kind}input_tokens", input_tokens)
+    if output_tokens:
+        collector.inc(f"scorer.gemini.{kind}output_tokens", output_tokens)
+
+
 def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str | None = None) -> str:
     """Call Gemini API and return text response."""
     from google.genai import types
@@ -87,6 +100,7 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
             config=types.GenerateContentConfig(**config_kwargs),
         )
         m.observe("scorer.gemini.latency_seconds", time.monotonic() - t0)
+        _record_gemini_usage(m, response, kind="")
         return response.text
     except Exception:
         m.inc("scorer.gemini.errors")
@@ -95,30 +109,47 @@ def _call_gemini(model: str, prompt: str, max_tokens: int = 2048, reasoning: str
 
 def _call_anthropic_vision(model: str, image_url: str, prompt: str, max_tokens: int = 1024) -> str:
     """Call Anthropic API with image and return text response."""
-    client = get_anthropic_client()
-    response = client.messages.create(
-        model=model,
-        max_tokens=max_tokens,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "image",
-                        "source": {
-                            "type": "url",
-                            "url": image_url,
+    from twag.metrics import get_collector
+
+    m = get_collector()
+    m.inc("scorer.anthropic.vision_calls")
+    t0 = time.monotonic()
+    try:
+        client = get_anthropic_client()
+        response = client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "url",
+                                "url": image_url,
+                            },
                         },
-                    },
-                    {
-                        "type": "text",
-                        "text": prompt,
-                    },
-                ],
-            },
-        ],
-    )
-    return _extract_anthropic_text(response.content)
+                        {
+                            "type": "text",
+                            "text": prompt,
+                        },
+                    ],
+                },
+            ],
+        )
+        m.observe("scorer.anthropic.vision_latency_seconds", time.monotonic() - t0)
+        if hasattr(response, "usage") and response.usage:
+            input_tokens = getattr(response.usage, "input_tokens", 0) or 0
+            output_tokens = getattr(response.usage, "output_tokens", 0) or 0
+            if input_tokens:
+                m.inc("scorer.anthropic.vision_input_tokens", input_tokens)
+            if output_tokens:
+                m.inc("scorer.anthropic.vision_output_tokens", output_tokens)
+        return _extract_anthropic_text(response.content)
+    except Exception:
+        m.inc("scorer.anthropic.vision_errors")
+        raise
 
 
 def _call_gemini_vision(model: str, image_url: str, prompt: str, max_tokens: int = 1024) -> str:
@@ -126,25 +157,36 @@ def _call_gemini_vision(model: str, image_url: str, prompt: str, max_tokens: int
     import httpx
     from google.genai import types
 
-    client = get_gemini_client()
+    from twag.metrics import get_collector
 
-    # Fetch image
-    resp = httpx.get(image_url, timeout=30)
-    resp.raise_for_status()
-    image_data = resp.content
-    mime_type = resp.headers.get("content-type", "image/jpeg")
+    m = get_collector()
+    m.inc("scorer.gemini.vision_calls")
+    t0 = time.monotonic()
+    try:
+        client = get_gemini_client()
 
-    # Create image part using new SDK
-    image_part = types.Part.from_bytes(data=image_data, mime_type=mime_type)
+        # Fetch image
+        resp = httpx.get(image_url, timeout=30)
+        resp.raise_for_status()
+        image_data = resp.content
+        mime_type = resp.headers.get("content-type", "image/jpeg")
 
-    response = client.models.generate_content(
-        model=model,
-        contents=[prompt, image_part],
-        config=types.GenerateContentConfig(
-            max_output_tokens=max_tokens,
-        ),
-    )
-    return response.text
+        # Create image part using new SDK
+        image_part = types.Part.from_bytes(data=image_data, mime_type=mime_type)
+
+        response = client.models.generate_content(
+            model=model,
+            contents=[prompt, image_part],
+            config=types.GenerateContentConfig(
+                max_output_tokens=max_tokens,
+            ),
+        )
+        m.observe("scorer.gemini.vision_latency_seconds", time.monotonic() - t0)
+        _record_gemini_usage(m, response, kind="vision_")
+        return response.text
+    except Exception:
+        m.inc("scorer.gemini.vision_errors")
+        raise
 
 
 def _call_llm(provider: str, model: str, prompt: str, max_tokens: int = 2048, reasoning: str | None = None) -> str:

--- a/twag/web/app.py
+++ b/twag/web/app.py
@@ -3,6 +3,7 @@
 import html
 import os
 import time
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, Request, Response
@@ -21,12 +22,23 @@ TEMPLATES_DIR = Path(__file__).parent / "templates"
 FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
 
 
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    # Startup: nothing to do beyond the work create_app() already performed.
+    yield
+    # Shutdown: persist in-memory metrics so `twag costs --since` sees them.
+    from ..metrics import flush_metrics
+
+    flush_metrics()
+
+
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     app = FastAPI(
         title="Twag",
         description="Twitter aggregator web interface",
         version="0.1.0",
+        lifespan=_lifespan,
     )
 
     app.state.db_path = get_database_path()


### PR DESCRIPTION
## Summary

- New `twag costs` Rich CLI command estimates per-component USD spend from locally-tracked metrics. Supports `--since 24h|7d|live`, `--json`, and `--pricing-file PATH` (defaults to `~/.twag/pricing.json` if present).
- New `twag/costs.py` module with a built-in `PRICING` table (Gemini 3.x/2.5/2.0, Claude Opus/Sonnet/Haiku 4.x), longest-substring matching, override loader, and an `estimate_costs(snapshot, ...)` function that emits per-provider scorer rows plus $0 rows for `fetcher`, `pipeline`, and `web` with explanatory notes (these are not API costs).
- Closes token-instrumentation gaps so the estimator has real numbers to work with: Gemini text + vision now read `response.usage_metadata` (`prompt_token_count`, `candidates_token_count`); Anthropic vision now records `input_tokens` / `output_tokens`.
- Tests cover pricing lookup (exact, substring, longest-match, unknown model), synthetic snapshots for both providers, configured-model fallback, override file (dict + list formats), and the CLI JSON/table/`--pricing-file` paths.
- README/CLAUDE updates document the new command and explicitly call out that estimates are advisory.

## Test plan

- [x] `uv run ruff format` on touched files
- [x] `uv run ruff check` on touched files
- [x] `uv run ty check` (clean)
- [x] `uv run pytest -q tests/test_costs.py tests/test_metrics.py` (52 passed)
- [x] `uv run pytest -q` (full suite passes)

Nightshift-Task: cost-attribution
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)