### PR TITLE
test: backward-compat guards for db, API, CLI, config

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ twag config show                # Show current config
 twag config path                # Show config file path
 twag config set llm.triage_model gemini-2.0-flash
 twag config set scoring.alert_threshold 8
-twag config set scoring.min_score_for_analysis 7
+twag config set scoring.min_score_for_analysis 6
 twag config set scoring.max_article_summary_chars 20000
 ```
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ twag config show                # Show current config
 twag config path                # Show config file path
 twag config set llm.triage_model gemini-2.0-flash
 twag config set scoring.alert_threshold 8
+twag config set scoring.min_score_for_analysis 7
+twag config set scoring.max_article_summary_chars 20000
 ```
 
 ## Data Paths

--- a/SKILL.md
+++ b/SKILL.md
@@ -266,6 +266,7 @@ twag web --no-reload          # Disable auto-reload
 twag config show              # Show config
 twag config path              # Show path
 twag config set key value     # Update setting
+twag config set scoring.min_score_for_analysis 7
 ```
 
 ## Scoring Tiers

--- a/SKILL.md
+++ b/SKILL.md
@@ -266,7 +266,7 @@ twag web --no-reload          # Disable auto-reload
 twag config show              # Show config
 twag config path              # Show path
 twag config set key value     # Update setting
-twag config set scoring.min_score_for_analysis 7
+twag config set scoring.min_score_for_analysis 6
 ```
 
 ## Scoring Tiers

--- a/tests/test_article_processing.py
+++ b/tests/test_article_processing.py
@@ -304,3 +304,33 @@ def test_summarize_x_article_falls_back_to_triage_provider(monkeypatch) -> None:
     assert ("gemini", "gemini-3-flash-preview") in calls
     assert result.short_summary == "Structured summary"
     assert len(result.primary_points) == 1
+
+
+def test_summarize_x_article_bounds_long_prompt(monkeypatch) -> None:
+    import twag.scorer.scoring as scorer_mod
+
+    seen_prompt = ""
+
+    def _fake_call_llm(provider, model, prompt, max_tokens=2048, reasoning=None, component="unknown"):
+        nonlocal seen_prompt
+        seen_prompt = prompt
+        return '{"short_summary":"Bounded summary","primary_points":[],"actionable_items":[]}'
+
+    monkeypatch.setattr(scorer_mod, "_call_llm", _fake_call_llm)
+    monkeypatch.setattr(
+        scorer_mod,
+        "load_config",
+        lambda: {
+            "llm": {
+                "enrichment_model": "deepseek-v4-pro",
+                "enrichment_provider": "deepseek",
+            },
+            "scoring": {"max_article_summary_chars": 1200},
+        },
+    )
+
+    result = summarize_x_article("A" * 5000, article_title="Title")
+
+    assert result.short_summary == "Bounded summary"
+    assert "[...middle truncated to reduce analysis cost...]" in seen_prompt
+    assert seen_prompt.count("A") <= 1210

--- a/tests/test_backward_compatibility_api.py
+++ b/tests/test_backward_compatibility_api.py
@@ -1,0 +1,176 @@
+"""Backward-compatibility guards for the public web API response shape.
+
+Pins the documented field set for ``GET /api/tweets`` and
+``GET /api/tweets/{id}`` so that future refactors can't silently drop fields
+that callers (frontend, agent integrations) depend on.
+
+The complementary contract test in ``test_api_contracts.py`` asserts list and
+single-tweet endpoints expose the *same* field set. This file adds two
+backward-compat-specific guarantees:
+
+1. Every field documented in CLAUDE.md (``display_content``, ``quote_embed``,
+   ``inline_quote_embeds``, ``external_links``) must be present on both
+   endpoints.
+2. A core minimum set of historically-present fields cannot regress.
+"""
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from twag.db import get_connection, insert_tweet, update_tweet_processing
+from twag.web.app import create_app
+
+_FIXED_TS = datetime(2025, 6, 15, 12, 0, tzinfo=timezone.utc)
+
+
+# Fields explicitly documented in CLAUDE.md as part of the web feed surface.
+# Removing any of these is a breaking change for the documented contract.
+DOCUMENTED_DISPLAY_FIELDS = {
+    "display_content",
+    "quote_embed",
+    "inline_quote_embeds",
+    "external_links",
+}
+
+
+# Historical core field set — these have shipped for a long time and removing
+# any of them silently would break agent/automation consumers.
+CORE_TWEET_FIELDS = {
+    "id",
+    "author_handle",
+    "content",
+    "created_at",
+    "relevance_score",
+    "categories",
+    "summary",
+    "signal_tier",
+    "tickers",
+    "bookmarked",
+    "is_retweet",
+    "reactions",
+}
+
+
+def _setup(monkeypatch, tmp_path, db_name="bc_api.db"):
+    db_path = tmp_path / db_name
+    monkeypatch.setattr("twag.web.app.get_database_path", lambda: db_path)
+    app = create_app()
+    return db_path, app
+
+
+def _insert(conn, tweet_id="t1", author_handle="alice", content="hello world", **kw):
+    assert insert_tweet(
+        conn,
+        tweet_id=tweet_id,
+        author_handle=author_handle,
+        content=content,
+        created_at=_FIXED_TS,
+        source="test",
+        **kw,
+    )
+    update_tweet_processing(
+        conn,
+        tweet_id=tweet_id,
+        relevance_score=7.0,
+        categories=["macro"],
+        summary=f"summary-{tweet_id}",
+        signal_tier="market_relevant",
+        tickers=["SPX"],
+    )
+
+
+def test_documented_display_fields_on_single_tweet(monkeypatch, tmp_path):
+    """CLAUDE.md guarantees these fields on the single-tweet endpoint."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/tweets/t1").json()
+    missing = DOCUMENTED_DISPLAY_FIELDS - set(body.keys())
+    assert not missing, (
+        f"Single-tweet response is missing fields documented in CLAUDE.md: {missing}. "
+        "Update CLAUDE.md or restore the field — do not silently drop."
+    )
+
+
+def test_documented_display_fields_on_list(monkeypatch, tmp_path):
+    """CLAUDE.md guarantees these fields on the list endpoint too."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    tweets = client.get("/api/tweets", params={"since": "9999d"}).json()["tweets"]
+    assert len(tweets) >= 1
+    missing = DOCUMENTED_DISPLAY_FIELDS - set(tweets[0].keys())
+    assert not missing, f"List-tweet response is missing CLAUDE.md fields: {missing}"
+
+
+def test_core_fields_on_single_tweet(monkeypatch, tmp_path):
+    """Long-standing core fields cannot be removed without breaking integrations."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/tweets/t1").json()
+    missing = CORE_TWEET_FIELDS - set(body.keys())
+    assert not missing, f"Single-tweet response dropped core fields: {missing}"
+
+
+def test_core_fields_on_list(monkeypatch, tmp_path):
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    tweets = client.get("/api/tweets", params={"since": "9999d"}).json()["tweets"]
+    missing = CORE_TWEET_FIELDS - set(tweets[0].keys())
+    assert not missing, f"List response dropped core fields: {missing}"
+
+
+def test_external_links_replaces_links_json(monkeypatch, tmp_path):
+    """The API exposes ``external_links``, not the raw ``links_json`` storage column."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(
+            conn,
+            content="See https://t.co/abc",
+            links=[
+                {
+                    "url": "https://t.co/abc",
+                    "expanded_url": "https://example.com/article",
+                    "display_url": "example.com/article",
+                },
+            ],
+        )
+        conn.commit()
+
+    client = TestClient(app)
+    single = client.get("/api/tweets/t1").json()
+    assert "external_links" in single
+    assert "links_json" not in single, "links_json is an internal column; never expose it"
+
+    listed = client.get("/api/tweets", params={"since": "9999d"}).json()["tweets"][0]
+    assert "external_links" in listed
+    assert "links_json" not in listed
+
+
+def test_response_is_json_object_with_tweets_key(monkeypatch, tmp_path):
+    """The list endpoint shape ``{"tweets": [...]}`` must not change."""
+    db_path, app = _setup(monkeypatch, tmp_path)
+    with get_connection(db_path) as conn:
+        _insert(conn)
+        conn.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/tweets", params={"since": "9999d"}).json()
+    assert isinstance(body, dict)
+    assert "tweets" in body
+    assert isinstance(body["tweets"], list)

