### PR TITLE
[codex] cache media analysis and reduce enrichment fanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ twag config show                # Show current config
 twag config path                # Show config file path
 twag config set llm.triage_model gemini-2.0-flash
 twag config set scoring.alert_threshold 8
-twag config set scoring.min_score_for_analysis 7
+twag config set scoring.min_score_for_analysis 6
 twag config set scoring.max_article_summary_chars 20000
 ```
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ twag config show                # Show current config
 twag config path                # Show config file path
 twag config set llm.triage_model gemini-2.0-flash
 twag config set scoring.alert_threshold 8
+twag config set scoring.min_score_for_analysis 7
+twag config set scoring.max_article_summary_chars 20000
 ```
 
 ## Data Paths

--- a/SKILL.md
+++ b/SKILL.md
@@ -266,6 +266,7 @@ twag web --no-reload          # Disable auto-reload
 twag config show              # Show config
 twag config path              # Show path
 twag config set key value     # Update setting
+twag config set scoring.min_score_for_analysis 7
 ```
 
 ## Scoring Tiers

--- a/SKILL.md
+++ b/SKILL.md
@@ -266,7 +266,7 @@ twag web --no-reload          # Disable auto-reload
 twag config show              # Show config
 twag config path              # Show path
 twag config set key value     # Update setting
-twag config set scoring.min_score_for_analysis 7
+twag config set scoring.min_score_for_analysis 6
 ```
 
 ## Scoring Tiers

--- a/tests/test_article_processing.py
+++ b/tests/test_article_processing.py
@@ -304,3 +304,33 @@ def test_summarize_x_article_falls_back_to_triage_provider(monkeypatch) -> None:
     assert ("gemini", "gemini-3-flash-preview") in calls
     assert result.short_summary == "Structured summary"
     assert len(result.primary_points) == 1
+
+
+def test_summarize_x_article_bounds_long_prompt(monkeypatch) -> None:
+    import twag.scorer.scoring as scorer_mod
+
+    seen_prompt = ""
+
+    def _fake_call_llm(provider, model, prompt, max_tokens=2048, reasoning=None, component="unknown"):
+        nonlocal seen_prompt
+        seen_prompt = prompt
+        return '{"short_summary":"Bounded summary","primary_points":[],"actionable_items":[]}'
+
+    monkeypatch.setattr(scorer_mod, "_call_llm", _fake_call_llm)
+    monkeypatch.setattr(
+        scorer_mod,
+        "load_config",
+        lambda: {
+            "llm": {
+                "enrichment_model": "deepseek-v4-pro",
+                "enrichment_provider": "deepseek",
+            },
+            "scoring": {"max_article_summary_chars": 1200},
+        },
+    )
+
+    result = summarize_x_article("A" * 5000, article_title="Title")
+
+    assert result.short_summary == "Bounded summary"
+    assert "[...middle truncated to reduce analysis cost...]" in seen_prompt
+    assert seen_prompt.count("A") <= 1210

