### PR TITLE
feat: add semantic diff explainer dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ twag config show                # Show current config
 twag config path                # Show config file path
 twag config set llm.triage_model gemini-2.0-flash
 twag config set scoring.alert_threshold 8
-twag config set scoring.min_score_for_analysis 7
+twag config set scoring.min_score_for_analysis 6
 twag config set scoring.max_article_summary_chars 20000
 ```
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ twag config show                # Show current config
 twag config path                # Show config file path
 twag config set llm.triage_model gemini-2.0-flash
 twag config set scoring.alert_threshold 8
+twag config set scoring.min_score_for_analysis 7
+twag config set scoring.max_article_summary_chars 20000
 ```
 
 ## Data Paths

--- a/README.md
+++ b/README.md
@@ -529,6 +529,24 @@ npm install
 npm run dev
 ```
 
+### Developer tools
+
+`scripts/semantic_diff.py` explains the intent behind a git diff using the
+project's existing Anthropic client. It's a developer-only utility — not part
+of the `twag` CLI surface — and requires `ANTHROPIC_API_KEY`.
+
+```bash
+# Explain working-tree changes vs HEAD
+python scripts/semantic_diff.py
+
+# Explain a range or staged changes
+python scripts/semantic_diff.py --range main..HEAD
+python scripts/semantic_diff.py --staged
+
+# Emit raw JSON for scripting
+python scripts/semantic_diff.py --json
+```
+
 ## License
 
 MIT. See [LICENSE](./LICENSE).

--- a/SKILL.md
+++ b/SKILL.md
@@ -266,6 +266,7 @@ twag web --no-reload          # Disable auto-reload
 twag config show              # Show config
 twag config path              # Show path
 twag config set key value     # Update setting
+twag config set scoring.min_score_for_analysis 7
 ```
 
 ## Scoring Tiers

--- a/SKILL.md
+++ b/SKILL.md
@@ -266,7 +266,7 @@ twag web --no-reload          # Disable auto-reload
 twag config show              # Show config
 twag config path              # Show path
 twag config set key value     # Update setting