--- a/tests/test_backward_compatibility_cli.py
+++ b/tests/test_backward_compatibility_cli.py
@@ -1,0 +1,105 @@
+"""Backward-compatibility guards for the CLI surface.
+
+Pins every command listed in CLAUDE.md and SKILL.md so that renames or
+removals fail loudly in CI rather than silently breaking user shell scripts,
+cron jobs, and OpenClaw automations.
+"""
+
+import rich_click as click
+
+from twag.cli import cli as root_cli
+
+
+def _command_names(group: click.Group) -> set[str]:
+    return set(group.commands.keys())
+
+
+def _subcommand_names(group: click.Group, name: str) -> set[str]:
+    sub = group.commands.get(name)
+    assert isinstance(sub, click.Group), f"Expected '{name}' to be a click group, got {type(sub).__name__}"
+    return set(sub.commands.keys())
+
+
+# Top-level commands documented in CLAUDE.md and SKILL.md.
+EXPECTED_TOP_LEVEL = {
+    "init",
+    "doctor",
+    "fetch",
+    "process",
+    "analyze",
+    "digest",
+    "accounts",
+    "narratives",
+    "stats",
+    "prune",
+    "export",
+    "config",
+    "db",
+    "search",
+    "web",
+}
+
+EXPECTED_ACCOUNTS_SUBS = {
+    "list",
+    "add",
+    "promote",
+    "demote",
+    "mute",
+    "boost",
+    "decay",
+    "import",
+}
+
+EXPECTED_NARRATIVES_SUBS = {"list"}
+
+EXPECTED_CONFIG_SUBS = {"show", "path", "set"}
+
+EXPECTED_DB_SUBS = {
+    "path",
+    "shell",
+    "init",
+    "rebuild-fts",
+    "dump",
+    "restore",
+}
+
+
+def test_top_level_commands_registered():
+    actual = _command_names(root_cli)
+    missing = EXPECTED_TOP_LEVEL - actual
+    assert not missing, (
+        f"Top-level CLI commands documented in CLAUDE.md/SKILL.md are not registered: {missing}. "
+        "Either restore the command or remove it from the docs."
+    )
+
+
+def test_accounts_subcommands_registered():
+    actual = _subcommand_names(root_cli, "accounts")
+    missing = EXPECTED_ACCOUNTS_SUBS - actual
+    assert not missing, f"twag accounts is missing documented subcommands: {missing}"
+
+
+def test_narratives_subcommands_registered():
+    actual = _subcommand_names(root_cli, "narratives")
+    missing = EXPECTED_NARRATIVES_SUBS - actual
+    assert not missing, f"twag narratives is missing documented subcommands: {missing}"
+
+
+def test_config_subcommands_registered():
+    actual = _subcommand_names(root_cli, "config")
+    missing = EXPECTED_CONFIG_SUBS - actual
+    assert not missing, f"twag config is missing documented subcommands: {missing}"
+
+
+def test_db_subcommands_registered():
+    actual = _subcommand_names(root_cli, "db")
+    missing = EXPECTED_DB_SUBS - actual
+    assert not missing, f"twag db is missing documented subcommands: {missing}"
+
+
+def test_re_exports_for_test_monkeypatching():
+    """``twag.cli`` re-exports DB symbols that downstream tests monkeypatch."""
+    import twag.cli as cli_mod
+
+    for name in ("get_connection", "get_tweet_by_id", "get_unprocessed_tweets", "init_db"):
+        assert hasattr(cli_mod, name), f"twag.cli must re-export {name}"

