### PR TITLE
td-review: 2026-04-30 — route shadowing fix, dead code, lint cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,6 @@ FETCH → PROCESS → DIGEST
 ```
 
 **Core packages:**
-- `twag/models/` — Pydantic data models (tweet, scoring, media, links, config, API, db_models)
 - `twag/auth.py` — Shared credential and env-file parsing
 - `twag/config.py` — Runtime config (paths, defaults, following file)
 - `twag/db/` — SQLite database layer (schema, connection, tweets, search, maintenance, accounts, narratives, reactions, prompts, context_commands, time_utils)
@@ -30,11 +29,12 @@ FETCH → PROCESS → DIGEST
 - `twag/renderer.py` — Markdown digest generation
 - `twag/tables.py` — Rich table formatting for CLI output
 - `twag/media.py` — Media handling utilities
+- `twag/metrics.py` — Lightweight in-process metrics collector (counters, gauges, histograms)
 - `twag/link_utils.py` — URL expansion and embed classification
 - `twag/article_visuals.py` — Visual selection for X Articles
 - `twag/text_utils.py` — Text processing utilities
 - `twag/article_sections.py` — Article section extraction
-- `twag/web/` — FastAPI backend (app, tweet_utils, templates/, routes: tweets, context, prompts, reactions)
+- `twag/web/` — FastAPI backend (app, tweet_utils, templates/, routes: tweets, context, prompts, reactions, metrics)
 - `twag/web/frontend/` — React feed UI
 
 ## Key Files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ line-length = 120
 exclude = ["twag/_version.py"]
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF", "PIE", "RET505", "TC003", "TC006", "PERF401", "PLR5501", "PLR1730", "PLR1714", "PLR1711", "FURB110", "FURB188", "PLW1510", "PLW0108", "PLW2901", "EXE001", "FAST002", "COM812", "RET501", "D403", "D301", "TRY400"]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF", "PIE", "RET505", "TC003", "TC006", "PERF401", "PLR5501", "PLR1730", "PLR1714", "PLR1711", "FURB110", "FURB188", "PLW1510", "PLW0108", "PLW2901", "EXE001", "FAST002", "RET501", "D403", "D301", "TRY400"]
 ignore = [
     "E501",    # line too long (handled by formatter)
     "SIM105",  # contextlib.suppress — less readable for multi-line try blocks

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -176,6 +176,35 @@ def test_list_tweet_reactions_is_list(monkeypatch, tmp_path):
     assert ">>" in t["reactions"]
 
 
+def test_reactions_summary_not_shadowed_by_tweet_id_route(monkeypatch, tmp_path):
+    """`/reactions/summary` must hit the summary route, not be matched as `tweet_id=summary`."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        insert_reaction(conn, tweet_id="t1", reaction_type=">>")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/reactions/summary").json()
+    assert "summary" in body, f"summary route shadowed by /reactions/{{tweet_id}}: {body}"
+    assert "tweet_id" not in body
+
+
+def test_reactions_export_not_shadowed_by_tweet_id_route(monkeypatch, tmp_path):
+    """`/reactions/export` must hit the export route, not be matched as `tweet_id=export`."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        insert_reaction(conn, tweet_id="t1", reaction_type=">>")
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/reactions/export").json()
+    assert "count" in body, f"export route shadowed by /reactions/{{tweet_id}}: {body}"
+    assert "reactions" in body
+    assert isinstance(body["reactions"], list)
+
+
 # ── Enriched display fields ───────────────────────────────────
 
 

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -66,17 +66,6 @@ def execute_with_retry(conn: sqlite3.Connection, sql: str, params: tuple | list 
     return _with_lock_retry("sqlite execute", lambda: conn.execute(sql, params))
 
 
-def executemany_with_retry(conn: sqlite3.Connection, sql: str, seq_of_params):
-    """Run ``conn.executemany`` with retries when SQLite reports a transient lock."""
-    cached_params = list(seq_of_params)
-    return _with_lock_retry("sqlite executemany", lambda: conn.executemany(sql, cached_params))
-
-
-def commit_with_retry(conn: sqlite3.Connection) -> None:
-    """Commit with retries when SQLite reports a transient lock."""
-    _with_lock_retry("sqlite commit", conn.commit)
-
-
 def _run_migrations(conn: sqlite3.Connection) -> None:
     """Run schema migrations for existing databases."""
     from .prompts import seed_prompts

--- a/twag/scorer/prompts.py
+++ b/twag/scorer/prompts.py
@@ -1,16 +1,5 @@
 """Prompt templates for LLM scoring and analysis."""
 
-# Triage prompt for fast scoring
-TRIAGE_PROMPT = """You are a financial markets triage agent. Score this tweet 0-10 for relevance to macro/investing.
-
-Categories (assign 1-3 that apply): fed_policy, inflation, job_market, macro_data, earnings, equities, rates_fx, credit, banks, consumer_spending, capex, commodities, energy, metals_mining, geopolitical, sanctions, tech_business, ai_advancement, crypto, noise
-
-Tweet: {tweet_text}
-Author: @{handle}
-
-Return JSON only:
-{{"score": 7, "categories": ["fed_policy", "rates_fx"], "summary": "One-liner summary", "tickers": ["TLT", "GLD"]}}"""
-
 # Batch triage prompt
 BATCH_TRIAGE_PROMPT = """You are a financial markets triage agent. Score these tweets 0-10 for relevance to macro/investing.
 

--- a/twag/web/routes/reactions.py
+++ b/twag/web/routes/reactions.py
@@ -85,43 +85,6 @@ async def create_reaction(request: Request, reaction: ReactionCreate) -> dict[st
     }
 
 
-@router.get("/reactions/{tweet_id}")
-async def get_tweet_reactions(request: Request, tweet_id: str) -> dict[str, Any]:
-    """Get all reactions for a specific tweet."""
-    db_path = request.app.state.db_path
-
-    with get_connection(db_path, readonly=True) as conn:
-        reactions = get_reactions_for_tweet(conn, tweet_id)
-
-    return {
-        "tweet_id": tweet_id,
-        "reactions": [
-            {
-                "id": r.id,
-                "reaction_type": r.reaction_type,
-                "reason": r.reason,
-                "target": r.target,
-                "created_at": r.created_at.isoformat() if r.created_at else None,
-            }
-            for r in reactions
-        ],
-    }
-
-
-@router.delete("/reactions/{reaction_id}")
-async def remove_reaction(request: Request, reaction_id: int) -> dict[str, Any]:
-    """Delete a reaction."""
-    db_path = request.app.state.db_path
-
-    with get_connection(db_path) as conn:
-        deleted = delete_reaction(conn, reaction_id)
-        conn.commit()
-
-    if deleted:
-        return {"message": "Reaction deleted"}
-    return {"error": "Reaction not found"}
-
-
 @router.get("/reactions/summary")
 async def reactions_summary(request: Request) -> dict[str, Any]:
     """Get summary of reaction counts by type."""
@@ -184,3 +147,40 @@ async def export_reactions(
         "count": len(export_data),
         "reactions": export_data,
     }
+
+
+@router.get("/reactions/{tweet_id}")
+async def get_tweet_reactions(request: Request, tweet_id: str) -> dict[str, Any]:
+    """Get all reactions for a specific tweet."""
+    db_path = request.app.state.db_path
+
+    with get_connection(db_path, readonly=True) as conn:
+        reactions = get_reactions_for_tweet(conn, tweet_id)
+
+    return {
+        "tweet_id": tweet_id,
+        "reactions": [
+            {
+                "id": r.id,
+                "reaction_type": r.reaction_type,
+                "reason": r.reason,
+                "target": r.target,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in reactions
+        ],
+    }
+
+
+@router.delete("/reactions/{reaction_id}")
+async def remove_reaction(request: Request, reaction_id: int) -> dict[str, Any]:
+    """Delete a reaction."""
+    db_path = request.app.state.db_path
+
+    with get_connection(db_path) as conn:
+        deleted = delete_reaction(conn, reaction_id)
+        conn.commit()
+
+    if deleted:
+        return {"message": "Reaction deleted"}
+    return {"error": "Reaction not found"}


### PR DESCRIPTION
## Summary

TD review session covering open PRs #172–#186. Applied 3 commits of trivial/small fixes; filed 8 new `tech-debt` issues for medium-or-larger items; closed 4 `tech-debt` issues whose work has shipped.

## Fixes applied (lane A)

- **`fix(web)` route shadowing** (cc047d8) — `/api/reactions/summary` and `/api/reactions/export` were silently being matched as `/reactions/{tweet_id}` because the dynamic route was registered first. FastAPI matches in declaration order; both static endpoints returned bogus empty payloads. Reordered the routes and added 2 regression tests in `tests/test_api_contracts.py`.
- **`chore` dead-code removal + CLAUDE.md drift** (1a2fe64) — removed `executemany_with_retry` and `commit_with_retry` from `twag/db/connection.py` (no callers across `twag/` or `tests/`), removed `TRIAGE_PROMPT` from `twag/scorer/prompts.py` (only `BATCH_TRIAGE_PROMPT` is imported), and dropped the stale `twag/models/` line from `CLAUDE.md` (directory does not exist on `main`).
- **`chore(lint)` remove COM812** (5ded820) — `COM812` conflicts with the ruff formatter and added a warning to every `ruff check` invocation. The formatter already enforces the equivalent.

## Issues filed (lane B + C)

Medium/large bugs deferred for separate sessions:
- #187 `[MEDIUM]` N+1 query in `triage._triage_rows` quote-tweet enrichment
- #188 `[MEDIUM]` Restrict LLM vision URL fetch to scheme allowlist (SSRF)
- #189 `[MEDIUM]` FTS5 search returns 500 on malformed user query
- #190 `[MEDIUM]` `prompt_history` exposes `created_at` instead of `updated_at`; missing `updated_by`
- #191 `[MEDIUM]` `metrics.histogram()` sorts on every observe; add `histogram_snapshot()` fast path
- #192 `[MEDIUM]` Vite bundle: add manual chunking and incremental tsc

Test coverage gaps:
- #193 `[TEST]` `twag.cli.costs_cmd._parse_window` error paths
- #194 `[TEST]` Fresh-DB schema verifies all migration-added columns

## Issues closed

Already shipped to main, verified by reading the current code:
- #59 `[MEDIUM]` Fix hardcoded signal-tier thresholds — resolved by PR #110 (`0073257`)
- #65 `[TEST]` Restore tests for `db/accounts.py` — resolved by PR #137 (`0d77aaf`)
- #67 `[TEST]` Restore tests for `db/time_utils.py` — resolved by PR #137 (`0d77aaf`)
- #69 `[TEST]` Restore tests for `notifier.py` — resolved by PR #129 (`fce5330`) + PR #137 (`0d77aaf`)

## PRs reviewed

Read-only review of 15 open PRs across 3 parallel subagent batches (#172, #173, #174, #175, #176, #177, #178, #179, #180, #181, #182, #183, #184, #185, #186). Findings drove the fixes and new issues above. Note: many older PRs (#141–#171) appear to be earlier nightshift duplicates of these and would benefit from a separate close-as-superseded sweep.

## Test plan

- [x] `uv run ruff format --check .` — 94 files already formatted
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ty check` — all checks passed
- [x] `uv run pytest -q` — **357 passed** in 88.87s
- [ ] Frontend build — not touched in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: td-review:/home/clifton/code/twag
task-type: td-review
task-title: TD Review Session
nightshift:metadata -->