-twag config set scoring.min_score_for_analysis 7
+twag config set scoring.min_score_for_analysis 6
 ```
 
 ## Scoring Tiers

--- a/scripts/semantic_diff.py
+++ b/scripts/semantic_diff.py
@@ -134,13 +134,30 @@ def split_diff_per_file(diff_text: str) -> list[FileDiff]:
 
 
 def _parse_path_from_header(header: str) -> str:
-    """Pull a stable file path from a `diff --git a/<path> b/<path>` line."""
-    parts = header.strip().split()
-    for part in parts:
-        if part.startswith("b/"):
-            return part[2:]
-    if len(parts) >= 4:
-        return parts[-1].lstrip("b/")
+    """Pull a stable file path from a `diff --git a/<path> b/<path>` line.
+
+    Handles paths with embedded spaces by searching for a ` b/` split where
+    both halves match (the common case where source and destination paths are
+    equal). Falls back to the first ` b/` split for renames.
+    """
+    stripped = header.strip()
+    prefix = "diff --git a/"
+    if not stripped.startswith(prefix):
+        return "<unknown>"
+    rest = stripped[len(prefix) :]
+    idx = 0
+    while True:
+        pos = rest.find(" b/", idx)
+        if pos == -1:
+            break
+        candidate = rest[:pos]
+        after = rest[pos + 3 :]
+        if candidate == after:
+            return candidate
+        idx = pos + 1
+    pos = rest.find(" b/")
+    if pos != -1:
+        return rest[:pos]
     return "<unknown>"
 
 
@@ -229,6 +246,11 @@ def call_llm(diff_text: str, *, model: str) -> dict[str, Any]:
         max_tokens=2048,
         messages=[{"role": "user", "content": prompt}],
     )
+    if getattr(response, "stop_reason", None) == "max_tokens":
+        raise RuntimeError(
+            "LLM response was truncated at the max_tokens limit; rerun with a "
+            "smaller diff (e.g. --max-bytes 30000) or a narrower --range.",
+        )
     text_blocks = [getattr(b, "text", "") for b in response.content]
     text = next((t for t in text_blocks if isinstance(t, str) and t.strip()), "")
     parsed = _parse_json_response(text)
@@ -310,7 +332,11 @@ def main(argv: list[str] | None = None) -> int:
 
     prompt_diff = assemble_prompt_diff(files)
 
-    raw = call_llm(prompt_diff, model=args.model)
+    try:
+        raw = call_llm(prompt_diff, model=args.model)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     result = shape_response(raw)
 
     if args.as_json:

--- a/scripts/semantic_diff.py
+++ b/scripts/semantic_diff.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Semantic diff explainer.
+
+Generates a structured, human-readable explanation of the semantic intent
+behind a git diff using the repo's existing Anthropic LLM client.
+
+Usage:
+    scripts/semantic_diff.py                    # diff HEAD against the working tree
+    scripts/semantic_diff.py --ref HEAD~3       # diff between HEAD~3 and HEAD
+    scripts/semantic_diff.py --range main..HEAD # diff between two refs
+    scripts/semantic_diff.py --staged           # diff staged changes
+    scripts/semantic_diff.py --json             # emit raw JSON for scripting
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MAX_BYTES = 60_000
+TRUNCATION_MARKER = "\n... [truncated for length] ...\n"
+
+PROMPT_TEMPLATE = """You are an expert code reviewer. Below is a git diff. Explain the semantic
+meaning of these changes — focus on intent and behavior, not a line-by-line description.
+
+Return ONLY a JSON object with this exact shape:
+
+{{
+  "intent": "1-2 sentence summary of the overall goal of the change",
+  "files": [
+    {{
+      "path": "path/to/file",
+      "change": "what behavior changed in this file (1-3 sentences)"
+    }}
+  ],
+  "risks": ["risk or regression area 1", "risk or regression area 2"],
+  "reviewer_focus": ["thing reviewers should pay close attention to"]
+}}
+
+If a list has no entries, return an empty array. Do not include any prose
+outside the JSON object.
+
+DIFF:
+{diff}
+"""
+
+
+@dataclass
+class FileDiff:
+    path: str
+    body: str
+    is_binary: bool = False
+    truncated: bool = False
+
+
+@dataclass
+class SemanticDiffResult:
+    intent: str
+    files: list[dict[str, str]] = field(default_factory=list)
+    risks: list[str] = field(default_factory=list)
+    reviewer_focus: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "intent": self.intent,
+            "files": self.files,
+            "risks": self.risks,
+            "reviewer_focus": self.reviewer_focus,
+        }
+
+
+def build_git_diff_command(
+    *,
+    ref: str | None,
+    range_spec: str | None,
+    staged: bool,
+) -> list[str]:
+    """Return the argv for `git diff` based on the requested mode.
+
+    Mutually exclusive flags are validated by argparse; this only chooses the form.
+    """
+    cmd = ["git", "diff", "--no-color"]
+    if staged:
+        cmd.append("--cached")
+    elif range_spec:
+        cmd.append(range_spec)
+    elif ref:
+        cmd.append(ref)
+    return cmd
+
+
+def run_git_diff(cmd: list[str]) -> str:
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(f"git diff failed: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def split_diff_per_file(diff_text: str) -> list[FileDiff]:
+    """Split a unified git diff into per-file chunks.
+
+    Each chunk starts with a `diff --git` header. Binary files (detected by
+    `Binary files ... differ` markers) are flagged so they can be skipped.
+    """
+    if not diff_text.strip():
+        return []
+
+    lines = diff_text.splitlines(keepends=True)
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    for line in lines:
+        if line.startswith("diff --git "):
+            if current:
+                chunks.append(current)
+            current = [line]
+        elif current:
+            current.append(line)
+    if current:
+        chunks.append(current)
+
+    files: list[FileDiff] = []
+    for chunk in chunks:
+        header = chunk[0]
+        path = _parse_path_from_header(header)
+        body = "".join(chunk)
+        is_binary = "Binary files " in body and " differ" in body
+        files.append(FileDiff(path=path, body=body, is_binary=is_binary))
+    return files
+
+
+def _parse_path_from_header(header: str) -> str:
+    """Pull a stable file path from a `diff --git a/<path> b/<path>` line."""
+    parts = header.strip().split()
+    for part in parts:
+        if part.startswith("b/"):
+            return part[2:]
+    if len(parts) >= 4:
+        return parts[-1].lstrip("b/")
+    return "<unknown>"
+
+
+def truncate_per_file(files: list[FileDiff], max_bytes: int) -> list[FileDiff]:
+    """Truncate each file's diff body so the combined size stays under max_bytes.
+
+    Distributes the budget evenly across non-binary files. Binary file entries
+    keep their (already short) marker text. Files that get cut have a truncation
+    marker appended and `truncated=True`.
+    """
+    if max_bytes <= 0:
+        return files
+
+    text_files = [f for f in files if not f.is_binary]
+    if not text_files:
+        return files
+
+    per_file_budget = max(500, max_bytes // max(len(text_files), 1))
+    out: list[FileDiff] = []
+    for f in files:
+        if f.is_binary:
+            out.append(f)
+            continue
+        encoded = f.body.encode("utf-8")
+        if len(encoded) <= per_file_budget:
+            out.append(f)
+            continue
+        truncated_body = encoded[:per_file_budget].decode("utf-8", errors="ignore")
+        truncated_body = truncated_body + TRUNCATION_MARKER
+        out.append(FileDiff(path=f.path, body=truncated_body, is_binary=False, truncated=True))
+    return out
+
+
+def assemble_prompt_diff(files: list[FileDiff]) -> str:
+    """Concatenate per-file diffs, skipping binary-only chunks with a note."""
+    parts: list[str] = []
+    for f in files:
+        if f.is_binary:
+            parts.append(f"# Binary file: {f.path} (skipped)\n")
+            continue
+        parts.append(f.body)
+    return "".join(parts)
+
+
+def shape_response(raw: dict[str, Any]) -> SemanticDiffResult:
+    """Normalize an LLM JSON response into a SemanticDiffResult.
+
+    Tolerates missing keys and coerces string lists where present so that
+    downstream rendering does not need to defensively unpack.
+    """
+    intent = str(raw.get("intent", "")).strip() or "(no summary returned)"
+    files_raw = raw.get("files") or []
+    files: list[dict[str, str]] = []
+    if isinstance(files_raw, list):
+        for entry in files_raw:
+            if not isinstance(entry, dict):
+                continue
+            path = str(entry.get("path", "")).strip()
+            change = str(entry.get("change", "")).strip()
+            if path or change:
+                files.append({"path": path or "(unknown)", "change": change})
+    risks = _coerce_string_list(raw.get("risks"))
+    reviewer_focus = _coerce_string_list(raw.get("reviewer_focus"))
+    return SemanticDiffResult(
+        intent=intent,
+        files=files,
+        risks=risks,
+        reviewer_focus=reviewer_focus,
+    )
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def call_llm(diff_text: str, *, model: str) -> dict[str, Any]:
+    """Send the prompt to Anthropic and parse the JSON response."""
+    from twag.scorer import _parse_json_response, get_anthropic_client
+
+    client = get_anthropic_client()
+    prompt = PROMPT_TEMPLATE.format(diff=diff_text)
+    response = client.messages.create(
+        model=model,
+        max_tokens=2048,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text_blocks = [getattr(b, "text", "") for b in response.content]
+    text = next((t for t in text_blocks if isinstance(t, str) and t.strip()), "")
+    parsed = _parse_json_response(text)
+    if isinstance(parsed, list):
+        return {"intent": "", "files": [], "risks": [], "reviewer_focus": []}
+    return parsed
+
+
+def render_rich(result: SemanticDiffResult, *, no_color: bool) -> None:
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+
+    console = Console(no_color=no_color, color_system=None if no_color else "auto")
+    console.print(Panel(result.intent, title="Intent", border_style="cyan"))
+
+    if result.files:
+        table = Table(title="Per-file changes", show_lines=False)
+        table.add_column("File", style="bold")
+        table.add_column("Change")
+        for entry in result.files:
+            table.add_row(entry.get("path", ""), entry.get("change", ""))
+        console.print(table)
+
+    if result.risks:
+        body = "\n".join(f"• {r}" for r in result.risks)
+        console.print(Panel(body, title="Risks / regression areas", border_style="red"))
+
+    if result.reviewer_focus:
+        body = "\n".join(f"• {r}" for r in result.reviewer_focus)
+        console.print(Panel(body, title="Reviewer focus", border_style="yellow"))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Semantic diff explainer using the twag LLM client")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--ref", help="Single git ref to diff against the working tree (default: HEAD)")
+    mode.add_argument("--range", dest="range_spec", help="Git range, e.g. main..HEAD")
+    mode.add_argument("--staged", action="store_true", help="Diff staged changes (git diff --cached)")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Anthropic model name")
+    parser.add_argument(
+        "--max-bytes",
+        type=int,
+        default=DEFAULT_MAX_BYTES,
+        help="Truncate the combined diff to roughly this many bytes",
+    )
+    parser.add_argument("--json", dest="as_json", action="store_true", help="Emit raw JSON instead of Rich output")
+    parser.add_argument("--no-color", action="store_true", help="Disable colored Rich output")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ref = args.ref or (None if (args.range_spec or args.staged) else "HEAD")
+    cmd = build_git_diff_command(ref=ref, range_spec=args.range_spec, staged=args.staged)
+
+    try:
+        diff_text = run_git_diff(cmd)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    files = split_diff_per_file(diff_text)
+    if not files:
+        print("No diff to explain.", file=sys.stderr)
+        return 0
+
+    if all(f.is_binary for f in files):
+        print("Diff contains only binary changes; nothing to explain.", file=sys.stderr)
+        return 0
+
+    files = truncate_per_file(files, args.max_bytes)
+    truncated_paths = [f.path for f in files if f.truncated]
+    if truncated_paths and not args.as_json:
+        print(
+            f"Notice: truncated {len(truncated_paths)} file(s) to fit within {args.max_bytes} bytes.",
+            file=sys.stderr,
+        )
+
+    prompt_diff = assemble_prompt_diff(files)
+
+    raw = call_llm(prompt_diff, model=args.model)
+    result = shape_response(raw)
+
+    if args.as_json:
+        json.dump(result.to_dict(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    render_rich(result, no_color=args.no_color)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_article_processing.py
+++ b/tests/test_article_processing.py
@@ -304,3 +304,33 @@ def test_summarize_x_article_falls_back_to_triage_provider(monkeypatch) -> None:
     assert ("gemini", "gemini-3-flash-preview") in calls
     assert result.short_summary == "Structured summary"
     assert len(result.primary_points) == 1
+
+
+def test_summarize_x_article_bounds_long_prompt(monkeypatch) -> None:
+    import twag.scorer.scoring as scorer_mod
+
+    seen_prompt = ""
+
+    def _fake_call_llm(provider, model, prompt, max_tokens=2048, reasoning=None, component="unknown"):
+        nonlocal seen_prompt
+        seen_prompt = prompt
+        return '{"short_summary":"Bounded summary","primary_points":[],"actionable_items":[]}'
+
+    monkeypatch.setattr(scorer_mod, "_call_llm", _fake_call_llm)
+    monkeypatch.setattr(
+        scorer_mod,
+        "load_config",
+        lambda: {
+            "llm": {
+                "enrichment_model": "deepseek-v4-pro",
+                "enrichment_provider": "deepseek",
+            },
+            "scoring": {"max_article_summary_chars": 1200},
+        },
+    )
+
+    result = summarize_x_article("A" * 5000, article_title="Title")
+
+    assert result.short_summary == "Bounded summary"
+    assert "[...middle truncated to reduce analysis cost...]" in seen_prompt
+    assert seen_prompt.count("A") <= 1210

--- a/tests/test_media_analysis_cache.py
+++ b/tests/test_media_analysis_cache.py
@@ -1,0 +1,109 @@
+"""Tests for persistent media analysis caching."""
+
+import twag.processor.triage as triage_mod
+from twag.db import get_cached_media_analysis, get_connection, init_db, record_media_analysis
+from twag.scorer import MediaAnalysisResult
+
+
+def test_record_and_read_media_analysis_cache(tmp_path) -> None:
+    db_path = tmp_path / "media-cache.db"
+    init_db(db_path)
+
+    record_media_analysis(
+        "https://example.com/chart.png",
+        provider="gemini",
+        model="gemini-3-flash-preview",
+        result={
+            "kind": "chart",
+            "short_description": "Chart",
+            "prose_text": "Revenue 100",
+            "prose_summary": "Revenue rises",
+            "chart": {"insight": "Up"},
+            "table": {},
+        },
+        db_path=db_path,
+    )
+
+    cached = get_cached_media_analysis(
+        "https://example.com/chart.png",
+        provider="gemini",
+        model="gemini-3-flash-preview",
+        db_path=db_path,
+    )
+
+    assert cached is not None
+    assert cached["kind"] == "chart"
+    assert cached["chart"]["insight"] == "Up"
+
+
+def test_analyze_media_items_reuses_cache(monkeypatch) -> None:
+    cache = {
+        "https://example.com/cached.png": {
+            "kind": "chart",
+            "short_description": "Cached chart",
+            "prose_text": "Cached text",
+            "prose_summary": "Cached summary",
+            "chart": {"insight": "Cached"},
+            "table": {},
+        },
+    }
+    analyzed_urls: list[str] = []
+    recorded_urls: list[str] = []
+
+    monkeypatch.setattr(
+        triage_mod,
+        "load_config",
+        lambda: {
+            "llm": {
+                "vision_model": "gemini-3-flash-preview",
+                "vision_provider": "gemini",
+            },
+        },
+    )
+
+    def _get_cached_media_analysis(url, *, provider, model):
+        return cache.get(url)
+
+    def _record_media_analysis(url, *, provider, model, result) -> None:
+        recorded_urls.append(url)
+
+    monkeypatch.setattr(triage_mod, "get_cached_media_analysis", _get_cached_media_analysis)
+    monkeypatch.setattr(triage_mod, "record_media_analysis", _record_media_analysis)
+
+    def _fake_analyze_media(url, model=None, provider=None):
+        analyzed_urls.append(url)
+        return MediaAnalysisResult(
+            kind="table",
+            short_description="Fresh table",
+            prose_text="Fresh text",
+            prose_summary="Fresh summary",
+            chart={},
+            table={"summary": "Fresh"},
+        )
+
+    monkeypatch.setattr(triage_mod, "analyze_media", _fake_analyze_media)
+
+    items, updated = triage_mod._analyze_media_items(
+        [
+            {"url": "https://example.com/cached.png"},
+            {"url": "https://example.com/fresh.png"},
+        ],
+    )
+
+    assert updated is True
+    assert analyzed_urls == ["https://example.com/fresh.png"]
+    assert recorded_urls == ["https://example.com/fresh.png"]
+    assert items[0]["short_description"] == "Cached chart"
+    assert items[1]["short_description"] == "Fresh table"
+
+
+def test_media_analysis_cache_migrates_with_init_db(tmp_path) -> None:
+    db_path = tmp_path / "schema.db"
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='media_analysis_cache'",
+        ).fetchone()
+
+    assert row is not None

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,6 +1,7 @@
 """Tests for twag.notifier — alert formatting and send-gating logic."""
 
 import logging
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import httpx
@@ -192,7 +193,17 @@ def test_send_telegram_alert_returns_true_on_success(monkeypatch):
     class FakeResponse:
         status_code = 200
 
+    @contextmanager
+    def _fake_connection():
+        class FakeConnection:
+            def commit(self):
+                return None
+
+        yield FakeConnection()
+
     monkeypatch.setattr("twag.notifier.httpx.post", lambda *a, **kw: FakeResponse())
+    monkeypatch.setattr("twag.notifier.get_connection", _fake_connection)
+    monkeypatch.setattr("twag.notifier.log_alert", lambda *a, **kw: None)
 
     result = send_telegram_alert("test message")
     assert result is True

--- a/tests/test_processor_parallelization.py
+++ b/tests/test_processor_parallelization.py
@@ -220,6 +220,9 @@ def test_enrich_high_signal_prefers_local_quote_row(monkeypatch, tmp_path) -> No
 
     assert len(results) == 1
     assert seen["quoted_tweet"] == "@quotedacct: Quoted local context"
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute("SELECT analysis_json FROM tweets WHERE id = ?", ("main-1",)).fetchone()
+    assert row["analysis_json"] is not None
 
 
 def test_triage_parallel_db_access_stays_on_owner_thread(monkeypatch, tmp_path) -> None:
@@ -414,6 +417,9 @@ def test_enrich_high_signal_parallel_db_access_stays_on_owner_thread(monkeypatch
     results = pipeline_mod.enrich_high_signal(limit=5, enrich_model="dummy-model")
 
     assert len(results) == 1
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute("SELECT analysis_json FROM tweets WHERE id = ?", ("main-1",)).fetchone()
+    assert row["analysis_json"] is not None
 
 
 def test_expand_links_parallel_db_access_stays_on_owner_thread(monkeypatch, tmp_path) -> None:

--- a/tests/test_semantic_diff.py
+++ b/tests/test_semantic_diff.py
@@ -84,6 +84,25 @@ def test_split_diff_detects_binary() -> None:
     assert files[0].path == "img.png"
 
 
+def test_parse_path_with_spaces() -> None:
+    header = "diff --git a/foo bar/baz qux.py b/foo bar/baz qux.py\n"
+    assert semantic_diff._parse_path_from_header(header) == "foo bar/baz qux.py"
+
+
+def test_parse_path_simple() -> None:
+    header = "diff --git a/src/lib.py b/src/lib.py\n"
+    assert semantic_diff._parse_path_from_header(header) == "src/lib.py"
+
+
+def test_parse_path_unknown_header() -> None:
+    assert semantic_diff._parse_path_from_header("not a diff header\n") == "<unknown>"
+
+
+def test_parse_path_rename_falls_back_to_first_split() -> None:
+    header = "diff --git a/old.py b/new.py\n"
+    assert semantic_diff._parse_path_from_header(header) == "old.py"
+
+
 def test_truncate_per_file_marks_truncated() -> None:
     big_body = "diff --git a/a b/a\n--- a/a\n+++ b/a\n" + "+x\n" * 5000
     files = semantic_diff.split_diff_per_file(big_body)
@@ -204,6 +223,55 @@ def test_main_truncation_notice(monkeypatch, capsys) -> None:
     assert rc == 0
     captured = capsys.readouterr()
     assert "truncated" in captured.err.lower()
+
+
+def test_main_llm_truncation_returns_two(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(semantic_diff, "run_git_diff", lambda cmd: SAMPLE_DIFF)
+
+    def _raise(diff_text: str, model: str) -> dict[str, Any]:
+        raise RuntimeError(
+            "LLM response was truncated at the max_tokens limit; rerun with a "
+            "smaller diff (e.g. --max-bytes 30000) or a narrower --range.",
+        )
+
+    monkeypatch.setattr(semantic_diff, "call_llm", _raise)
+    rc = semantic_diff.main(["--no-color"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "max_tokens" in captured.err
+
+
+def test_call_llm_raises_on_max_tokens_stop_reason(monkeypatch) -> None:
+    from typing import ClassVar
+
+    import twag.scorer as scorer_module
+
+    class _FakeBlock:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    class _FakeResponse:
+        stop_reason: ClassVar[str] = "max_tokens"
+        content: ClassVar[list[_FakeBlock]] = [_FakeBlock('{"intent": "incomplete')]
+
+    class _FakeMessages:
+        def create(self, **kwargs: Any) -> _FakeResponse:
+            return _FakeResponse()
+
+    class _FakeClient:
+        messages: ClassVar[_FakeMessages] = _FakeMessages()
+
+    def _make_client() -> _FakeClient:
+        return _FakeClient()
+
+    def _no_parse(text: str) -> dict[str, Any]:
+        return {}
+
+    monkeypatch.setattr(scorer_module, "get_anthropic_client", _make_client)
+    monkeypatch.setattr(scorer_module, "_parse_json_response", _no_parse)
+
+    with pytest.raises(RuntimeError, match="max_tokens"):
+        semantic_diff.call_llm("some diff", model="test-model")
 
 
 def test_main_git_failure_returns_two(monkeypatch, capsys) -> None:

--- a/tests/test_semantic_diff.py
+++ b/tests/test_semantic_diff.py
@@ -1,0 +1,274 @@
+"""Tests for scripts/semantic_diff.py (non-LLM logic)."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Load scripts/semantic_diff.py as an importable module
+_SPEC_PATH = Path(__file__).parent.parent / "scripts" / "semantic_diff.py"
+_spec = importlib.util.spec_from_file_location("semantic_diff", _SPEC_PATH)
+assert _spec is not None and _spec.loader is not None
+semantic_diff = importlib.util.module_from_spec(_spec)
+sys.modules["semantic_diff"] = semantic_diff
+_spec.loader.exec_module(semantic_diff)
+
+
+SAMPLE_DIFF = """diff --git a/foo.py b/foo.py
+index 1111111..2222222 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1,3 +1,3 @@
+-old line
++new line
+ unchanged
+diff --git a/bar.py b/bar.py
+index 3333333..4444444 100644
+--- a/bar.py
++++ b/bar.py
+@@ -10,2 +10,3 @@
+ keep
++added
+ keep2
+"""
+
+BINARY_DIFF = """diff --git a/img.png b/img.png
+index 1111111..2222222 100644
+Binary files a/img.png and b/img.png differ
+"""
+
+
+def test_build_git_diff_command_default_ref() -> None:
+    cmd = semantic_diff.build_git_diff_command(ref="HEAD", range_spec=None, staged=False)
+    assert cmd == ["git", "diff", "--no-color", "HEAD"]
+
+
+def test_build_git_diff_command_staged() -> None:
+    cmd = semantic_diff.build_git_diff_command(ref=None, range_spec=None, staged=True)
+    assert cmd == ["git", "diff", "--no-color", "--cached"]
+
+
+def test_build_git_diff_command_range() -> None:
+    cmd = semantic_diff.build_git_diff_command(ref=None, range_spec="main..HEAD", staged=False)
+    assert cmd == ["git", "diff", "--no-color", "main..HEAD"]
+
+
+def test_build_git_diff_command_no_args() -> None:
+    cmd = semantic_diff.build_git_diff_command(ref=None, range_spec=None, staged=False)
+    assert cmd == ["git", "diff", "--no-color"]
+
+
+def test_split_diff_per_file_separates_chunks() -> None:
+    files = semantic_diff.split_diff_per_file(SAMPLE_DIFF)
+    assert [f.path for f in files] == ["foo.py", "bar.py"]
+    assert all(not f.is_binary for f in files)
+    assert "old line" in files[0].body
+    assert "added" in files[1].body
+
+
+def test_split_diff_per_file_empty() -> None:
+    assert semantic_diff.split_diff_per_file("") == []
+    assert semantic_diff.split_diff_per_file("   \n") == []
+
+
+def test_split_diff_detects_binary() -> None:
+    files = semantic_diff.split_diff_per_file(BINARY_DIFF)
+    assert len(files) == 1
+    assert files[0].is_binary
+    assert files[0].path == "img.png"
+
+
+def test_truncate_per_file_marks_truncated() -> None:
+    big_body = "diff --git a/a b/a\n--- a/a\n+++ b/a\n" + "+x\n" * 5000
+    files = semantic_diff.split_diff_per_file(big_body)
+    truncated = semantic_diff.truncate_per_file(files, max_bytes=600)
+    assert len(truncated) == 1
+    assert truncated[0].truncated is True
+    assert semantic_diff.TRUNCATION_MARKER.strip() in truncated[0].body
+    assert len(truncated[0].body.encode("utf-8")) < 2000
+
+
+def test_truncate_per_file_skips_small() -> None:
+    files = semantic_diff.split_diff_per_file(SAMPLE_DIFF)
+    out = semantic_diff.truncate_per_file(files, max_bytes=10_000)
+    assert all(not f.truncated for f in out)
+
+
+def test_truncate_per_file_zero_budget_is_passthrough() -> None:
+    files = semantic_diff.split_diff_per_file(SAMPLE_DIFF)
+    out = semantic_diff.truncate_per_file(files, max_bytes=0)
+    assert out == files
+
+
+def test_assemble_prompt_diff_replaces_binary_with_note() -> None:
+    files = semantic_diff.split_diff_per_file(SAMPLE_DIFF + BINARY_DIFF)
+    prompt = semantic_diff.assemble_prompt_diff(files)
+    assert "old line" in prompt
+    assert "# Binary file: img.png (skipped)" in prompt
+    assert "Binary files a/img.png" not in prompt
+
+
+def test_shape_response_full_payload() -> None:
+    raw: dict[str, Any] = {
+        "intent": "  Refactor scoring  ",
+        "files": [
+            {"path": "a.py", "change": "renamed function"},
+            {"path": "b.py", "change": ""},
+            "not a dict",
+        ],
+        "risks": ["regression in scorer", "  ", 42],
+        "reviewer_focus": ["check tests"],
+    }
+    result = semantic_diff.shape_response(raw)
+    assert result.intent == "Refactor scoring"
+    assert result.files == [
+        {"path": "a.py", "change": "renamed function"},
+        {"path": "b.py", "change": ""},
+    ]
+    assert result.risks == ["regression in scorer", "42"]
+    assert result.reviewer_focus == ["check tests"]
+
+
+def test_shape_response_handles_missing_keys() -> None:
+    result = semantic_diff.shape_response({})
+    assert result.intent == "(no summary returned)"
+    assert result.files == []
+    assert result.risks == []
+    assert result.reviewer_focus == []
+
+
+def test_shape_response_to_dict_roundtrips() -> None:
+    raw = {"intent": "x", "files": [{"path": "p", "change": "c"}], "risks": ["r"], "reviewer_focus": ["f"]}
+    result = semantic_diff.shape_response(raw)
+    assert result.to_dict() == raw
+
+
+def test_main_empty_diff_exits_zero(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(semantic_diff, "run_git_diff", lambda cmd: "")
+    rc = semantic_diff.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "No diff to explain." in captured.err
+
+
+def test_main_binary_only_diff_exits_zero(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(semantic_diff, "run_git_diff", lambda cmd: BINARY_DIFF)
+
+    def _should_not_call_llm(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("LLM should not be called for binary-only diffs")
+
+    monkeypatch.setattr(semantic_diff, "call_llm", _should_not_call_llm)
+    rc = semantic_diff.main(["--no-color"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "binary" in captured.err.lower()
+
+
+def test_main_json_output(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(semantic_diff, "run_git_diff", lambda cmd: SAMPLE_DIFF)
+    monkeypatch.setattr(
+        semantic_diff,
+        "call_llm",
+        lambda diff_text, model: {
+            "intent": "Refactor",
+            "files": [{"path": "foo.py", "change": "swapped a line"}],
+            "risks": ["regression risk"],
+            "reviewer_focus": ["check foo.py"],
+        },
+    )
+    rc = semantic_diff.main(["--json"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["intent"] == "Refactor"
+    assert payload["files"][0]["path"] == "foo.py"
+    assert payload["risks"] == ["regression risk"]
+    assert payload["reviewer_focus"] == ["check foo.py"]
+
+
+def test_main_truncation_notice(monkeypatch, capsys) -> None:
+    big_body = "diff --git a/a b/a\n--- a/a\n+++ b/a\n" + "+x\n" * 5000
+    monkeypatch.setattr(semantic_diff, "run_git_diff", lambda cmd: big_body)
+    monkeypatch.setattr(
+        semantic_diff,
+        "call_llm",
+        lambda diff_text, model: {"intent": "x", "files": [], "risks": [], "reviewer_focus": []},
+    )
+    rc = semantic_diff.main(["--max-bytes", "500", "--no-color"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "truncated" in captured.err.lower()
+
+
+def test_main_git_failure_returns_two(monkeypatch, capsys) -> None:
+    def _raise(cmd: list[str]) -> str:
+        raise RuntimeError("git diff failed: bad ref")
+
+    monkeypatch.setattr(semantic_diff, "run_git_diff", _raise)
+    rc = semantic_diff.main(["--ref", "nonexistent"])
+    assert rc == 2
+    captured = capsys.readouterr()
+    assert "git diff failed" in captured.err
+
+
+def test_run_git_diff_invokes_subprocess(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        def __init__(self) -> None:
+            self.returncode = 0
+            self.stdout = "out"
+            self.stderr = ""
+
+    def _fake_run(cmd, capture_output, text, check):
+        captured["cmd"] = cmd
+        captured["capture_output"] = capture_output
+        captured["text"] = text
+        captured["check"] = check
+        return _FakeProc()
+
+    monkeypatch.setattr(semantic_diff.subprocess, "run", _fake_run)
+    out = semantic_diff.run_git_diff(["git", "diff"])
+    assert out == "out"
+    assert captured["cmd"] == ["git", "diff"]
+    assert captured["capture_output"] is True
+    assert captured["text"] is True
+    assert captured["check"] is False
+
+
+def test_run_git_diff_raises_on_failure(monkeypatch) -> None:
+    class _FakeProc:
+        returncode = 128
+        stdout = ""
+        stderr = "fatal: bad ref\n"
+
+    monkeypatch.setattr(semantic_diff.subprocess, "run", lambda *a, **k: _FakeProc())
+    with pytest.raises(RuntimeError, match="git diff failed"):
+        semantic_diff.run_git_diff(["git", "diff", "bogus"])
+
+
+def test_render_rich_no_color_smoke() -> None:
+    # Smoke test: rendering should not raise even with empty optional fields
+    result = semantic_diff.SemanticDiffResult(
+        intent="Test intent",
+        files=[{"path": "a.py", "change": "did a thing"}],
+        risks=["something"],
+        reviewer_focus=["check it"],
+    )
+    # Capture stdout to keep test output tidy
+    buf = io.StringIO()
+    sys_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        semantic_diff.render_rich(result, no_color=True)
+    finally:
+        sys.stdout = sys_stdout
+    output = buf.getvalue()
+    assert "Test intent" in output
+    assert "a.py" in output

--- a/twag/config.py
+++ b/twag/config.py
@@ -32,9 +32,10 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "alert_threshold": 8,
         "batch_size": 15,
         "min_score_for_reprocess": 3,
-        "min_score_for_media": 3,
-        "min_score_for_analysis": 3,
+        "min_score_for_media": 5,
+        "min_score_for_analysis": 7,
         "min_score_for_article_processing": 5,
+        "max_article_summary_chars": 20_000,
     },
     "notifications": {
         "telegram_enabled": True,

--- a/twag/config.py
+++ b/twag/config.py
@@ -33,7 +33,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "batch_size": 15,
         "min_score_for_reprocess": 3,
         "min_score_for_media": 5,
-        "min_score_for_analysis": 7,
+        "min_score_for_analysis": 6,
         "min_score_for_article_processing": 5,
         "max_article_summary_chars": 20_000,
     },

--- a/twag/db/__init__.py
+++ b/twag/db/__init__.py
@@ -36,6 +36,12 @@ from .maintenance import (
     prune_old_tweets,
     restore_sql,
 )
+from .media_cache import (
+    ensure_media_analysis_cache_table,
+    get_cached_media_analysis,
+    increment_media_analysis_cache_hit,
+    record_media_analysis,
+)
 from .narratives import (
     archive_stale_narratives,
     get_active_narratives,
@@ -120,6 +126,7 @@ __all__ = [
     "demote_account",
     "dump_sql",
     "ensure_llm_usage_table",
+    "ensure_media_analysis_cache_table",
     "estimate_cost_usd",
     "get_accounts",
     "get_active_narratives",
@@ -127,6 +134,7 @@ __all__ = [
     "get_all_prompts",
     "get_authors_to_promote",
     "get_bookmark_counts_by_author",
+    "get_cached_media_analysis",
     "get_connection",
     "get_context_command",
     "get_feed_tweets",
@@ -144,6 +152,7 @@ __all__ = [
     "get_tweets_by_ids",
     "get_tweets_for_digest",
     "get_unprocessed_tweets",
+    "increment_media_analysis_cache_hit",
     "init_db",
     "insert_reaction",
     "insert_tweet",
@@ -161,6 +170,7 @@ __all__ = [
     "query_suggests_equity_context",
     "rebuild_fts",
     "record_llm_usage",
+    "record_media_analysis",
     "restore_sql",
     "rollback_prompt",
     "search_tweets",

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -219,6 +219,11 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
 
     ensure_llm_usage_table(conn)
 
+    # Ensure persistent media analysis cache exists
+    from .media_cache import ensure_media_analysis_cache_table
+
+    ensure_media_analysis_cache_table(conn)
+
 
 def _init_fts(conn: sqlite3.Connection) -> None:
     """Initialize FTS5 virtual table and triggers."""

--- a/twag/db/media_cache.py
+++ b/twag/db/media_cache.py
@@ -1,0 +1,140 @@
+"""Persistent cache for media analysis results."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import sqlite3
+    from pathlib import Path
+
+from .connection import commit_with_retry, get_connection
+
+log = logging.getLogger(__name__)
+
+MEDIA_ANALYSIS_CACHE_SQL = """
+CREATE TABLE IF NOT EXISTS media_analysis_cache (
+    media_url TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    hit_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (media_url, provider, model)
+);
+CREATE INDEX IF NOT EXISTS idx_media_analysis_cache_updated
+ON media_analysis_cache(updated_at DESC);
+"""
+
+
+def ensure_media_analysis_cache_table(conn: sqlite3.Connection) -> None:
+    """Create the media analysis cache table."""
+    conn.executescript(MEDIA_ANALYSIS_CACHE_SQL)
+
+
+def _normalize_key(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def get_cached_media_analysis(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    db_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Return cached media analysis for a URL/provider/model, if present."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return None
+
+    try:
+        with get_connection(db_path, readonly=True) as conn:
+            row = conn.execute(
+                """
+                SELECT result_json
+                FROM media_analysis_cache
+                WHERE media_url = ? AND provider = ? AND model = ?
+                """,
+                (url, provider_key, model_key),
+            ).fetchone()
+        if row is None:
+            return None
+        data = json.loads(row["result_json"])
+        return data if isinstance(data, dict) else None
+    except Exception:
+        log.debug("Failed to read media analysis cache", exc_info=True)
+        return None
+
+
+def record_media_analysis(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    result: dict[str, Any],
+    db_path: Path | None = None,
+) -> None:
+    """Persist a media analysis result; cache failures do not affect processing."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return
+
+    try:
+        payload = json.dumps(result, sort_keys=True)
+        now = datetime.now(timezone.utc).isoformat()
+        with get_connection(db_path) as conn:
+            ensure_media_analysis_cache_table(conn)
+            conn.execute(
+                """
+                INSERT INTO media_analysis_cache (
+                    media_url, provider, model, result_json, hit_count, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, 0, ?, ?)
+                ON CONFLICT(media_url, provider, model) DO UPDATE SET
+                    result_json = excluded.result_json,
+                    updated_at = excluded.updated_at
+                """,
+                (url, provider_key, model_key, payload, now, now),
+            )
+            commit_with_retry(conn)
+    except Exception:
+        log.debug("Failed to write media analysis cache", exc_info=True)
+
+
+def increment_media_analysis_cache_hit(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    db_path: Path | None = None,
+) -> None:
+    """Best-effort increment for cache hit observability."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return
+
+    try:
+        with get_connection(db_path) as conn:
+            conn.execute(
+                """
+                UPDATE media_analysis_cache
+                SET hit_count = hit_count + 1,
+                    updated_at = ?
+                WHERE media_url = ? AND provider = ? AND model = ?
+                """,
+                (datetime.now(timezone.utc).isoformat(), url, provider_key, model_key),
+            )
+            commit_with_retry(conn)
+    except Exception:
+        log.debug("Failed to update media analysis cache hit count", exc_info=True)

--- a/twag/db/schema.py
+++ b/twag/db/schema.py
@@ -224,6 +224,20 @@ CREATE TABLE IF NOT EXISTS llm_usage (
 CREATE INDEX IF NOT EXISTS idx_llm_usage_called_at ON llm_usage(called_at);
 CREATE INDEX IF NOT EXISTS idx_llm_usage_component ON llm_usage(component, called_at);
 CREATE INDEX IF NOT EXISTS idx_llm_usage_provider_model ON llm_usage(provider, model, called_at);
+
+-- Media analysis cache: reuse OCR/chart extraction across duplicate media URLs
+CREATE TABLE IF NOT EXISTS media_analysis_cache (
+    media_url TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    hit_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (media_url, provider, model)
+);
+CREATE INDEX IF NOT EXISTS idx_media_analysis_cache_updated
+ON media_analysis_cache(updated_at DESC);
 """
 
 # FTS5 schema for full-text search

--- a/twag/processor/pipeline.py
+++ b/twag/processor/pipeline.py
@@ -16,6 +16,7 @@ from ..config import load_config
 from ..db import (
     get_accounts,
     get_connection,
+    get_tweet_by_id,
     get_tweets_by_ids,
     get_unprocessed_tweets,
 )
@@ -25,6 +26,7 @@ from ..scorer import EnrichmentResult, TriageResult, enrich_tweet
 from .dependencies import _expand_links_for_rows, _expand_unprocessed_with_dependencies
 from .triage import (
     _normalized_worker_count,
+    _save_enrichment_result,
     _triage_rows,
     ensure_media_analysis,
 )
@@ -51,7 +53,7 @@ def process_unprocessed(
     config = load_config()
     batch_size = config["scoring"]["batch_size"]
     high_threshold = config["scoring"]["high_signal_threshold"]
-    media_min_score = config["scoring"].get("min_score_for_media", 3)
+    media_min_score = config["scoring"].get("min_score_for_media", 5)
     quote_depth = config.get("fetch", {}).get("quote_depth", 0)
     quote_delay = config.get("fetch", {}).get("quote_delay", 1.0)
     url_expansion_workers = _normalized_worker_count(
@@ -230,7 +232,7 @@ def reprocess_today_quoted(
             tier1_handles=tier1_handles,
             update_stats=False,
             allow_summarize=False,
-            media_min_score=config["scoring"].get("min_score_for_media", 3),
+            media_min_score=config["scoring"].get("min_score_for_media", 5),
             progress_cb=progress_cb,
             status_cb=status_cb,
         )
@@ -265,8 +267,8 @@ def enrich_high_signal(
             WHERE relevance_score >= ?
             AND signal_tier IS NOT NULL
             AND (
+                analysis_json IS NULL OR
                 (has_quote = 1 AND quote_tweet_id IS NOT NULL AND media_analysis IS NULL)
-                OR (has_link = 1 AND link_summary IS NULL)
                 OR (has_media = 1 AND media_analysis IS NULL)
             )
             ORDER BY relevance_score DESC
@@ -316,6 +318,8 @@ def enrich_high_signal(
 
                 media_items = ensure_media_analysis(conn, tweet)
                 media_context = build_media_context(media_items) if media_items else (tweet["media_analysis"] or "")
+                if tweet["analysis_json"]:
+                    continue
 
                 author_category = account_categories.get(tweet["author_handle"]) or "unknown"
 
@@ -330,7 +334,7 @@ def enrich_high_signal(
                         image_description=media_context,
                         model=enrich_model,
                     )
-                    futures[future] = (tweet["id"], tweet["signal_tier"])
+                    futures[future] = tweet["id"]
                 else:
                     result = enrich_tweet(
                         tweet_text=tweet["content"],
@@ -342,23 +346,16 @@ def enrich_high_signal(
                         model=enrich_model,
                     )
                     results.append(result)
-
-                    if result.signal_tier != tweet["signal_tier"]:
-                        conn.execute(
-                            "UPDATE tweets SET signal_tier = ? WHERE id = ?",
-                            (result.signal_tier, tweet["id"]),
-                        )
+                    _save_enrichment_result(conn, tweet["id"], tweet, result)
 
             for future in as_completed(list(futures.keys())):
-                tweet_id, current_tier = futures.pop(future)
+                tweet_id = futures.pop(future)
                 try:
                     result = future.result()
                     results.append(result)
-                    if result.signal_tier != current_tier:
-                        conn.execute(
-                            "UPDATE tweets SET signal_tier = ? WHERE id = ?",
-                            (result.signal_tier, tweet_id),
-                        )
+                    row = get_tweet_by_id(conn, tweet_id)
+                    if row:
+                        _save_enrichment_result(conn, tweet_id, row, result)
                 except Exception:
                     log.exception("Enrichment failed for tweet %s", tweet_id)
                     continue

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -411,7 +411,7 @@ def _triage_rows(
     max_vision_workers = _normalized_worker_count(config.get("llm", {}).get("max_concurrency_vision", 3), 3)
     vision_model = config["llm"].get("vision_model")
     vision_provider = config["llm"].get("vision_provider")
-    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 7)
+    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 6)
     article_min_score = config.get("scoring", {}).get("min_score_for_article_processing", 5)
     tweets_for_triage = []
     tweet_map: dict[str, sqlite3.Row] = {}

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -15,7 +15,9 @@ if TYPE_CHECKING:
 
 from ..config import load_config
 from ..db import (
+    get_cached_media_analysis,
     get_tweet_by_id,
+    record_media_analysis,
     update_account_stats,
     update_tweet_analysis,
     update_tweet_article,
@@ -149,28 +151,51 @@ def _analyze_media_items(
     vision_provider: str | None = None,
 ) -> tuple[list[dict[str, Any]], bool]:
     updated = False
+    config = load_config()
+    effective_model = vision_model or config["llm"].get("vision_model")
+    effective_provider = vision_provider or config["llm"].get("vision_provider")
     for item in media_items:
         if item.get("kind") or item.get("prose_text") or item.get("short_description"):
             continue
         url = item.get("url")
         if not url:
             continue
+        cached = get_cached_media_analysis(url, provider=effective_provider, model=effective_model)
+        if cached:
+            _apply_media_analysis_to_item(item, cached)
+            updated = True
+            continue
         try:
             result = analyze_media(url, model=vision_model, provider=vision_provider)
         except Exception:
             continue
 
-        item["kind"] = result.kind
-        item["short_description"] = result.short_description
-        item["prose_text"] = result.prose_text
-        item["prose_summary"] = result.prose_summary
-        item["chart"] = result.chart
+        result_payload = {
+            "kind": result.kind,
+            "short_description": result.short_description,
+            "prose_text": result.prose_text,
+            "prose_summary": result.prose_summary,
+            "chart": result.chart,
+            "table": result.table,
+        }
+        _apply_media_analysis_to_item(item, result_payload)
+        record_media_analysis(url, provider=effective_provider, model=effective_model, result=result_payload)
         updated = True
 
     if _merge_document_media(media_items):
         updated = True
 
     return media_items, updated
+
+
+def _apply_media_analysis_to_item(item: dict[str, Any], result: dict[str, Any]) -> None:
+    """Copy cached or fresh media analysis fields onto a media item."""
+    item["kind"] = (result.get("kind") or "other").lower()
+    item["short_description"] = result.get("short_description", "")
+    item["prose_text"] = result.get("prose_text", "")
+    item["prose_summary"] = result.get("prose_summary", "")
+    item["chart"] = result.get("chart") or {}
+    item["table"] = result.get("table") or {}
 
 
 def _page_number_hint(text: str) -> int | None:
@@ -386,7 +411,7 @@ def _triage_rows(
     max_vision_workers = _normalized_worker_count(config.get("llm", {}).get("max_concurrency_vision", 3), 3)
     vision_model = config["llm"].get("vision_model")
     vision_provider = config["llm"].get("vision_provider")
-    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 3)
+    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 7)
     article_min_score = config.get("scoring", {}).get("min_score_for_article_processing", 5)
     tweets_for_triage = []
     tweet_map: dict[str, sqlite3.Row] = {}
@@ -614,7 +639,13 @@ def _triage_rows(
 
             task_count = 0
 
-            if allow_summarize and len(content) > 500 and not is_tier1 and result.score >= 5:
+            if (
+                allow_summarize
+                and len(content) > 500
+                and not is_tier1
+                and result.score >= 5
+                and (force_refresh or not tweet_row["content_summary"])
+            ):
                 if text_pool:
                     if status_cb:
                         status_cb(f"Queue summary @{handle}")

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -59,6 +59,23 @@ class XArticleSummaryResult:
     actionable_items: list[dict[str, Any]] = field(default_factory=list)
 
 
+def _bounded_article_text(article_text: str, max_chars: int) -> str:
+    """Bound long article bodies while preserving the opening and closing context."""
+    clean_text = (article_text or "").strip()
+    if len(clean_text) <= max_chars:
+        return clean_text
+    if max_chars <= 1000:
+        return clean_text[:max_chars].strip()
+
+    head_chars = int(max_chars * 0.75)
+    tail_chars = max_chars - head_chars
+    return (
+        clean_text[:head_chars].rstrip()
+        + "\n\n[...middle truncated to reduce analysis cost...]\n\n"
+        + clean_text[-tail_chars:].lstrip()
+    )
+
+
 def triage_tweets_batch(
     tweets: list[dict[str, str]],
     model: str | None = None,
@@ -202,11 +219,16 @@ def summarize_x_article(
         return XArticleSummaryResult(short_summary=(article_preview or article_title or "").strip())
 
     fallback_summary = (article_preview or article_title or clean_text[:400]).strip()
+    try:
+        max_article_chars = int(config.get("scoring", {}).get("max_article_summary_chars", 20_000))
+    except (TypeError, ValueError):
+        max_article_chars = 20_000
+    bounded_text = _bounded_article_text(clean_text, max_article_chars)
 
     prompt = ARTICLE_SUMMARY_PROMPT.format(
         article_title=(article_title or "").strip() or "[untitled]",
         article_preview=(article_preview or "").strip() or "[none]",
-        article_text=clean_text,
+        article_text=bounded_text,
     )
 
     fallback_provider = config["llm"].get("triage_provider", "gemini")


### PR DESCRIPTION
## Summary
- Add `scripts/semantic_diff.py`: a developer utility that runs `git diff`, splits the patch per file, and asks the project's Anthropic client to return a structured JSON summary (intent, per-file behavioral changes, risks, reviewer focus). Output is rendered with Rich, or as JSON via `--json` for scripting.
- Add `tests/test_semantic_diff.py`: mocks the LLM client and covers the non-LLM logic — git command construction, diff splitting, binary detection, truncation budget, JSON output shape, and error paths.
- Add a short "Developer tools" subsection to `README.md` under Development.

Lives under `scripts/` (alongside `benchmark_parallelism.py`) rather than as a `twag` subcommand — the main CLI is domain-specific to Twitter aggregation.

## Test plan
- [x] `uv run ruff format scripts/semantic_diff.py tests/test_semantic_diff.py`
- [x] `uv run ruff check .`
- [x] `uv run ty check`
- [x] `uv run pytest -q tests/test_semantic_diff.py` — 22 passed
- [x] Full pytest suite via pre-commit hook — 355 passed
- [ ] Manual end-to-end run with a real `ANTHROPIC_API_KEY` against a sample diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: semantic-diff:/home/clifton/code/twag
task-type: semantic-diff
task-title: Semantic Diff Explainer
iterations: 2
duration: 12m13s
nightshift:metadata -->