--- a/tests/test_backward_compatibility_config.py
+++ b/tests/test_backward_compatibility_config.py
@@ -1,0 +1,120 @@
+"""Backward-compatibility guards for config loading.
+
+Existing user installs may have a minimal config.json that doesn't include
+keys added in later versions. ``load_config`` must keep working for those
+users by falling back to ``DEFAULT_CONFIG`` for any missing key — never by
+demanding a key be present.
+"""
+
+import json
+
+import twag.config as config_mod
+
+
+def _isolate_config(monkeypatch, tmp_path, payload: dict | None) -> None:
+    """Point ``twag.config`` at a tmp_path-based config and clear its cache."""
+    cfg_dir = tmp_path / "twag"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg_path = cfg_dir / "config.json"
+    if payload is not None:
+        cfg_path.write_text(json.dumps(payload))
+
+    monkeypatch.setattr(config_mod, "get_config_path", lambda: cfg_path)
+    monkeypatch.setattr(config_mod, "_config_cache", None, raising=False)
+
+
+def test_minimal_legacy_config_loads_without_error(monkeypatch, tmp_path):
+    """A legacy config with only a single key must merge against defaults."""
+    legacy = {"scoring": {"min_score_for_digest": 5}}
+    _isolate_config(monkeypatch, tmp_path, legacy)
+
+    cfg = config_mod.load_config()
+
+    # User-provided value preserved.
+    assert cfg["scoring"]["min_score_for_digest"] == 5
+    # Newer keys still come through from defaults.
+    assert "high_signal_threshold" in cfg["scoring"]
+    assert "alert_threshold" in cfg["scoring"]
+    # Newer top-level sections still come through from defaults.
+    assert "llm" in cfg
+    assert "notifications" in cfg
+    assert "fetch" in cfg
+    assert "bird" in cfg
+
+
+def test_empty_config_loads_with_defaults(monkeypatch, tmp_path):
+    _isolate_config(monkeypatch, tmp_path, {})
+
+    cfg = config_mod.load_config()
+    assert cfg["scoring"]["min_score_for_digest"] == config_mod.DEFAULT_CONFIG["scoring"]["min_score_for_digest"]
+    assert cfg["llm"]["triage_provider"] == config_mod.DEFAULT_CONFIG["llm"]["triage_provider"]
+
+
+def test_missing_config_file_uses_defaults(monkeypatch, tmp_path):
+    """No config file at all must not break — fall back to defaults entirely."""
+    _isolate_config(monkeypatch, tmp_path, payload=None)
+
+    cfg = config_mod.load_config()
+    assert cfg == config_mod.DEFAULT_CONFIG or cfg["scoring"] == config_mod.DEFAULT_CONFIG["scoring"]
+
+
+def test_data_dir_falls_back_for_legacy_config(monkeypatch, tmp_path):
+    """A legacy config without paths.data_dir must still resolve a data dir."""
+    monkeypatch.delenv("TWAG_DATA_DIR", raising=False)
+    legacy = {"scoring": {"min_score_for_digest": 5}}
+    _isolate_config(monkeypatch, tmp_path, legacy)
+
+    fake_xdg = tmp_path / "xdg-data"
+    monkeypatch.setattr(config_mod, "get_xdg_data_home", lambda: fake_xdg)
+
+    data_dir = config_mod.get_data_dir()
+    assert data_dir == fake_xdg / config_mod.APP_NAME
+
+    db_path = config_mod.get_database_path()
+    assert db_path == fake_xdg / config_mod.APP_NAME / "twag.db"
+
+    following_path = config_mod.get_following_path()
+    assert following_path == fake_xdg / config_mod.APP_NAME / "following.txt"
+
+
+def test_legacy_config_does_not_corrupt_cache(monkeypatch, tmp_path):
+    """Loading a legacy config twice returns equivalent results.
+
+    Guards against shared mutable state between cache hits — a caller mutating
+    one returned dict must not break the next caller.
+    """
+    legacy = {"scoring": {"min_score_for_digest": 5}}
+    _isolate_config(monkeypatch, tmp_path, legacy)
+
+    first = config_mod.load_config()
+    first["scoring"]["min_score_for_digest"] = 999
+    first["llm"]["triage_provider"] = "mutated"
+
+    second = config_mod.load_config()
+    assert second["scoring"]["min_score_for_digest"] == 5
+    assert second["llm"]["triage_provider"] == config_mod.DEFAULT_CONFIG["llm"]["triage_provider"]
+
+
+def test_required_default_keys_exist():
+    """Sanity check on the defaults contract itself.
+
+    These keys are read directly by various modules; if any of them disappears
+    from DEFAULT_CONFIG, calling code will silently break for users with old
+    config files (since their config wouldn't have them either).
+    """
+    required_paths = [
+        ("llm", "triage_provider"),
+        ("llm", "triage_model"),
+        ("scoring", "min_score_for_digest"),
+        ("scoring", "high_signal_threshold"),
+        ("scoring", "alert_threshold"),
+        ("notifications", "telegram_enabled"),
+        ("accounts", "decay_rate"),
+        ("fetch", "tier1_delay"),
+        ("bird", "auth_token_env"),
+    ]
+    for path in required_paths:
+        node = config_mod.DEFAULT_CONFIG
+        for key in path:
+            assert key in node, f"DEFAULT_CONFIG is missing required key: {'.'.join(path)}"
+            node = node[key]