--- a/tests/test_media_analysis_cache.py
+++ b/tests/test_media_analysis_cache.py
@@ -1,0 +1,109 @@
+"""Tests for persistent media analysis caching."""
+
+import twag.processor.triage as triage_mod
+from twag.db import get_cached_media_analysis, get_connection, init_db, record_media_analysis
+from twag.scorer import MediaAnalysisResult
+
+
+def test_record_and_read_media_analysis_cache(tmp_path) -> None:
+    db_path = tmp_path / "media-cache.db"
+    init_db(db_path)
+
+    record_media_analysis(
+        "https://example.com/chart.png",
+        provider="gemini",
+        model="gemini-3-flash-preview",
+        result={
+            "kind": "chart",
+            "short_description": "Chart",
+            "prose_text": "Revenue 100",
+            "prose_summary": "Revenue rises",
+            "chart": {"insight": "Up"},
+            "table": {},
+        },
+        db_path=db_path,
+    )
+
+    cached = get_cached_media_analysis(
+        "https://example.com/chart.png",
+        provider="gemini",
+        model="gemini-3-flash-preview",
+        db_path=db_path,
+    )
+
+    assert cached is not None
+    assert cached["kind"] == "chart"
+    assert cached["chart"]["insight"] == "Up"
+
+
+def test_analyze_media_items_reuses_cache(monkeypatch) -> None:
+    cache = {
+        "https://example.com/cached.png": {
+            "kind": "chart",
+            "short_description": "Cached chart",
+            "prose_text": "Cached text",
+            "prose_summary": "Cached summary",
+            "chart": {"insight": "Cached"},
+            "table": {},
+        },
+    }
+    analyzed_urls: list[str] = []
+    recorded_urls: list[str] = []
+
+    monkeypatch.setattr(
+        triage_mod,
+        "load_config",
+        lambda: {
+            "llm": {
+                "vision_model": "gemini-3-flash-preview",
+                "vision_provider": "gemini",
+            },
+        },
+    )
+
+    def _get_cached_media_analysis(url, *, provider, model):
+        return cache.get(url)
+
+    def _record_media_analysis(url, *, provider, model, result) -> None:
+        recorded_urls.append(url)
+
+    monkeypatch.setattr(triage_mod, "get_cached_media_analysis", _get_cached_media_analysis)
+    monkeypatch.setattr(triage_mod, "record_media_analysis", _record_media_analysis)
+
+    def _fake_analyze_media(url, model=None, provider=None):
+        analyzed_urls.append(url)
+        return MediaAnalysisResult(
+            kind="table",
+            short_description="Fresh table",
+            prose_text="Fresh text",
+            prose_summary="Fresh summary",
+            chart={},
+            table={"summary": "Fresh"},
+        )
+
+    monkeypatch.setattr(triage_mod, "analyze_media", _fake_analyze_media)
+
+    items, updated = triage_mod._analyze_media_items(
+        [
+            {"url": "https://example.com/cached.png"},
+            {"url": "https://example.com/fresh.png"},
+        ],
+    )
+
+    assert updated is True
+    assert analyzed_urls == ["https://example.com/fresh.png"]
+    assert recorded_urls == ["https://example.com/fresh.png"]
+    assert items[0]["short_description"] == "Cached chart"
+    assert items[1]["short_description"] == "Fresh table"
+
+
+def test_media_analysis_cache_migrates_with_init_db(tmp_path) -> None:
+    db_path = tmp_path / "schema.db"
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='media_analysis_cache'",
+        ).fetchone()
+
+    assert row is not None

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,6 +1,7 @@
 """Tests for twag.notifier — alert formatting and send-gating logic."""
 
 import logging
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import httpx
@@ -192,7 +193,17 @@ def test_send_telegram_alert_returns_true_on_success(monkeypatch):
     class FakeResponse:
         status_code = 200
 
+    @contextmanager
+    def _fake_connection():
+        class FakeConnection:
+            def commit(self):
+                return None
+
+        yield FakeConnection()
+
     monkeypatch.setattr("twag.notifier.httpx.post", lambda *a, **kw: FakeResponse())
+    monkeypatch.setattr("twag.notifier.get_connection", _fake_connection)
+    monkeypatch.setattr("twag.notifier.log_alert", lambda *a, **kw: None)
 
     result = send_telegram_alert("test message")
     assert result is True

--- a/tests/test_processor_parallelization.py
+++ b/tests/test_processor_parallelization.py
@@ -220,6 +220,9 @@ def test_enrich_high_signal_prefers_local_quote_row(monkeypatch, tmp_path) -> No
 
     assert len(results) == 1
     assert seen["quoted_tweet"] == "@quotedacct: Quoted local context"
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute("SELECT analysis_json FROM tweets WHERE id = ?", ("main-1",)).fetchone()
+    assert row["analysis_json"] is not None
 
 
 def test_triage_parallel_db_access_stays_on_owner_thread(monkeypatch, tmp_path) -> None:
@@ -414,6 +417,9 @@ def test_enrich_high_signal_parallel_db_access_stays_on_owner_thread(monkeypatch
     results = pipeline_mod.enrich_high_signal(limit=5, enrich_model="dummy-model")
 
     assert len(results) == 1
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute("SELECT analysis_json FROM tweets WHERE id = ?", ("main-1",)).fetchone()
+    assert row["analysis_json"] is not None
 
 
 def test_expand_links_parallel_db_access_stays_on_owner_thread(monkeypatch, tmp_path) -> None:

--- a/twag/config.py
+++ b/twag/config.py
@@ -32,9 +32,10 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "alert_threshold": 8,
         "batch_size": 15,
         "min_score_for_reprocess": 3,
-        "min_score_for_media": 3,
-        "min_score_for_analysis": 3,
+        "min_score_for_media": 5,
+        "min_score_for_analysis": 7,
         "min_score_for_article_processing": 5,
+        "max_article_summary_chars": 20_000,
     },
     "notifications": {
         "telegram_enabled": True,

--- a/twag/config.py
+++ b/twag/config.py
@@ -33,7 +33,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "batch_size": 15,
         "min_score_for_reprocess": 3,
         "min_score_for_media": 5,
-        "min_score_for_analysis": 7,
+        "min_score_for_analysis": 6,
         "min_score_for_article_processing": 5,
         "max_article_summary_chars": 20_000,
     },

