### PR TITLE
perf: fix 4 regressions introduced by recent metrics/triage PRs

### DIFF
--- a/twag/metrics.py
+++ b/twag/metrics.py
@@ -160,6 +160,14 @@ class MetricsCollector:
                 "p99": obs[_min(int(n * 0.99), n - 1)],
             }
 
+    def histogram_snapshot(self, name: str) -> HistogramSnapshot:
+        """Cheap snapshot (count/min/max/avg/total) without sorting observations."""
+        with self._lock:
+            h = self._histograms.get(name)
+            if not h:
+                return {"count": 0, "min": 0.0, "max": 0.0, "avg": 0.0, "total": 0.0}
+            return h.snapshot()
+
     # -- Snapshot --
 
     def snapshot(self) -> dict[str, Any]:
@@ -264,14 +272,7 @@ def counter(name: str, *, value: float = 1.0, labels: LabelMap | None = None) ->
 def histogram(name: str, value: float, *, labels: LabelMap | None = None) -> HistogramSnapshot:
     key = _label_key(name, labels)
     _collector.observe(key, value)
-    stats = _collector.histogram_stats(key)
-    return {
-        "count": int(stats["count"]),
-        "min": stats["min"],
-        "max": stats["max"],
-        "avg": stats["mean"],
-        "total": stats["total"],
-    }
+    return _collector.histogram_snapshot(key)
 
 
 @contextmanager

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 from ..config import load_config
 from ..db import (
-    get_tweet_by_id,
+    get_tweets_by_ids,
     update_account_stats,
     update_tweet_analysis,
     update_tweet_article,
@@ -413,6 +413,10 @@ def _triage_rows(
         )
         account_categories = {r["handle"]: r["category"] for r in acct_cursor.fetchall()}
 
+    # Batch-fetch all quoted tweets in one query instead of N individual lookups.
+    quote_ids = {row["quote_tweet_id"] for row in tweet_rows if row["has_quote"] and row["quote_tweet_id"]}
+    quoted_rows: dict[str, sqlite3.Row] = get_tweets_by_ids(conn, quote_ids) if quote_ids else {}
+
     all_results: list[TriageResult] = []
 
     total = len(tweets_for_triage)
@@ -453,7 +457,7 @@ def _triage_rows(
 
         quoted_text = ""
         if row["has_quote"] and row["quote_tweet_id"]:
-            quoted_row = get_tweet_by_id(conn, row["quote_tweet_id"])
+            quoted_row = quoted_rows.get(row["quote_tweet_id"])
             if quoted_row:
                 quoted_text = f"@{quoted_row['author_handle']}: {quoted_row['content']}"
 

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -169,15 +169,28 @@ def _call_llm_vision(provider: str, model: str, image_url: str, prompt: str, max
     return _with_retry(_invoke)
 
 
+_RETRY_PARAMS_CACHE: tuple[int, float, float, float] | None = None
+
+
+def _retry_params() -> tuple[int, float, float, float]:
+    """Return cached retry params. Read once per process to keep _with_retry off the config hot path."""
+    global _RETRY_PARAMS_CACHE
+    if _RETRY_PARAMS_CACHE is None:
+        llm_cfg = load_config().get("llm", {})
+        _RETRY_PARAMS_CACHE = (
+            int(llm_cfg.get("retry_max_attempts", 4)),
+            float(llm_cfg.get("retry_base_seconds", 1.0)),
+            float(llm_cfg.get("retry_max_seconds", 20.0)),
+            float(llm_cfg.get("retry_jitter", 0.3)),
+        )
+    return _RETRY_PARAMS_CACHE
+
+
 def _with_retry(fn: Callable[[], _T]) -> _T:
     from twag.metrics import get_collector
 
     m = get_collector()
-    config = load_config()
-    retries = config.get("llm", {}).get("retry_max_attempts", 4)
-    base_delay = config.get("llm", {}).get("retry_base_seconds", 1.0)
-    max_delay = config.get("llm", {}).get("retry_max_seconds", 20.0)
-    jitter = config.get("llm", {}).get("retry_jitter", 0.3)
+    retries, base_delay, max_delay, jitter = _retry_params()
 
     attempt = 0
     while True:

--- a/twag/web/app.py
+++ b/twag/web/app.py
@@ -47,14 +47,15 @@ def create_app() -> FastAPI:
     templates.env.filters["unescape"] = lambda s: html.unescape(s) if s else s
     app.state.templates = templates
 
-    # Request metrics middleware
+    # Resolve the collector once at app build time so each request skips the lookup.
+    metrics_collector = get_collector()
+
     @app.middleware("http")
     async def metrics_middleware(request: Request, call_next) -> Response:
-        m = get_collector()
-        m.inc("web.requests")
+        metrics_collector.inc("web.requests")
         t0 = time.monotonic()
         response: Response = await call_next(request)
-        m.observe("web.request_latency_seconds", time.monotonic() - t0)
+        metrics_collector.observe("web.request_latency_seconds", time.monotonic() - t0)
         return response
 
     # Include API routers


### PR DESCRIPTION
## Summary

Four small, scoped fixes for performance regressions traceable to recent PRs.

| # | File | Regression | Introduced by |
|---|------|-----------|---------------|
| 1 | `twag/scorer/llm_client.py` | `_with_retry` re-reads config (and deepcopies the cached dict) on every LLM call | #139 |
| 2 | `twag/metrics.py` | Module-level `histogram()` triggers `sorted(observations)` on every observe via `histogram_stats()` | #139 |
| 3 | `twag/web/app.py` | FastAPI middleware re-resolves `get_collector()` per request | #139 |
| 4 | `twag/processor/triage.py` | N+1 `get_tweet_by_id` lookup for quoted tweets in the enrichment loop | missed by #116 |

### 1. Cache retry params (llm_client.py)

`_with_retry` runs once per LLM call, of which there are 30+ per pipeline run. It was calling `load_config()` (which deep-copies the cached config dict) and then re-reading the same four `llm.retry_*` values every time. Hoisted to a module-level cache (`_RETRY_PARAMS_CACHE`) populated on first call. Retry tunables are config, not per-call state, so a process-lifetime cache is safe.

### 2. Skip sort on histogram writer path (metrics.py)

The module-level `histogram()` helper called `histogram_stats()` after every `observe()`, which sorted all observations to compute p50/p99 — but the returned `HistogramSnapshot` only exposes `count/min/max/avg/total`, none of which need a sort. Added `MetricsCollector.histogram_snapshot()` that returns the cheap counter-derived stats, and used it from `histogram()`. Sort cost is now incurred only by `/metrics` readers via `histogram_stats()` / `snapshot()`.

### 3. Resolve collector once (web/app.py)

`metrics_middleware` called `get_collector()` per request. Hoisted resolution to app build time and captured the collector via closure. The hot-path savings is small (function call + module attr lookup), but it's a free win and matches the pattern used elsewhere.

### 4. Batch quoted-tweet fetches (processor/triage.py)

Mirrors the exact fix #116 applied in `pipeline.py:enrich_high_signal`: collect all `quote_tweet_id`s upfront and call `get_tweets_by_ids` once before the loop instead of one `get_tweet_by_id` per row inside `_submit_enrichment`.

## Out of scope (documented for follow-up)

These longstanding inefficiencies are not addressed in this PR — they're not regressions traceable to a recent change:

- `SELECT *` in `get_feed_tweets` (twag/db/tweets.py)
- Missing index on `narratives` filter columns
- `date()`-wrapped predicates that defeat existing indexes
- Full-table scan in the `/tickers` route

## Test plan

- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ty check` — all checks passed
- [x] `uv run pytest` — 355 passed
- [x] Targeted suites: `test_metrics.py`, `test_processor.py`, `test_processor_parallelization.py`, `test_article_processing.py`, `test_web_tweets_api.py`, `test_api_contracts.py` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: perf-regression:/home/clifton/code/twag
task-type: perf-regression
task-title: Performance Regression Spotter
iterations: 1
duration: 8m50s
nightshift:metadata -->