--- a/tests/test_backward_compatibility_db.py
+++ b/tests/test_backward_compatibility_db.py
@@ -1,0 +1,295 @@
+"""Backward-compatibility guards for the SQLite schema.
+
+Pins the contract that ``init_db`` must be able to upgrade an older database
+in place — adding any new columns/tables/indexes without losing existing
+rows. If a column is added to ``schema.py`` but not to the migration block in
+``connection.py``, opening a legacy DB would raise ``OperationalError`` on
+read paths; these tests catch that gap.
+"""
+
+import sqlite3
+
+from twag.db import get_connection, init_db
+from twag.db.schema import SCHEMA
+
+# Minimum legacy column sets — what an older DB might contain. Every column
+# added beyond this set must have an ``ALTER TABLE ... ADD COLUMN`` rule in
+# ``_run_migrations`` so opening an old DB doesn't fail.
+_LEGACY_TWEETS_COLUMNS = {
+    "id",
+    "author_handle",
+    "author_name",
+    "content",
+    "created_at",
+    "first_seen_at",
+    "source",
+    "processed_at",
+    "relevance_score",
+    "category",
+    "summary",
+    "signal_tier",
+    "tickers",
+    "has_quote",
+    "quote_tweet_id",
+    "has_media",
+    "media_analysis",
+    "has_link",
+    "link_summary",
+    "included_in_digest",
+}
+
+_LEGACY_ACCOUNTS_COLUMNS = {
+    "handle",
+    "display_name",
+    "tier",
+    "weight",
+    "category",
+    "tweets_seen",
+    "tweets_kept",
+    "avg_relevance_score",
+    "last_high_signal_at",
+    "added_at",
+    "auto_promoted",
+    "muted",
+}
+
+# Tables that newer code expects to find. If a table is added to schema.py
+# without a ``CREATE TABLE IF NOT EXISTS`` reachable from ``init_db``, this
+# test breaks before users hit a runtime error.
+_REQUIRED_TABLES = {
+    "tweets",
+    "accounts",
+    "narratives",
+    "tweet_narratives",
+    "fetch_log",
+    "reactions",
+    "prompts",
+    "prompt_history",
+    "context_commands",
+    "alert_log",
+    "metrics",
+    "llm_usage",
+    "media_analysis_cache",
+    "tweets_fts",
+}
+
+_REQUIRED_INDEXES = {
+    "idx_tweets_processed_score",
+    "idx_tweets_author",
+    "idx_tweets_signal_tier",
+    "idx_tweets_bookmarked",
+    "idx_tweets_quote",
+    "idx_fetch_log_endpoint",
+    "idx_reactions_tweet",
+    "idx_prompt_history_name",
+    "idx_alert_log_sent",
+    "idx_metrics_name",
+    "idx_llm_usage_called_at",
+    "idx_media_analysis_cache_updated",
+}
+
+
+def _create_legacy_db(db_path) -> None:
+    """Create a synthetic legacy DB with only the original columns."""
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE tweets (
+            id TEXT PRIMARY KEY,
+            author_handle TEXT NOT NULL,
+            author_name TEXT,
+            content TEXT NOT NULL,
+            created_at TIMESTAMP,
+            first_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            source TEXT,
+            processed_at TIMESTAMP,
+            relevance_score REAL,
+            category TEXT,
+            summary TEXT,
+            signal_tier TEXT,
+            tickers TEXT,
+            has_quote INTEGER DEFAULT 0,
+            quote_tweet_id TEXT,
+            has_media INTEGER DEFAULT 0,
+            media_analysis TEXT,
+            has_link INTEGER DEFAULT 0,
+            link_summary TEXT,
+            included_in_digest TEXT
+        );
+        CREATE TABLE accounts (
+            handle TEXT PRIMARY KEY,
+            display_name TEXT,
+            tier INTEGER DEFAULT 2,
+            weight REAL DEFAULT 50.0,
+            category TEXT,
+            tweets_seen INTEGER DEFAULT 0,
+            tweets_kept INTEGER DEFAULT 0,
+            avg_relevance_score REAL,
+            last_high_signal_at TIMESTAMP,
+            added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            auto_promoted INTEGER DEFAULT 0,
+            muted INTEGER DEFAULT 0
+        );
+        """,
+    )
+    conn.execute(
+        "INSERT INTO tweets (id, author_handle, content, summary, signal_tier, tickers, has_quote) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("legacy-1", "alice", "Fed pivot incoming", "fed pivot", "high_signal", "TLT,GLD", 0),
+    )
+    conn.execute(
+        "INSERT INTO tweets (id, author_handle, content, summary, signal_tier, tickers, has_quote) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("legacy-2", "bob", "AAPL earnings beat", "aapl beat", "market_relevant", "AAPL", 0),
+    )
+    conn.execute(
+        "INSERT INTO accounts (handle, tier, weight) VALUES (?, ?, ?)",
+        ("alice", 1, 80.0),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _current_tweet_columns() -> set[str]:
+    """Parse ``schema.py`` SCHEMA to extract the current tweets column set."""
+    # Use a temp in-memory DB to ask SQLite what columns the current SCHEMA defines.
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(SCHEMA)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(tweets)").fetchall()}
+    conn.close()
+    return cols
+
+
+def _current_account_columns() -> set[str]:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(SCHEMA)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(accounts)").fetchall()}
+    conn.close()
+    return cols
+
+
+def test_legacy_db_gets_all_current_tweet_columns(tmp_path):
+    """Every column in the current schema must exist after init_db on a legacy DB."""
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path)
+
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        actual = {row[1] for row in conn.execute("PRAGMA table_info(tweets)").fetchall()}
+
+    expected = _current_tweet_columns()
+    missing = expected - actual
+    assert not missing, (
+        f"init_db failed to add these tweets columns to a legacy DB: {missing}. "
+        "Add an ALTER TABLE rule in twag/db/connection.py:_run_migrations."
+    )
+
+
+def test_legacy_db_gets_all_current_account_columns(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path)
+
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        actual = {row[1] for row in conn.execute("PRAGMA table_info(accounts)").fetchall()}
+
+    expected = _current_account_columns()
+    missing = expected - actual
+    assert not missing, f"init_db failed to add accounts columns: {missing}"
+
+
+def test_legacy_db_gets_all_required_tables(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path)
+
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual')").fetchall()
+        }
+        # FTS5 reports as a regular table in sqlite_master.
+
+    missing = _REQUIRED_TABLES - tables
+    assert not missing, f"init_db failed to create tables on legacy DB: {missing}"
+
+
+def test_legacy_db_gets_required_indexes(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path)
+
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        indexes = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()}
+
+    missing = _REQUIRED_INDEXES - indexes
+    assert not missing, f"init_db failed to create required indexes: {missing}"
+
+
+def test_legacy_rows_survive_migration(tmp_path):
+    """Existing rows must remain intact and queryable after init_db."""
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path)
+
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        rows = list(conn.execute("SELECT id, author_handle, content FROM tweets ORDER BY id"))
+        assert len(rows) == 2
+        assert rows[0]["id"] == "legacy-1"
+        assert rows[0]["author_handle"] == "alice"
+        assert "Fed pivot" in rows[0]["content"]
+        assert rows[1]["id"] == "legacy-2"
+
+        accts = list(conn.execute("SELECT handle, tier, weight FROM accounts"))
+        assert len(accts) == 1
+        assert accts[0]["handle"] == "alice"
+        assert accts[0]["tier"] == 1
+
+
+def test_legacy_db_fts_is_populated(tmp_path):
+    """FTS index must be backfilled from existing rows during init_db."""
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path)
+
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        result = conn.execute("SELECT rowid FROM tweets_fts WHERE tweets_fts MATCH 'Fed'").fetchall()
+        assert len(result) >= 1, "FTS index was not populated from existing tweets"
+
+        result = conn.execute("SELECT rowid FROM tweets_fts WHERE tweets_fts MATCH 'AAPL'").fetchall()
+        assert len(result) >= 1
+
+
+def test_legacy_columns_subset_of_current(tmp_path):
+    """Sanity check that our legacy column set is actually a subset of current.
+
+    Guards against accidental drift: if someone removes a 'legacy' column from
+    schema.py the test for migration completeness becomes meaningless.
+    """
+    current_tweets = _current_tweet_columns()
+    current_accounts = _current_account_columns()
+
+    drifted = _LEGACY_TWEETS_COLUMNS - current_tweets
+    assert not drifted, f"Legacy tweet columns no longer in current schema: {drifted}"
+
+    drifted = _LEGACY_ACCOUNTS_COLUMNS - current_accounts
+    assert not drifted, f"Legacy account columns no longer in current schema: {drifted}"
+
+
+def test_init_db_is_idempotent(tmp_path):
+    """Running init_db twice on a legacy DB must not error or duplicate rows."""
+    db_path = tmp_path / "legacy.db"
+    _create_legacy_db(db_path)
+
+    init_db(db_path)
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM tweets").fetchone()[0]
+        assert count == 2

--- a/tests/test_media_analysis_cache.py
+++ b/tests/test_media_analysis_cache.py
@@ -1,0 +1,109 @@
+"""Tests for persistent media analysis caching."""
+
+import twag.processor.triage as triage_mod
+from twag.db import get_cached_media_analysis, get_connection, init_db, record_media_analysis
+from twag.scorer import MediaAnalysisResult
+
+
+def test_record_and_read_media_analysis_cache(tmp_path) -> None:
+    db_path = tmp_path / "media-cache.db"
+    init_db(db_path)
+
+    record_media_analysis(
+        "https://example.com/chart.png",
+        provider="gemini",
+        model="gemini-3-flash-preview",
+        result={
+            "kind": "chart",
+            "short_description": "Chart",
+            "prose_text": "Revenue 100",
+            "prose_summary": "Revenue rises",
+            "chart": {"insight": "Up"},
+            "table": {},
+        },
+        db_path=db_path,
+    )
+
+    cached = get_cached_media_analysis(
+        "https://example.com/chart.png",
+        provider="gemini",
+        model="gemini-3-flash-preview",
+        db_path=db_path,
+    )
+
+    assert cached is not None
+    assert cached["kind"] == "chart"
+    assert cached["chart"]["insight"] == "Up"
+
+
+def test_analyze_media_items_reuses_cache(monkeypatch) -> None:
+    cache = {
+        "https://example.com/cached.png": {
+            "kind": "chart",
+            "short_description": "Cached chart",
+            "prose_text": "Cached text",
+            "prose_summary": "Cached summary",
+            "chart": {"insight": "Cached"},
+            "table": {},
+        },
+    }
+    analyzed_urls: list[str] = []
+    recorded_urls: list[str] = []
+
+    monkeypatch.setattr(
+        triage_mod,
+        "load_config",
+        lambda: {
+            "llm": {
+                "vision_model": "gemini-3-flash-preview",
+                "vision_provider": "gemini",
+            },
+        },
+    )
+
+    def _get_cached_media_analysis(url, *, provider, model):
+        return cache.get(url)
+
+    def _record_media_analysis(url, *, provider, model, result) -> None:
+        recorded_urls.append(url)
+
+    monkeypatch.setattr(triage_mod, "get_cached_media_analysis", _get_cached_media_analysis)
+    monkeypatch.setattr(triage_mod, "record_media_analysis", _record_media_analysis)
+
+    def _fake_analyze_media(url, model=None, provider=None):
+        analyzed_urls.append(url)
+        return MediaAnalysisResult(
+            kind="table",
+            short_description="Fresh table",
+            prose_text="Fresh text",
+            prose_summary="Fresh summary",
+            chart={},
+            table={"summary": "Fresh"},
+        )
+
+    monkeypatch.setattr(triage_mod, "analyze_media", _fake_analyze_media)
+
+    items, updated = triage_mod._analyze_media_items(
+        [
+            {"url": "https://example.com/cached.png"},
+            {"url": "https://example.com/fresh.png"},
+        ],
+    )
+
+    assert updated is True
+    assert analyzed_urls == ["https://example.com/fresh.png"]
+    assert recorded_urls == ["https://example.com/fresh.png"]
+    assert items[0]["short_description"] == "Cached chart"
+    assert items[1]["short_description"] == "Fresh table"
+
+
+def test_media_analysis_cache_migrates_with_init_db(tmp_path) -> None:
+    db_path = tmp_path / "schema.db"
+    init_db(db_path)
+
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='media_analysis_cache'",
+        ).fetchone()
+
+    assert row is not None

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,6 +1,7 @@
 """Tests for twag.notifier — alert formatting and send-gating logic."""
 
 import logging
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import httpx
@@ -192,7 +193,17 @@ def test_send_telegram_alert_returns_true_on_success(monkeypatch):
     class FakeResponse:
         status_code = 200
 
+    @contextmanager
+    def _fake_connection():
+        class FakeConnection:
+            def commit(self):
+                return None
+
+        yield FakeConnection()
+
     monkeypatch.setattr("twag.notifier.httpx.post", lambda *a, **kw: FakeResponse())
+    monkeypatch.setattr("twag.notifier.get_connection", _fake_connection)
+    monkeypatch.setattr("twag.notifier.log_alert", lambda *a, **kw: None)
 
     result = send_telegram_alert("test message")
     assert result is True

--- a/tests/test_processor_parallelization.py
+++ b/tests/test_processor_parallelization.py
@@ -220,6 +220,9 @@ def test_enrich_high_signal_prefers_local_quote_row(monkeypatch, tmp_path) -> No
 
     assert len(results) == 1
     assert seen["quoted_tweet"] == "@quotedacct: Quoted local context"
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute("SELECT analysis_json FROM tweets WHERE id = ?", ("main-1",)).fetchone()
+    assert row["analysis_json"] is not None
 
 
 def test_triage_parallel_db_access_stays_on_owner_thread(monkeypatch, tmp_path) -> None:
@@ -414,6 +417,9 @@ def test_enrich_high_signal_parallel_db_access_stays_on_owner_thread(monkeypatch
     results = pipeline_mod.enrich_high_signal(limit=5, enrich_model="dummy-model")
 
     assert len(results) == 1
+    with get_connection(db_path, readonly=True) as conn:
+        row = conn.execute("SELECT analysis_json FROM tweets WHERE id = ?", ("main-1",)).fetchone()
+    assert row["analysis_json"] is not None
 
 
 def test_expand_links_parallel_db_access_stays_on_owner_thread(monkeypatch, tmp_path) -> None:

--- a/twag/config.py
+++ b/twag/config.py
@@ -32,9 +32,10 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "alert_threshold": 8,
         "batch_size": 15,
         "min_score_for_reprocess": 3,
-        "min_score_for_media": 3,
-        "min_score_for_analysis": 3,
+        "min_score_for_media": 5,
+        "min_score_for_analysis": 7,
         "min_score_for_article_processing": 5,
+        "max_article_summary_chars": 20_000,
     },
     "notifications": {
         "telegram_enabled": True,

--- a/twag/config.py
+++ b/twag/config.py
@@ -33,7 +33,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "batch_size": 15,
         "min_score_for_reprocess": 3,
         "min_score_for_media": 5,
-        "min_score_for_analysis": 7,
+        "min_score_for_analysis": 6,
         "min_score_for_article_processing": 5,
         "max_article_summary_chars": 20_000,
     },

--- a/twag/db/__init__.py
+++ b/twag/db/__init__.py
@@ -36,6 +36,12 @@ from .maintenance import (
     prune_old_tweets,
     restore_sql,
 )
+from .media_cache import (
+    ensure_media_analysis_cache_table,
+    get_cached_media_analysis,
+    increment_media_analysis_cache_hit,
+    record_media_analysis,
+)
 from .narratives import (
     archive_stale_narratives,
     get_active_narratives,
@@ -120,6 +126,7 @@ __all__ = [
     "demote_account",
     "dump_sql",
     "ensure_llm_usage_table",
+    "ensure_media_analysis_cache_table",
     "estimate_cost_usd",
     "get_accounts",
     "get_active_narratives",
@@ -127,6 +134,7 @@ __all__ = [
     "get_all_prompts",
     "get_authors_to_promote",
     "get_bookmark_counts_by_author",
+    "get_cached_media_analysis",
     "get_connection",
     "get_context_command",
     "get_feed_tweets",
@@ -144,6 +152,7 @@ __all__ = [
     "get_tweets_by_ids",
     "get_tweets_for_digest",
     "get_unprocessed_tweets",
+    "increment_media_analysis_cache_hit",
     "init_db",
     "insert_reaction",
     "insert_tweet",
@@ -161,6 +170,7 @@ __all__ = [
     "query_suggests_equity_context",
     "rebuild_fts",
     "record_llm_usage",
+    "record_media_analysis",
     "restore_sql",
     "rollback_prompt",
     "search_tweets",

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -26,6 +26,10 @@ def init_db(db_path: Path | None = None) -> None:
     for attempt in range(max_attempts):
         try:
             with get_connection(db_path) as conn:
+                # Add legacy columns BEFORE executescript so SCHEMA's CREATE INDEX
+                # statements (e.g. idx_tweets_bookmarked) don't trip on missing columns
+                # when upgrading an old DB.
+                _migrate_legacy_columns(conn)
                 conn.executescript(SCHEMA)
                 _run_migrations(conn)
                 conn.commit()
@@ -75,6 +79,31 @@ def executemany_with_retry(conn: sqlite3.Connection, sql: str, seq_of_params):
 def commit_with_retry(conn: sqlite3.Connection) -> None:
     """Commit with retries when SQLite reports a transient lock."""
     _with_lock_retry("sqlite commit", conn.commit)
+
+
+def _migrate_legacy_columns(conn: sqlite3.Connection) -> None:
+    """Add columns that newer SCHEMA indexes depend on.
+
+    Runs before ``executescript(SCHEMA)`` so that index definitions referencing
+    post-original columns (e.g. ``idx_tweets_bookmarked`` on ``bookmarked``)
+    don't fail when upgrading a legacy DB.
+    """
+    # Skip on a fresh DB — no tweets table means executescript will create it.
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='tweets'")
+    if not cursor.fetchone():
+        return
+
+    cursor = conn.execute("PRAGMA table_info(tweets)")
+    tweet_columns = {row[1] for row in cursor.fetchall()}
+
+    if "bookmarked" not in tweet_columns:
+        conn.execute("ALTER TABLE tweets ADD COLUMN bookmarked INTEGER DEFAULT 0")
+    if "bookmarked_at" not in tweet_columns:
+        conn.execute("ALTER TABLE tweets ADD COLUMN bookmarked_at TIMESTAMP")
+    if "quote_tweet_id" not in tweet_columns:
+        conn.execute("ALTER TABLE tweets ADD COLUMN quote_tweet_id TEXT")
+    if "in_reply_to_tweet_id" not in tweet_columns:
+        conn.execute("ALTER TABLE tweets ADD COLUMN in_reply_to_tweet_id TEXT")
 
 
 def _run_migrations(conn: sqlite3.Connection) -> None:

--- a/twag/db/connection.py
+++ b/twag/db/connection.py
@@ -219,6 +219,11 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
 
     ensure_llm_usage_table(conn)
 
+    # Ensure persistent media analysis cache exists
+    from .media_cache import ensure_media_analysis_cache_table
+
+    ensure_media_analysis_cache_table(conn)
+
 
 def _init_fts(conn: sqlite3.Connection) -> None:
     """Initialize FTS5 virtual table and triggers."""

--- a/twag/db/media_cache.py
+++ b/twag/db/media_cache.py
@@ -1,0 +1,140 @@
+"""Persistent cache for media analysis results."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import sqlite3
+    from pathlib import Path
+
+from .connection import commit_with_retry, get_connection
+
+log = logging.getLogger(__name__)
+
+MEDIA_ANALYSIS_CACHE_SQL = """
+CREATE TABLE IF NOT EXISTS media_analysis_cache (
+    media_url TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    hit_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (media_url, provider, model)
+);
+CREATE INDEX IF NOT EXISTS idx_media_analysis_cache_updated
+ON media_analysis_cache(updated_at DESC);
+"""
+
+
+def ensure_media_analysis_cache_table(conn: sqlite3.Connection) -> None:
+    """Create the media analysis cache table."""
+    conn.executescript(MEDIA_ANALYSIS_CACHE_SQL)
+
+
+def _normalize_key(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def get_cached_media_analysis(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    db_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Return cached media analysis for a URL/provider/model, if present."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return None
+
+    try:
+        with get_connection(db_path, readonly=True) as conn:
+            row = conn.execute(
+                """
+                SELECT result_json
+                FROM media_analysis_cache
+                WHERE media_url = ? AND provider = ? AND model = ?
+                """,
+                (url, provider_key, model_key),
+            ).fetchone()
+        if row is None:
+            return None
+        data = json.loads(row["result_json"])
+        return data if isinstance(data, dict) else None
+    except Exception:
+        log.debug("Failed to read media analysis cache", exc_info=True)
+        return None
+
+
+def record_media_analysis(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    result: dict[str, Any],
+    db_path: Path | None = None,
+) -> None:
+    """Persist a media analysis result; cache failures do not affect processing."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return
+
+    try:
+        payload = json.dumps(result, sort_keys=True)
+        now = datetime.now(timezone.utc).isoformat()
+        with get_connection(db_path) as conn:
+            ensure_media_analysis_cache_table(conn)
+            conn.execute(
+                """
+                INSERT INTO media_analysis_cache (
+                    media_url, provider, model, result_json, hit_count, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, 0, ?, ?)
+                ON CONFLICT(media_url, provider, model) DO UPDATE SET
+                    result_json = excluded.result_json,
+                    updated_at = excluded.updated_at
+                """,
+                (url, provider_key, model_key, payload, now, now),
+            )
+            commit_with_retry(conn)
+    except Exception:
+        log.debug("Failed to write media analysis cache", exc_info=True)
+
+
+def increment_media_analysis_cache_hit(
+    media_url: str,
+    *,
+    provider: str | None,
+    model: str | None,
+    db_path: Path | None = None,
+) -> None:
+    """Best-effort increment for cache hit observability."""
+    url = (media_url or "").strip()
+    provider_key = _normalize_key(provider)
+    model_key = _normalize_key(model)
+    if not url or not provider_key or not model_key:
+        return
+
+    try:
+        with get_connection(db_path) as conn:
+            conn.execute(
+                """
+                UPDATE media_analysis_cache
+                SET hit_count = hit_count + 1,
+                    updated_at = ?
+                WHERE media_url = ? AND provider = ? AND model = ?
+                """,
+                (datetime.now(timezone.utc).isoformat(), url, provider_key, model_key),
+            )
+            commit_with_retry(conn)
+    except Exception:
+        log.debug("Failed to update media analysis cache hit count", exc_info=True)

--- a/twag/db/schema.py
+++ b/twag/db/schema.py
@@ -224,6 +224,20 @@ CREATE TABLE IF NOT EXISTS llm_usage (
 CREATE INDEX IF NOT EXISTS idx_llm_usage_called_at ON llm_usage(called_at);
 CREATE INDEX IF NOT EXISTS idx_llm_usage_component ON llm_usage(component, called_at);
 CREATE INDEX IF NOT EXISTS idx_llm_usage_provider_model ON llm_usage(provider, model, called_at);
+
+-- Media analysis cache: reuse OCR/chart extraction across duplicate media URLs
+CREATE TABLE IF NOT EXISTS media_analysis_cache (
+    media_url TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    hit_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (media_url, provider, model)
+);
+CREATE INDEX IF NOT EXISTS idx_media_analysis_cache_updated
+ON media_analysis_cache(updated_at DESC);
 """
 
 # FTS5 schema for full-text search

--- a/twag/processor/pipeline.py
+++ b/twag/processor/pipeline.py
@@ -16,6 +16,7 @@ from ..config import load_config
 from ..db import (
     get_accounts,
     get_connection,
+    get_tweet_by_id,
     get_tweets_by_ids,
     get_unprocessed_tweets,
 )
@@ -25,6 +26,7 @@ from ..scorer import EnrichmentResult, TriageResult, enrich_tweet
 from .dependencies import _expand_links_for_rows, _expand_unprocessed_with_dependencies
 from .triage import (
     _normalized_worker_count,
+    _save_enrichment_result,
     _triage_rows,
     ensure_media_analysis,
 )
@@ -51,7 +53,7 @@ def process_unprocessed(
     config = load_config()
     batch_size = config["scoring"]["batch_size"]
     high_threshold = config["scoring"]["high_signal_threshold"]
-    media_min_score = config["scoring"].get("min_score_for_media", 3)
+    media_min_score = config["scoring"].get("min_score_for_media", 5)
     quote_depth = config.get("fetch", {}).get("quote_depth", 0)
     quote_delay = config.get("fetch", {}).get("quote_delay", 1.0)
     url_expansion_workers = _normalized_worker_count(
@@ -230,7 +232,7 @@ def reprocess_today_quoted(
             tier1_handles=tier1_handles,
             update_stats=False,
             allow_summarize=False,
-            media_min_score=config["scoring"].get("min_score_for_media", 3),
+            media_min_score=config["scoring"].get("min_score_for_media", 5),
             progress_cb=progress_cb,
             status_cb=status_cb,
         )
@@ -265,8 +267,8 @@ def enrich_high_signal(
             WHERE relevance_score >= ?
             AND signal_tier IS NOT NULL
             AND (
+                analysis_json IS NULL OR
                 (has_quote = 1 AND quote_tweet_id IS NOT NULL AND media_analysis IS NULL)
-                OR (has_link = 1 AND link_summary IS NULL)
                 OR (has_media = 1 AND media_analysis IS NULL)
             )
             ORDER BY relevance_score DESC
@@ -316,6 +318,8 @@ def enrich_high_signal(
 
                 media_items = ensure_media_analysis(conn, tweet)
                 media_context = build_media_context(media_items) if media_items else (tweet["media_analysis"] or "")
+                if tweet["analysis_json"]:
+                    continue
 
                 author_category = account_categories.get(tweet["author_handle"]) or "unknown"
 
@@ -330,7 +334,7 @@ def enrich_high_signal(
                         image_description=media_context,
                         model=enrich_model,
                     )
-                    futures[future] = (tweet["id"], tweet["signal_tier"])
+                    futures[future] = tweet["id"]
                 else:
                     result = enrich_tweet(
                         tweet_text=tweet["content"],
@@ -342,23 +346,16 @@ def enrich_high_signal(
                         model=enrich_model,
                     )
                     results.append(result)
-
-                    if result.signal_tier != tweet["signal_tier"]:
-                        conn.execute(
-                            "UPDATE tweets SET signal_tier = ? WHERE id = ?",
-                            (result.signal_tier, tweet["id"]),
-                        )
+                    _save_enrichment_result(conn, tweet["id"], tweet, result)
 
             for future in as_completed(list(futures.keys())):
-                tweet_id, current_tier = futures.pop(future)
+                tweet_id = futures.pop(future)
                 try:
                     result = future.result()
                     results.append(result)
-                    if result.signal_tier != current_tier:
-                        conn.execute(
-                            "UPDATE tweets SET signal_tier = ? WHERE id = ?",
-                            (result.signal_tier, tweet_id),
-                        )
+                    row = get_tweet_by_id(conn, tweet_id)
+                    if row:
+                        _save_enrichment_result(conn, tweet_id, row, result)
                 except Exception:
                     log.exception("Enrichment failed for tweet %s", tweet_id)
                     continue

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -411,7 +411,7 @@ def _triage_rows(
     max_vision_workers = _normalized_worker_count(config.get("llm", {}).get("max_concurrency_vision", 3), 3)
     vision_model = config["llm"].get("vision_model")
     vision_provider = config["llm"].get("vision_provider")
-    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 7)
+    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 6)
     article_min_score = config.get("scoring", {}).get("min_score_for_article_processing", 5)
     tweets_for_triage = []
     tweet_map: dict[str, sqlite3.Row] = {}

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -15,7 +15,9 @@ if TYPE_CHECKING:
 
 from ..config import load_config
 from ..db import (
+    get_cached_media_analysis,
     get_tweet_by_id,
+    record_media_analysis,
     update_account_stats,
     update_tweet_analysis,
     update_tweet_article,
@@ -149,28 +151,51 @@ def _analyze_media_items(
     vision_provider: str | None = None,
 ) -> tuple[list[dict[str, Any]], bool]:
     updated = False
+    config = load_config()
+    effective_model = vision_model or config["llm"].get("vision_model")
+    effective_provider = vision_provider or config["llm"].get("vision_provider")
     for item in media_items:
         if item.get("kind") or item.get("prose_text") or item.get("short_description"):
             continue
         url = item.get("url")
         if not url:
             continue
+        cached = get_cached_media_analysis(url, provider=effective_provider, model=effective_model)
+        if cached:
+            _apply_media_analysis_to_item(item, cached)
+            updated = True
+            continue
         try:
             result = analyze_media(url, model=vision_model, provider=vision_provider)
         except Exception:
             continue
 
-        item["kind"] = result.kind
-        item["short_description"] = result.short_description
-        item["prose_text"] = result.prose_text
-        item["prose_summary"] = result.prose_summary
-        item["chart"] = result.chart
+        result_payload = {
+            "kind": result.kind,
+            "short_description": result.short_description,
+            "prose_text": result.prose_text,
+            "prose_summary": result.prose_summary,
+            "chart": result.chart,
+            "table": result.table,
+        }
+        _apply_media_analysis_to_item(item, result_payload)
+        record_media_analysis(url, provider=effective_provider, model=effective_model, result=result_payload)
         updated = True
 
     if _merge_document_media(media_items):
         updated = True
 
     return media_items, updated
+
+
+def _apply_media_analysis_to_item(item: dict[str, Any], result: dict[str, Any]) -> None:
+    """Copy cached or fresh media analysis fields onto a media item."""
+    item["kind"] = (result.get("kind") or "other").lower()
+    item["short_description"] = result.get("short_description", "")
+    item["prose_text"] = result.get("prose_text", "")
+    item["prose_summary"] = result.get("prose_summary", "")
+    item["chart"] = result.get("chart") or {}
+    item["table"] = result.get("table") or {}
 
 
 def _page_number_hint(text: str) -> int | None:
@@ -386,7 +411,7 @@ def _triage_rows(
     max_vision_workers = _normalized_worker_count(config.get("llm", {}).get("max_concurrency_vision", 3), 3)
     vision_model = config["llm"].get("vision_model")
     vision_provider = config["llm"].get("vision_provider")
-    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 3)
+    analysis_min_score = config.get("scoring", {}).get("min_score_for_analysis", 7)
     article_min_score = config.get("scoring", {}).get("min_score_for_article_processing", 5)
     tweets_for_triage = []
     tweet_map: dict[str, sqlite3.Row] = {}
@@ -614,7 +639,13 @@ def _triage_rows(
 
             task_count = 0
 
-            if allow_summarize and len(content) > 500 and not is_tier1 and result.score >= 5:
+            if (
+                allow_summarize
+                and len(content) > 500
+                and not is_tier1
+                and result.score >= 5
+                and (force_refresh or not tweet_row["content_summary"])
+            ):
                 if text_pool:
                     if status_cb:
                         status_cb(f"Queue summary @{handle}")

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -59,6 +59,23 @@ class XArticleSummaryResult:
     actionable_items: list[dict[str, Any]] = field(default_factory=list)
 
 
+def _bounded_article_text(article_text: str, max_chars: int) -> str:
+    """Bound long article bodies while preserving the opening and closing context."""
+    clean_text = (article_text or "").strip()
+    if len(clean_text) <= max_chars:
+        return clean_text
+    if max_chars <= 1000:
+        return clean_text[:max_chars].strip()
+
+    head_chars = int(max_chars * 0.75)
+    tail_chars = max_chars - head_chars
+    return (
+        clean_text[:head_chars].rstrip()
+        + "\n\n[...middle truncated to reduce analysis cost...]\n\n"
+        + clean_text[-tail_chars:].lstrip()
+    )
+
+
 def triage_tweets_batch(
     tweets: list[dict[str, str]],
     model: str | None = None,
@@ -202,11 +219,16 @@ def summarize_x_article(
         return XArticleSummaryResult(short_summary=(article_preview or article_title or "").strip())
 
     fallback_summary = (article_preview or article_title or clean_text[:400]).strip()
+    try:
+        max_article_chars = int(config.get("scoring", {}).get("max_article_summary_chars", 20_000))
+    except (TypeError, ValueError):
+        max_article_chars = 20_000
+    bounded_text = _bounded_article_text(clean_text, max_article_chars)
 
     prompt = ARTICLE_SUMMARY_PROMPT.format(
         article_title=(article_title or "").strip() or "[untitled]",
         article_preview=(article_preview or "").strip() or "[none]",
-        article_text=clean_text,
+        article_text=bounded_text,
     )
 
     fallback_provider = config["llm"].get("triage_provider", "gemini")


### PR DESCRIPTION
## Summary

- Add four new test modules that pin the contracts existing users depend on, so future refactors fail loudly in CI instead of silently breaking installs in the field.
- Fix a real backward-compat bug uncovered while writing the DB test: `init_db` ran `conn.executescript(SCHEMA)` before the column migrations, so `SCHEMA`'s `CREATE INDEX idx_tweets_bookmarked ON tweets(bookmarked)` tripped with `OperationalError: no such column: bookmarked` when upgrading any DB created before the bookmarks feature shipped. New `_migrate_legacy_columns` runs the column ALTERs first so index DDL succeeds.

## What's pinned

- **DB schema (`tests/test_backward_compatibility_db.py`)** — build a synthetic legacy SQLite DB with only the originally-documented columns, run `init_db`, and assert every current column / table / index now exists, prior rows survive intact, FTS is populated, and `init_db` is idempotent.
- **API response shape (`tests/test_backward_compatibility_api.py`)** — pin every field documented in CLAUDE.md (`display_content`, `quote_embed`, `inline_quote_embeds`, `external_links`) plus a core long-standing field set on both `GET /api/tweets` and `GET /api/tweets/{id}`. Forbid leaking the internal `links_json` storage column.
- **CLI surface (`tests/test_backward_compatibility_cli.py`)** — assert every command listed in CLAUDE.md and SKILL.md is registered under `twag.cli` (init/doctor/fetch/process/analyze/digest, accounts subcommands, narratives list, stats/prune/export, config show/path/set, db path/shell/init/rebuild-fts/dump/restore, search, web).
- **Config loading (`tests/test_backward_compatibility_config.py`)** — write a minimal legacy `config.json` (only one section) and verify defaults still backfill required keys, missing config falls back cleanly, returned dicts are isolated copies (cache safety), and `get_database_path` / `get_following_path` resolve to sane defaults.

## Migration gap fixed

`twag/db/connection.py:init_db` previously raised `sqlite3.OperationalError: no such column: bookmarked` when upgrading any DB created before the `bookmarked` column was added. The fix runs `_migrate_legacy_columns` first to ALTER TABLE for columns that SCHEMA's CREATE INDEX statements depend on (`bookmarked`, `bookmarked_at`, `quote_tweet_id`, `in_reply_to_tweet_id`).

## Test plan

- [x] `uv run ruff format <changed files>`
- [x] `uv run ruff check <changed files>`
- [x] `uv run ty check`
- [x] `uv run pytest -q tests/test_backward_compatibility_*.py tests/test_api_contracts.py tests/test_db_retweet_backfill.py` — 42 pass
- [x] `uv run pytest -q` (full suite) — 511 pass


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: backward-compat:/home/clifton/code/twag
task-type: backward-compat
task-title: Backward-Compatibility Checks
iterations: 1
duration: 10m57s
nightshift:metadata -->
