### PR TITLE
docs(skill): groom SKILL.md against current CLI surface and spec

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -31,7 +31,7 @@ metadata:
         bins: ["bird"]
         label: "Install bird CLI (brew)"
         os: ["darwin"]
-allowed-tools: Bash(twag:*), Bash(bird:*)
+allowed-tools: Bash(twag:*) Bash(bird:*)
 ---
 
 # twag — Twitter/X Market Signal Aggregator
@@ -181,8 +181,8 @@ twag search "query" --order score    # Sort: rank, score, or time
 
 ```bash
 twag fetch                    # Home + tier-1 + bookmarks
-twag fetch --no-tier1         # Home only
-twag fetch --source user -u @handle  # Specific user
+twag fetch --no-tier1 --no-bookmarks   # Home only
+twag fetch --source user -u @handle    # Specific user
 twag fetch --source search -q "query"  # Search tweets
 twag fetch --stagger 5        # Rotate: fetch 5 least-recent tier-1
 twag fetch --delay 5.0        # Pacing between tier-1 fetches (default: 3s)
@@ -225,7 +225,9 @@ twag accounts import          # Import from following.txt
 twag stats                    # All-time
 twag stats --today            # Today
 twag prune --days 14          # Delete old tweets
+twag prune --dry-run          # Preview prune
 twag export --days 7          # Export recent
+twag metrics                  # Show instrumentation coverage and counters
 ```
 
 ### Narratives


### PR DESCRIPTION
## Summary

Audit and update of project-local agent skills against the [Agent Skills specification](https://agentskills.io/specification.md), with safe fixes applied to `SKILL.md`.

### Audit findings
- **`.claude/skills` and `.codex/skills`** — neither directory exists. `.claude/` and `.codex/` only contain settings/hooks files. No project-scoped Claude or Codex skill manifests to validate.
- **`SKILL.md` (root, OpenClaw skill)** — frontmatter `name`/`description` are spec-valid (kebab-case, length OK). Referenced files (`TELEGRAM_DIGEST_FORMAT.md`, `SUGGESTED_CRON_SCHEDULE.md`) exist on disk. Custom `read_when`/`homepage` fields and `metadata.openclaw` are OpenClaw extensions and unchanged.

### Changes applied
1. **`allowed-tools` syntax** — spec requires a space-separated string; was comma-separated. Fixed to `Bash(twag:*) Bash(bird:*)`.
2. **`twag fetch --no-tier1` example** — comment said "Home only" but `--bookmarks` defaults to true, so it'd still pull bookmarks. Updated example to `--no-tier1 --no-bookmarks` to match the comment.
3. **Surfaced `twag metrics`** — registered as a top-level command in `twag/cli/__init__.py:53` but missing from both `SKILL.md` and `README.md`. Added to the Stats & Maintenance section. Also added the existing `twag prune --dry-run` recipe (already in `README.md`).

### Verified, no change needed
- All other CLI flags in `SKILL.md` (`-c`, `-a`, `-s`, `-t`, `-T`, `-b`, `-n`, `-o`, `-f`, `-u`, `-q`, `-d`, `--time`, `--today`, `--ticker`, `--bookmarks`, `--stagger`, `--delay`, `--reprocess`, `--reprocess-min-score`, `--no-reprocess-quotes`, `--stdout`, `--min-score`, `--amount`, `--rate`, `--force`, `--host`, `--port`, `--dev`, `--no-reload`) match the actual Click definitions in `twag/cli/*.py`.
- `metadata.openclaw.requires.bins`/`env` and `install` steps match `README.md` and `INSTALL.md`.

### Follow-ups (left for the maintainer)
- `README.md` also omits `twag metrics`; this PR only updates `SKILL.md`. Worth deciding whether `metrics` is intended as a public CLI command or an internal/diagnostic one before documenting it more broadly.

## Test plan
- [x] `git diff SKILL.md` reviewed — only the three intended hunks.
- [x] Pre-commit hooks (ruff format, ruff check, ty check, pytest) passed.
- [x] All file paths referenced from `SKILL.md` (`{baseDir}/TELEGRAM_DIGEST_FORMAT.md`, `{baseDir}/SUGGESTED_CRON_SCHEDULE.md`) exist on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: skill-groom:/home/clifton/code/twag
task-type: skill-groom
task-title: Skill Grooming
iterations: 1
duration: 7m20s
nightshift:metadata -->