--- a/twag/db/__init__.py
+++ b/twag/db/__init__.py
@@ -36,6 +36,12 @@ from .maintenance import (
     prune_old_tweets,
     restore_sql,
 )
+from .media_cache import (
+    ensure_media_analysis_cache_table,
+    get_cached_media_analysis,
+    increment_media_analysis_cache_hit,
+    record_media_analysis,
+)
 from .narratives import (
     archive_stale_narratives,
     get_active_narratives,
@@ -120,6 +126,7 @@ __all__ = [
     "demote_account",
     "dump_sql",
     "ensure_llm_usage_table",
+    "ensure_media_analysis_cache_table",
     "estimate_cost_usd",
     "get_accounts",
     "get_active_narratives",
@@ -127,6 +134,7 @@ __all__ = [
     "get_all_prompts",
     "get_authors_to_promote",
     "get_bookmark_counts_by_author",
+    "get_cached_media_analysis",
     "get_connection",
     "get_context_command",
     "get_feed_tweets",
@@ -144,6 +152,7 @@ __all__ = [
     "get_tweets_by_ids",
     "get_tweets_for_digest",
     "get_unprocessed_tweets",
+    "increment_media_analysis_cache_hit",
     "init_db",
     "insert_reaction",
     "insert_tweet",
@@ -161,6 +170,7 @@ __all__ = [
     "query_suggests_equity_context",
     "rebuild_fts",
     "record_llm_usage",
+    "record_media_analysis",
     "restore_sql",
     "rollback_prompt",
     "search_tweets",

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -219,6 +219,11 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
 
     ensure_llm_usage_table(conn)
 
+    # Ensure persistent media analysis cache exists
+    from .media_cache import ensure_media_analysis_cache_table
+
+    ensure_media_analysis_cache_table(conn)
+
 
 def _init_fts(conn: sqlite3.Connection) -> None:
     """Initialize FTS5 virtual table and triggers."""

--- a/twag/db/media_cache.py
+++ b/twag/db/media_cache.py
@@ -1,0 +1,140 @@
+"""Persistent cache for media analysis results."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import sqlite3
+    from pathlib import Path
+
+from .connection import commit_with_retry, get_connection
+
+log = logging.getLogger(__name__)
+
+MEDIA_ANALYSIS_CACHE_SQL = """
+CREATE TABLE IF NOT EXISTS media_analysis_cache (
+    media_url TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    hit_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (media_url, provider, model)
+);
+CREATE INDEX IF NOT EXISTS idx_media_analysis_cache_updated
+ON media_analysis_cache(updated_at DESC);
+"""
+
+
+def ensure_media_analysis_cache_table(conn: sqlite3.Connection) -> None:
+    """Create the media analysis cache table."""
+    conn.executescript(MEDIA_ANALYSIS_CACHE_SQL)
+
+
+def _normalize_key(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def get_cached_media_analysis(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    db_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Return cached media analysis for a URL/provider/model, if present."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return None
+
+    try:
+        with get_connection(db_path, readonly=True) as conn:
+            row = conn.execute(
+                """
+                SELECT result_json
+                FROM media_analysis_cache
+                WHERE media_url = ? AND provider = ? AND model = ?
+                """,
+                (url, provider_key, model_key),
+            ).fetchone()
+        if row is None:
+            return None
+        data = json.loads(row["result_json"])
+        return data if isinstance(data, dict) else None
+    except Exception:
+        log.debug("Failed to read media analysis cache", exc_info=True)
+        return None
+
+
+def record_media_analysis(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    result: dict[str, Any],
+    db_path: Path | None = None,
+) -> None:
+    """Persist a media analysis result; cache failures do not affect processing."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return
+
+    try:
+        payload = json.dumps(result, sort_keys=True)
+        now = datetime.now(timezone.utc).isoformat()
+        with get_connection(db_path) as conn:
+            ensure_media_analysis_cache_table(conn)
+            conn.execute(
+                """
+                INSERT INTO media_analysis_cache (
+                    media_url, provider, model, result_json, hit_count, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, 0, ?, ?)
+                ON CONFLICT(media_url, provider, model) DO UPDATE SET
+                    result_json = excluded.result_json,
+                    updated_at = excluded.updated_at
+                """,
+                (url, provider_key, model_key, payload, now, now),
+            )
+            commit_with_retry(conn)
+    except Exception:
+        log.debug("Failed to write media analysis cache", exc_info=True)
+
+
+def increment_media_analysis_cache_hit(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    db_path: Path | None = None,
+) -> None:
+    """Best-effort increment for cache hit observability."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return
+
+    try:
+        with get_connection(db_path) as conn:
+            conn.execute(
+                """
+                UPDATE media_analysis_cache
+                SET hit_count = hit_count + 1,
+                    updated_at = ?
+                WHERE media_url = ? AND provider = ? AND model = ?
+                """,
+                (datetime.now(timezone.utc).isoformat(), url, provider_key, model_key),
+            )
+            commit_with_retry(conn)
+    except Exception:
+        log.debug("Failed to update media analysis cache hit count", exc_info=True)

--- a/twag/db/schema.py
+++ b/twag/db/schema.py
@@ -224,6 +224,20 @@ CREATE TABLE IF NOT EXISTS llm_usage (
 CREATE INDEX IF NOT EXISTS idx_llm_usage_called_at ON llm_usage(called_at);
 CREATE INDEX IF NOT EXISTS idx_llm_usage_component ON llm_usage(component, called_at);
 CREATE INDEX IF NOT EXISTS idx_llm_usage_provider_model ON llm_usage(provider, model, called_at);
+
+-- Media analysis cache: reuse OCR/chart extraction across duplicate media URLs
+CREATE TABLE IF NOT EXISTS media_analysis_cache (
+    media_url TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    hit_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (media_url, provider, model)
+);
+CREATE INDEX IF NOT EXISTS idx_media_analysis_cache_updated
+ON media_analysis_cache(updated_at DESC);
 """
 
 # FTS5 schema for full-text search

--- a/twag/processor/pipeline.py
+++ b/twag/processor/pipeline.py
@@ -16,6 +16,7 @@ from ..config import load_config
 from ..db import (
     get_accounts,
     get_connection,
+    get_tweet_by_id,
     get_tweets_by_ids,
     get_unprocessed_tweets,
 )
@@ -25,6 +26,7 @@ from ..scorer import EnrichmentResult, TriageResult, enrich_tweet
 from .dependencies import _expand_links_for_rows, _expand_unprocessed_with_dependencies
 from .triage import (
     _normalized_worker_count,
+    _save_enrichment_result,
     _triage_rows,
     ensure_media_analysis,
 )
@@ -51,7 +53,7 @@ def process_unprocessed(
     config = load_config()
     batch_size = config["scoring"]["batch_size"]
     high_threshold = config["scoring"]["high_signal_threshold"]
-    media_min_score = config["scoring"].get("min_score_for_media", 3)
+    media_min_score = config["scoring"].get("min_score_for_media", 5)
     quote_depth = config.get("fetch", {}).get("quote_depth", 0)
     quote_delay = config.get("fetch", {}).get("quote_delay", 1.0)
     url_expansion_workers = _normalized_worker_count(
@@ -230,7 +232,7 @@ def reprocess_today_quoted(
             tier1_handles=tier1_handles,
             update_stats=False,
             allow_summarize=False,
-            media_min_score=config["scoring"].get("min_score_for_media", 3),
+            media_min_score=config["scoring"].get("min_score_for_media", 5),
             progress_cb=progress_cb,
             status_cb=status_cb,
         )
@@ -265,8 +267,8 @@ def enrich_high_signal(
             WHERE relevance_score >= ?
             AND signal_tier IS NOT NULL
             AND (
+                analysis_json IS NULL OR
                 (has_quote = 1 AND quote_tweet_id IS NOT NULL AND media_analysis IS NULL)
-                OR (has_link = 1 AND link_summary IS NULL)
                 OR (has_media = 1 AND media_analysis IS NULL)
             )
             ORDER BY relevance_score DESC
@@ -316,6 +318,8 @@ def enrich_high_signal(
 
                 media_items = ensure_media_analysis(conn, tweet)
                 media_context = build_media_context(media_items) if media_items else (tweet["media_analysis"] or "")
+                if tweet["analysis_json"]:
+                    continue
 
                 author_category = account_categories.get(tweet["author_handle"]) or "unknown"
 
@@ -330,7 +334,7 @@ def enrich_high_signal(
                         image_description=media_context,
                         model=enrich_model,
                     )
-                    futures[future] = (tweet["id"], tweet["signal_tier"])
+                    futures[future] = tweet["id"]
                 else:
                     result = enrich_tweet(
                         tweet_text=tweet["content"],
@@ -342,23 +346,16 @@ def enrich_high_signal(
                         model=enrich_model,
                     )
                     results.append(result)
-
-                    if result.signal_tier != tweet["signal_tier"]:
-                        conn.execute(
-                            "UPDATE tweets SET signal_tier = ? WHERE id = ?",
-                            (result.signal_tier, tweet["id"]),
-                        )
+                    _save_enrichment_result(conn, tweet["id"], tweet, result)
 
             for future in as_completed(list(futures.keys())):
-                tweet_id, current_tier = futures.pop(future)
+                tweet_id = futures.pop(future)
                 try:
                     result = future.result()
                     results.append(result)
-                    if result.signal_tier != current_tier:
-                        conn.execute(
-                            "UPDATE tweets SET signal_tier = ? WHERE id = ?",
-                            (result.signal_tier, tweet_id),
-                        )
+                    row = get_tweet_by_id(conn, tweet_id)
+                    if row:
+                        _save_enrichment_result(conn, tweet_id, row, result)
                 except Exception:
                     log.exception("Enrichment failed for tweet %s", tweet_id)
                     continue

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -411,7 +411,7 @@ def _triage_rows(
     max_vision_workers = _normalized_worker_count(config.get("llm", {}).get("max_concurrency_vision", 3), 3)
     vision_model = config["llm"].get("vision_model")
     vision_provider = config["llm"].get("vision_provider")
-    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 7)
+    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 6)
     article_min_score = config.get("scoring", {}).get("min_score_for_article_processing", 5)
     tweets_for_triage = []
     tweet_map: dict[str, sqlite3.Row] = {}

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -15,7 +15,9 @@ if TYPE_CHECKING:
 
 from ..config import load_config
 from ..db import (
+    get_cached_media_analysis,
     get_tweet_by_id,
+    record_media_analysis,
     update_account_stats,
     update_tweet_analysis,
     update_tweet_article,
@@ -149,28 +151,51 @@ def _analyze_media_items(
     vision_provider: str | None = None,
 ) -> tuple[list[dict[str, Any]], bool]:
     updated = False
+    config = load_config()
+    effective_model = vision_model or config["llm"].get("vision_model")
+    effective_provider = vision_provider or config["llm"].get("vision_provider")
     for item in media_items:
         if item.get("kind") or item.get("prose_text") or item.get("short_description"):
             continue
         url = item.get("url")
         if not url:
             continue
+        cached = get_cached_media_analysis(url, provider=effective_provider, model=effective_model)
+        if cached:
+            _apply_media_analysis_to_item(item, cached)
+            updated = True
+            continue
         try:
             result = analyze_media(url, model=vision_model, provider=vision_provider)
         except Exception:
             continue
 
-        item["kind"] = result.kind
-        item["short_description"] = result.short_description
-        item["prose_text"] = result.prose_text
-        item["prose_summary"] = result.prose_summary
-        item["chart"] = result.chart
+        result_payload = {
+            "kind": result.kind,
+            "short_description": result.short_description,
+            "prose_text": result.prose_text,
+            "prose_summary": result.prose_summary,
+            "chart": result.chart,
+            "table": result.table,
+        }
+        _apply_media_analysis_to_item(item, result_payload)
+        record_media_analysis(url, provider=effective_provider, model=effective_model, result=result_payload)
         updated = True
 
     if _merge_document_media(media_items):
         updated = True
 
     return media_items, updated
+
+
+def _apply_media_analysis_to_item(item: dict[str, Any], result: dict[str, Any]) -> None:
+    """Copy cached or fresh media analysis fields onto a media item."""
+    item["kind"] = (result.get("kind") or "other").lower()
+    item["short_description"] = result.get("short_description", "")
+    item["prose_text"] = result.get("prose_text", "")
+    item["prose_summary"] = result.get("prose_summary", "")
+    item["chart"] = result.get("chart") or {}
+    item["table"] = result.get("table") or {}
 
 
 def _page_number_hint(text: str) -> int | None:
@@ -386,7 +411,7 @@ def _triage_rows(
     max_vision_workers = _normalized_worker_count(config.get("llm", {}).get("max_concurrency_vision", 3), 3)
     vision_model = config["llm"].get("vision_model")
     vision_provider = config["llm"].get("vision_provider")
-    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 3)
+    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 7)
     article_min_score = config.get("scoring", {}).get("min_score_for_article_processing", 5)
     tweets_for_triage = []
     tweet_map: dict[str, sqlite3.Row] = {}
@@ -614,7 +639,13 @@ def _triage_rows(
 
             task_count = 0
 
-            if allow_summarize and len(content) > 500 and not is_tier1 and result.score >= 5:
+            if (
+                allow_summarize
+                and len(content) > 500
+                and not is_tier1
+                and result.score >= 5
+                and (force_refresh or not tweet_row["content_summary"])
+            ):
                 if text_pool:
                     if status_cb:
                         status_cb(f"Queue summary @{handle}")

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -59,6 +59,23 @@ class XArticleSummaryResult:
     actionable_items: list[dict[str, Any]] = field(default_factory=list)
 
 
+def _bounded_article_text(article_text: str, max_chars: int) -> str:
+    """Bound long article bodies while preserving the opening and closing context."""
+    clean_text = (article_text or "").strip()
+    if len(clean_text) <= max_chars:
+        return clean_text
+    if max_chars <= 1000:
+        return clean_text[:max_chars].strip()
+
+    head_chars = int(max_chars * 0.75)
+    tail_chars = max_chars - head_chars
+    return (
+        clean_text[:head_chars].rstrip()
+        + "\n\n[...middle truncated to reduce analysis cost...]\n\n"
+        + clean_text[-tail_chars:].lstrip()
+    )
+
+
 def triage_tweets_batch(
     tweets: list[dict[str, str]],
     model: str | None = None,
@@ -202,11 +219,16 @@ def summarize_x_article(
         return XArticleSummaryResult(short_summary=(article_preview or article_title or "").strip())
 
     fallback_summary = (article_preview or article_title or clean_text[:400]).strip()
+    try:
+        max_article_chars = int(config.get("scoring", {}).get("max_article_summary_chars", 20_000))
+    except (TypeError, ValueError):
+        max_article_chars = 20_000
+    bounded_text = _bounded_article_text(clean_text, max_article_chars)
 
     prompt = ARTICLE_SUMMARY_PROMPT.format(
         article_title=(article_title or "").strip() or "[untitled]",
         article_preview=(article_preview or "").strip() or "[none]",
-        article_text=clean_text,
+        article_text=bounded_text,
     )
 
     fallback_provider = config["llm"].get("triage_provider", "gemini")


### PR DESCRIPTION
## Summary
- Add a persistent media analysis cache keyed by media URL, provider, and model, with schema migration and unit coverage.
- Reduce expensive downstream fanout by raising default media/analysis thresholds and skipping already-populated summaries/analysis.
- Persist full `analysis_json` from `enrich_high_signal`, and bound long X Article summarization prompts with configurable `scoring.max_article_summary_chars`.
- Fix the Telegram notifier success-path test so it does not touch the live DB and hang under a cron-held SQLite lock.

## Runtime Findings
- Exact X Article text dedupe is not currently useful: sampled live DB article texts were unique, so prompt bounding is the better cost control.
- Duplicate media URLs do exist, so media URL caching avoids repeat vision/OCR/chart analysis and will populate going forward.
- The largest cost lever is avoiding deep enrichment for mid-score tweets; the default analysis threshold is now 7, while digest-grade triage summaries remain available.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uvx ty check`
- `npx biome check .`
- `timeout 180s uv run pytest -q`
- `uv run twag doctor`