### PR TITLE
feat: schema evolution advisor (twag db advise)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Defined in `twag/cli/`:
 - **Query:** `search`, `narratives list`
 - **Maintenance:** `stats`, `prune`, `export`
 - **Config:** `show`, `path`, `set`
-- **Database:** `path`, `shell`, `init`, `rebuild-fts`, `dump`, `restore`
+- **Database:** `path`, `shell`, `init`, `rebuild-fts`, `dump`, `restore`, `advise`
 - **Web:** `web`
 
 If command behavior changes, update `README.md` and `SKILL.md` in the same PR.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ twag db dump                    # Backup database (auto-named file)
 twag db dump --stdout           # Backup to stdout
 twag db restore backup.sql      # Restore from backup
 twag db restore backup.sql --force  # Restore without confirmation
+twag db advise                  # Schema-evolution advisor (read-only drift report)
+twag db advise --skip-db        # Only check migrations vs declarative SCHEMA
 ```
 
 ### Web Interface

--- a/tests/db/test_schema_advisor.py
+++ b/tests/db/test_schema_advisor.py
@@ -1,0 +1,225 @@
+"""Tests for twag.db.schema_advisor."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING
+
+from twag.db.schema_advisor import (
+    analyze_database,
+    analyze_migrations,
+    parse_migrations,
+    parse_schema_sql,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SIMPLE_SCHEMA = """
+CREATE TABLE tweets (
+    id TEXT PRIMARY KEY,
+    content TEXT NOT NULL,
+    bookmarked INTEGER DEFAULT 0
+);
+CREATE INDEX idx_tweets_content ON tweets(content);
+"""
+
+
+def _build_db(path: Path, schema_sql: str) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(schema_sql)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_parse_schema_sql_extracts_tables_and_indexes() -> None:
+    snap = parse_schema_sql(SIMPLE_SCHEMA)
+
+    assert "tweets" in snap.tables
+    assert snap.tables["tweets"] == {"id", "content", "bookmarked"}
+    assert "idx_tweets_content" in snap.indexes
+
+
+def test_clean_db_matching_schema_has_no_findings(tmp_path: Path) -> None:
+    db_path = tmp_path / "clean.db"
+    _build_db(db_path, SIMPLE_SCHEMA)
+
+    report = analyze_database(db_path, schema_sql=SIMPLE_SCHEMA)
+
+    assert report.is_empty(), [f.message for f in report.findings]
+    assert not report.has_errors()
+
+
+def test_db_missing_migrated_column_warns(tmp_path: Path) -> None:
+    db_path = tmp_path / "stale.db"
+    # Live DB lacks 'bookmarked' which the schema declares
+    _build_db(
+        db_path,
+        """
+        CREATE TABLE tweets (id TEXT PRIMARY KEY, content TEXT NOT NULL);
+        CREATE INDEX idx_tweets_content ON tweets(content);
+        """,
+    )
+
+    report = analyze_database(db_path, schema_sql=SIMPLE_SCHEMA)
+
+    findings = [f for f in report.findings if f.category == "column_missing"]
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert "bookmarked" in findings[0].message
+
+
+def test_db_with_extra_column_is_info(tmp_path: Path) -> None:
+    db_path = tmp_path / "extra.db"
+    _build_db(
+        db_path,
+        """
+        CREATE TABLE tweets (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            bookmarked INTEGER DEFAULT 0,
+            ghost_field TEXT
+        );
+        CREATE INDEX idx_tweets_content ON tweets(content);
+        """,
+    )
+
+    report = analyze_database(db_path, schema_sql=SIMPLE_SCHEMA)
+
+    findings = [f for f in report.findings if f.category == "column_undeclared"]
+    assert len(findings) == 1
+    assert findings[0].severity == "info"
+    assert "ghost_field" in findings[0].message
+    assert not report.has_errors()
+
+
+def test_missing_index_is_warning(tmp_path: Path) -> None:
+    db_path = tmp_path / "noindex.db"
+    _build_db(
+        db_path,
+        """
+        CREATE TABLE tweets (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            bookmarked INTEGER DEFAULT 0
+        );
+        """,
+    )
+
+    report = analyze_database(db_path, schema_sql=SIMPLE_SCHEMA)
+
+    findings = [f for f in report.findings if f.category == "index_missing"]
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert "idx_tweets_content" in findings[0].message
+
+
+def test_undeclared_table_is_info(tmp_path: Path) -> None:
+    db_path = tmp_path / "extratable.db"
+    _build_db(
+        db_path,
+        """
+        CREATE TABLE tweets (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            bookmarked INTEGER DEFAULT 0
+        );
+        CREATE INDEX idx_tweets_content ON tweets(content);
+        CREATE TABLE legacy (id INTEGER PRIMARY KEY);
+        """,
+    )
+
+    report = analyze_database(db_path, schema_sql=SIMPLE_SCHEMA)
+
+    findings = [f for f in report.findings if f.category == "table_undeclared"]
+    assert len(findings) == 1
+    assert findings[0].severity == "info"
+    assert "legacy" in findings[0].message
+
+
+def test_missing_database_returns_error(tmp_path: Path) -> None:
+    db_path = tmp_path / "does-not-exist.db"
+
+    report = analyze_database(db_path, schema_sql=SIMPLE_SCHEMA)
+
+    assert report.has_errors()
+    assert report.findings[0].category == "database_missing"
+
+
+def test_parse_migrations_extracts_alter_table_columns() -> None:
+    source = """
+    def _run_migrations(conn):
+        if "foo" not in cols:
+            conn.execute("ALTER TABLE tweets ADD COLUMN foo TEXT")
+        if "bar" not in cols:
+            conn.execute("ALTER TABLE tweets ADD COLUMN bar INTEGER DEFAULT 0")
+        if "baz" not in cols:
+            conn.execute("ALTER TABLE accounts ADD COLUMN baz TIMESTAMP")
+    """
+
+    summary = parse_migrations(source)
+
+    assert summary.altered_columns["tweets"] == ["foo", "bar"]
+    assert summary.altered_columns["accounts"] == ["baz"]
+    assert summary.total() == 3
+
+
+def test_redundant_migration_detected() -> None:
+    schema = """
+    CREATE TABLE tweets (id TEXT PRIMARY KEY, foo TEXT, bar INTEGER);
+    """
+    migration_source = """
+    conn.execute("ALTER TABLE tweets ADD COLUMN foo TEXT")
+    conn.execute("ALTER TABLE tweets ADD COLUMN bar INTEGER DEFAULT 0")
+    """
+
+    report = analyze_migrations(schema_sql=schema, migration_source=migration_source)
+
+    redundants = [f for f in report.findings if f.category == "migration_redundant"]
+    assert len(redundants) == 2
+    assert all(f.severity == "info" for f in redundants)
+    assert not report.has_errors()
+
+
+def test_migration_drift_detected_when_column_not_in_schema() -> None:
+    schema = """
+    CREATE TABLE tweets (id TEXT PRIMARY KEY, foo TEXT);
+    """
+    migration_source = """
+    conn.execute("ALTER TABLE tweets ADD COLUMN foo TEXT")
+    conn.execute("ALTER TABLE tweets ADD COLUMN missing TEXT")
+    """
+
+    report = analyze_migrations(schema_sql=schema, migration_source=migration_source)
+
+    drifts = [f for f in report.findings if f.category == "migration_drift"]
+    assert len(drifts) == 1
+    assert drifts[0].severity == "error"
+    assert "missing" in drifts[0].message
+    assert report.has_errors()
+
+
+def test_migration_orphan_when_table_missing_in_schema() -> None:
+    schema = "CREATE TABLE other (id TEXT);"
+    migration_source = 'conn.execute("ALTER TABLE tweets ADD COLUMN foo TEXT")'
+
+    report = analyze_migrations(schema_sql=schema, migration_source=migration_source)
+
+    orphans = [f for f in report.findings if f.category == "migration_orphan"]
+    assert len(orphans) == 1
+    assert orphans[0].severity == "error"
+
+
+def test_real_schema_and_migrations_have_no_drift_errors() -> None:
+    """The shipped SCHEMA + connection.py migrations should be consistent."""
+    report = analyze_migrations()
+
+    drift = [f for f in report.findings if f.category == "migration_drift"]
+    orphans = [f for f in report.findings if f.category == "migration_orphan"]
+    duplicates = [f for f in report.findings if f.category == "migration_duplicate"]
+
+    assert drift == [], [f.message for f in drift]
+    assert orphans == [], [f.message for f in orphans]
+    assert duplicates == [], [f.message for f in duplicates]

--- a/twag/cli/db_cmd.py
+++ b/twag/cli/db_cmd.py
@@ -5,9 +5,15 @@ from datetime import datetime
 from pathlib import Path
 
 import rich_click as click
+from rich.table import Table
 
 from ..config import get_database_path
 from ..db import dump_sql, get_connection, init_db, rebuild_fts, restore_sql
+from ..db.schema_advisor import (
+    SchemaFinding,
+    analyze_database,
+    analyze_migrations,
+)
 from ._console import console
 
 
@@ -145,3 +151,77 @@ def db_restore(input_file: str, force: bool):
     except Exception as e:
         console.print(f"[red]Error restoring database: {e}[/red]")
         sys.exit(1)
+
+
+_SEVERITY_STYLE = {
+    "error": "red",
+    "warning": "yellow",
+    "info": "cyan",
+}
+
+
+def _render_findings(title: str, findings: list[SchemaFinding]) -> None:
+    if not findings:
+        console.print(f"[green]✓[/green] {title}: no findings")
+        return
+
+    table = Table(title=title, show_lines=False)
+    table.add_column("Severity", no_wrap=True)
+    table.add_column("Category", style="magenta", no_wrap=True)
+    table.add_column("Message")
+    table.add_column("Suggested action", style="dim")
+
+    for finding in findings:
+        style = _SEVERITY_STYLE.get(finding.severity, "white")
+        table.add_row(
+            f"[{style}]{finding.severity.upper()}[/{style}]",
+            finding.category,
+            finding.message,
+            finding.suggested_action or "-",
+        )
+    console.print(table)
+
+
+@db.command("advise")
+@click.option(
+    "--db-path",
+    "db_path_opt",
+    type=click.Path(),
+    default=None,
+    help="Override the database file to analyze (defaults to twag's configured DB).",
+)
+@click.option(
+    "--skip-db",
+    is_flag=True,
+    help="Skip live database analysis (useful when no DB exists yet).",
+)
+def db_advise(db_path_opt: str | None, skip_db: bool) -> None:
+    """Analyze schema drift between code and the live database.
+
+    Read-only by design — this command never mutates the database. It reports:
+
+    - Tables/columns/indexes declared in SCHEMA but missing from the database
+    - Tables/columns/indexes present in the database but undeclared in SCHEMA
+    - Migrations that add columns now also present in CREATE TABLE (informational)
+    - Migrations that add columns missing from the declarative SCHEMA (drift)
+
+    Exits non-zero if any error-level findings are present.
+    """
+    error_count = 0
+
+    if not skip_db:
+        db_file = Path(db_path_opt) if db_path_opt else get_database_path()
+        console.print(f"Analyzing database: [bold]{db_file}[/bold]")
+        db_report = analyze_database(db_file)
+        _render_findings("Database vs SCHEMA", db_report.findings)
+        error_count += len(db_report.errors())
+
+    console.print()
+    mig_report = analyze_migrations()
+    _render_findings("Migrations vs SCHEMA", mig_report.findings)
+    error_count += len(mig_report.errors())
+
+    if error_count:
+        console.print(f"\n[red]✗ {error_count} error finding(s); exiting non-zero.[/red]")
+        sys.exit(1)
+    console.print("\n[green]✓ No error-level findings.[/green]")

--- a/twag/db/schema_advisor.py
+++ b/twag/db/schema_advisor.py
@@ -1,0 +1,329 @@
+"""Schema Evolution Advisor.
+
+Analyzes drift between the declarative ``SCHEMA`` in :mod:`twag.db.schema`,
+the imperative ``ALTER TABLE`` migrations in :mod:`twag.db.connection`, and a
+live SQLite database. Read-only by design — never mutates anything.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .schema import SCHEMA
+
+Severity = str  # one of: "info", "warning", "error"
+
+
+@dataclass
+class SchemaFinding:
+    """A single observation about schema drift."""
+
+    severity: Severity
+    category: str
+    message: str
+    suggested_action: str = ""
+
+    def label(self) -> str:
+        return f"[{self.severity.upper()}] {self.category}"
+
+
+@dataclass
+class SchemaReport:
+    """Aggregate result of running the schema advisor."""
+
+    findings: list[SchemaFinding] = field(default_factory=list)
+
+    def add(self, finding: SchemaFinding) -> None:
+        self.findings.append(finding)
+
+    def errors(self) -> list[SchemaFinding]:
+        return [f for f in self.findings if f.severity == "error"]
+
+    def warnings(self) -> list[SchemaFinding]:
+        return [f for f in self.findings if f.severity == "warning"]
+
+    def has_errors(self) -> bool:
+        return any(f.severity == "error" for f in self.findings)
+
+    def is_empty(self) -> bool:
+        return not self.findings
+
+
+@dataclass
+class SchemaSnapshot:
+    """Tables, columns, and indexes loaded from a SQLite source."""
+
+    tables: dict[str, set[str]] = field(default_factory=dict)
+    indexes: set[str] = field(default_factory=set)
+    objects: dict[str, str] = field(default_factory=dict)  # name -> object type
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_from_connection(conn: sqlite3.Connection) -> SchemaSnapshot:
+    """Read tables/columns/indexes from an open SQLite connection."""
+    snap = SchemaSnapshot()
+    cursor = conn.execute(
+        "SELECT name, type FROM sqlite_master WHERE type IN ('table', 'index', 'view', 'trigger') "
+        "AND name NOT LIKE 'sqlite_%'",
+    )
+    for row in cursor.fetchall():
+        name, obj_type = row[0], row[1]
+        snap.objects[name] = obj_type
+        if obj_type == "table":
+            cols = conn.execute(f"PRAGMA table_info({name})").fetchall()
+            snap.tables[name] = {c[1] for c in cols}
+        elif obj_type == "index":
+            snap.indexes.add(name)
+    return snap
+
+
+def parse_schema_sql(sql: str | None = None) -> SchemaSnapshot:
+    """Parse a schema script by loading it into an in-memory SQLite DB.
+
+    Avoids regex parsing — we rely on SQLite's own parser by executing the
+    DDL into a throwaway in-memory database and then introspecting it.
+    """
+    script = sql if sql is not None else SCHEMA
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(script)
+        return _snapshot_from_connection(conn)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration source introspection
+# ---------------------------------------------------------------------------
+
+
+_ALTER_RE = re.compile(
+    r"ALTER\s+TABLE\s+(?P<table>[A-Za-z_][A-Za-z0-9_]*)\s+"
+    r"ADD\s+COLUMN\s+(?P<column>[A-Za-z_][A-Za-z0-9_]*)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class MigrationSummary:
+    """Per-table ALTER TABLE migrations discovered in source."""
+
+    altered_columns: dict[str, list[str]] = field(default_factory=lambda: defaultdict(list))
+
+    def total(self) -> int:
+        return sum(len(v) for v in self.altered_columns.values())
+
+
+def _connection_source_path() -> Path:
+    return Path(__file__).resolve().parent / "connection.py"
+
+
+def parse_migrations(source: str | None = None) -> MigrationSummary:
+    """Extract ALTER TABLE ... ADD COLUMN statements from connection.py."""
+    if source is None:
+        source = _connection_source_path().read_text(encoding="utf-8")
+    summary = MigrationSummary()
+    for match in _ALTER_RE.finditer(source):
+        table = match.group("table")
+        column = match.group("column")
+        summary.altered_columns[table].append(column)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+def analyze_migrations(
+    schema_sql: str | None = None,
+    migration_source: str | None = None,
+) -> SchemaReport:
+    """Compare migrations in ``connection.py`` against the declarative ``SCHEMA``.
+
+    Reports columns added through migrations that are also present in the
+    declarative ``CREATE TABLE`` (the migration is now a safety net for older
+    DBs — useful, but worth flagging as informational), and columns added via
+    migrations that are *missing* from the declarative schema (a real drift).
+    """
+    report = SchemaReport()
+    declared = parse_schema_sql(schema_sql)
+    migrations = parse_migrations(migration_source)
+
+    for table, columns in migrations.altered_columns.items():
+        declared_cols = declared.tables.get(table)
+        if declared_cols is None:
+            report.add(
+                SchemaFinding(
+                    severity="error",
+                    category="migration_orphan",
+                    message=(f"Migration adds column(s) to '{table}' but no CREATE TABLE is declared in SCHEMA."),
+                    suggested_action=f"Add CREATE TABLE {table} to twag/db/schema.py.",
+                ),
+            )
+            continue
+
+        seen: set[str] = set()
+        for column in columns:
+            if column in seen:
+                report.add(
+                    SchemaFinding(
+                        severity="warning",
+                        category="migration_duplicate",
+                        message=f"Migration adds '{table}.{column}' more than once.",
+                        suggested_action="Remove the duplicate ALTER TABLE block.",
+                    ),
+                )
+                continue
+            seen.add(column)
+            if column not in declared_cols:
+                report.add(
+                    SchemaFinding(
+                        severity="error",
+                        category="migration_drift",
+                        message=(
+                            f"Migration adds '{table}.{column}' but the column is missing from CREATE TABLE in SCHEMA."
+                        ),
+                        suggested_action=(
+                            f"Add '{column}' to the CREATE TABLE for '{table}' in "
+                            f"twag/db/schema.py so fresh installs match migrated DBs."
+                        ),
+                    ),
+                )
+            else:
+                report.add(
+                    SchemaFinding(
+                        severity="info",
+                        category="migration_redundant",
+                        message=(
+                            f"Migration ALTER for '{table}.{column}' is also declared "
+                            f"in CREATE TABLE — kept as a safety net for older DBs."
+                        ),
+                        suggested_action=("Once all live databases have run migrations, this branch can be retired."),
+                    ),
+                )
+
+    return report
+
+
+def analyze_database(
+    db_path: Path,
+    schema_sql: str | None = None,
+) -> SchemaReport:
+    """Compare a live SQLite DB at ``db_path`` against the declarative ``SCHEMA``.
+
+    The database is opened readonly. We never write or migrate.
+    """
+    report = SchemaReport()
+    if not db_path.exists():
+        report.add(
+            SchemaFinding(
+                severity="error",
+                category="database_missing",
+                message=f"Database not found at {db_path}.",
+                suggested_action="Run `twag db init` to create the database.",
+            ),
+        )
+        return report
+
+    declared = parse_schema_sql(schema_sql)
+
+    uri = f"file:{db_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=10)
+    try:
+        live = _snapshot_from_connection(conn)
+    finally:
+        conn.close()
+
+    # Tables declared but missing live
+    for table, declared_cols in declared.tables.items():
+        live_cols = live.tables.get(table)
+        if live_cols is None:
+            report.add(
+                SchemaFinding(
+                    severity="error",
+                    category="table_missing",
+                    message=f"Table '{table}' is declared in SCHEMA but missing from the database.",
+                    suggested_action="Run `twag db init` (idempotent) to create missing tables.",
+                ),
+            )
+            continue
+
+        for column in sorted(declared_cols - live_cols):
+            report.add(
+                SchemaFinding(
+                    severity="warning",
+                    category="column_missing",
+                    message=f"Column '{table}.{column}' is declared in SCHEMA but missing from the database.",
+                    suggested_action="Run `twag db init` to apply pending migrations.",
+                ),
+            )
+
+        for column in sorted(live_cols - declared_cols):
+            report.add(
+                SchemaFinding(
+                    severity="info",
+                    category="column_undeclared",
+                    message=(f"Column '{table}.{column}' exists in the database but is not declared in SCHEMA."),
+                    suggested_action=("Either add it to twag/db/schema.py or drop it (manual ALTER required)."),
+                ),
+            )
+
+    # Tables in DB but not declared
+    for table in sorted(set(live.tables) - set(declared.tables)):
+        # Skip SQLite/FTS shadow tables
+        if table.startswith("tweets_fts"):
+            continue
+        report.add(
+            SchemaFinding(
+                severity="info",
+                category="table_undeclared",
+                message=f"Table '{table}' exists in the database but is not declared in SCHEMA.",
+                suggested_action="Either add it to twag/db/schema.py or drop it manually.",
+            ),
+        )
+
+    # Indexes declared but missing live
+    for index in sorted(declared.indexes - live.indexes):
+        report.add(
+            SchemaFinding(
+                severity="warning",
+                category="index_missing",
+                message=f"Index '{index}' is declared in SCHEMA but missing from the database.",
+                suggested_action="Run `twag db init` to create missing indexes.",
+            ),
+        )
+
+    # Indexes in DB but not declared (skip SQLite-managed names)
+    for index in sorted(live.indexes - declared.indexes):
+        if index.startswith("sqlite_autoindex_"):
+            continue
+        report.add(
+            SchemaFinding(
+                severity="info",
+                category="index_undeclared",
+                message=f"Index '{index}' exists in the database but is not declared in SCHEMA.",
+                suggested_action="Either add it to twag/db/schema.py or drop it manually.",
+            ),
+        )
+
+    return report
+
+
+def analyze_all(db_path: Path | None = None) -> SchemaReport:
+    """Run both database and migration analyses, returning a merged report."""
+    combined = SchemaReport()
+    if db_path is not None:
+        for finding in analyze_database(db_path).findings:
+            combined.add(finding)
+    for finding in analyze_migrations().findings:
+        combined.add(finding)
+    return combined


### PR DESCRIPTION
## Summary
- Adds `twag/db/schema_advisor.py` exposing `analyze_database()` and `analyze_migrations()` to diff the declarative `SCHEMA`, the imperative `ALTER TABLE` migrations in `connection.py`, and a live SQLite database.
- Wires a new `twag db advise` subcommand that prints a Rich-formatted findings report and exits non-zero on errors.
- Read-only by design — the advisor never opens the DB for write nor mutates it.

## Findings reported
- Tables/columns/indexes declared in SCHEMA but missing from the live DB
- Tables/columns/indexes present in the live DB but undeclared in SCHEMA
- Migrations whose columns now exist in `CREATE TABLE` (informational — useful safety net for old DBs)
- Migrations whose columns are missing from `CREATE TABLE` (real drift, error)
- Migrations targeting tables not declared in SCHEMA (orphan, error)

## Test plan
- [x] `uv run pytest -q tests/db/test_schema_advisor.py` (12 new tests)
- [x] `uv run pytest -q` (full suite green)
- [x] `uv run ruff check .` / `uv run ruff format .` / `uv run ty check`
- [x] CLI smoke: `twag db advise --db-path /tmp/clean.db` against a freshly seeded DB shows no DB findings and only `info` migration_redundant entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: schema-evolution:/home/clifton/code/twag
task-type: schema-evolution
task-title: Schema Evolution Advisor
iterations: 1
duration: 7m13s
nightshift:metadata -->
