### PR TITLE
Add bounded live X search

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ twag process 1234567890123456789
 # Basic search
 twag search "inflation fed"
 
+# Query fresh public X results through authenticated bird
+twag search "NVIDIA" --live --time 1h
+
+# Explicit cache-only behavior (--cached is the default)
+twag search "inflation fed" --cached
+
 # With filters
 twag search "rate hike" --category fed_policy
 twag search "NVDA" --author zerohedge
@@ -219,6 +225,9 @@ twag search "fed" --format json             # JSON output
 # Score threshold
 twag search "market" --min-score 7          # High-signal only
 
+# Cashtag query: single quotes prevent the shell from expanding $BLND
+twag search '$BLND OR "Blend Labs"' --live --time 30d --min-score 4
+
 # Additional filters
 twag search --bookmarks                     # Only bookmarked tweets
 twag search "fed" --tier 1                  # Filter by signal tier
@@ -230,6 +239,19 @@ twag search "fed" --order score             # Sort by: rank, score, or time
 - Phrase: `"rate hike"` (exact match)
 - Boolean: `inflation AND fed`, `fed NOT fomc`
 - Prefix: `infla*` (wildcard)
+- Cashtags: `'$BLND OR "Blend Labs"'` (cashtags are normalized for FTS5; single-quote the whole query in the shell)
+- Column: `author_handle:zerohedge`
+
+Query searches use the local FTS5 index by default. Pass `--live` to query fresh
+public X results through authenticated `bird search`; twag stores only the
+current bird result set inside the requested time range and restricts output to
+those IDs. New live rows are classified only when score, category, tier, ticker,
+or score ordering needs model metadata. The bird call is capped at 30 seconds,
+and classification has a killable 120-second overall timeout (adjustable with
+`--classification-timeout`). Live syntax supports X terms, phrases, `OR`, and
+cashtags; FTS-only prefix and column expressions are cache-only syntax. A local
+empty result recommends `--live`, while a bird or classification failure exits
+nonzero with a separate credential-safe error.
 
 ### Narrative Commands
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -169,6 +169,8 @@ twag search -c fed_policy --time 7d  # Browse by category
 
 # Full-text search mode
 twag search "query"                  # FTS5 search
+twag search "query" --live           # Fresh public X results through bird
+twag search "query" --cached         # Explicit local-only search (default)
 twag search "query" -c fed_policy    # Filter by category
 twag search "query" -a handle        # Filter by author
 twag search "query" --ticker AAPL    # Filter by ticker
@@ -187,6 +189,15 @@ twag search "query" --order score    # Sort: rank, score, or time
 - Phrase: `"rate hike"` (exact)
 - Boolean: `inflation AND fed`, `fed NOT fomc`
 - Prefix: `infla*` (wildcard)
+- Cashtag: `twag search '$BLND OR "Blend Labs"' --live` (single quotes preserve `$BLND`)
+
+Query searches are local-only by default. `--live` queries fresh public X
+results through authenticated `bird search`, stores the in-window result set,
+and limits output to those fetched IDs. New live rows are classified when score,
+category, tier, ticker, or score-order filters need model metadata. Bird is
+bounded to 30 seconds; classification defaults to a killable 120-second overall
+timeout. Live syntax supports X terms, phrases, `OR`, and cashtags; FTS prefixes
+and column expressions are cache-only.
 
 ### Fetch & Process
 

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -204,10 +204,83 @@ def test_default_order_rank_with_query(monkeypatch):
     monkeypatch.setattr(cli_mod, "search_tweets", _fake_search_tweets)
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["search", "test"])
+    result = runner.invoke(cli, ["search", "test", "--cached"])
 
     assert result.exit_code == 0
     assert calls["order_by"] == "rank"
+
+
+def test_live_query_refreshes_from_x_then_searches_only_fetched_ids(monkeypatch):
+    """--live should refresh through bird before querying the fetched result set."""
+    import twag.cli.search as cli_mod
+
+    search_calls = []
+    refresh_calls = []
+
+    def _fake_search_tweets(conn, query, **kwargs):
+        search_calls.append((query, kwargs))
+        return [_make_search_result(content="Fresh NVIDIA result", summary=None)]
+
+    def _fake_refresh(query, **kwargs):
+        refresh_calls.append((query, kwargs))
+        return {"123"}
+
+    monkeypatch.setattr(cli_mod, "get_connection", _fake_connection)
+    monkeypatch.setattr(cli_mod, "search_tweets", _fake_search_tweets)
+    monkeypatch.setattr(cli_mod, "refresh_search_cache", _fake_refresh)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["search", "NVIDIA", "--live", "--time", "1h", "-s", "4", "-n", "10"])
+
+    assert result.exit_code == 0
+    assert len(search_calls) == 1
+    assert refresh_calls[0][0] == "NVIDIA"
+    assert refresh_calls[0][1]["count"] == 20
+    assert refresh_calls[0][1]["since"] is not None
+    assert refresh_calls[0][1]["classify"] is True
+    assert refresh_calls[0][1]["classification_timeout"] == 120
+    assert search_calls[0][1]["tweet_ids"] == {"123"}
+    assert "Fresh NVIDIA result" in result.output
+
+
+def test_cached_flag_does_not_run_live_fallback(monkeypatch):
+    """--cached should preserve a read-only local FTS lookup."""
+    import twag.cli.search as cli_mod
+
+    monkeypatch.setattr(cli_mod, "get_connection", _fake_connection)
+    monkeypatch.setattr(cli_mod, "search_tweets", lambda conn, query, **kwargs: [])
+
+    def _unexpected_refresh(*args, **kwargs):
+        raise AssertionError("live fallback should not run")
+
+    monkeypatch.setattr(cli_mod, "refresh_search_cache", _unexpected_refresh)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["search", "NVIDIA", "--time", "1h", "--cached"])
+
+    assert result.exit_code == 0
+    assert "No cached results found." in result.output
+    assert "--live" in result.output
+
+
+def test_live_failure_is_not_reported_as_local_empty(monkeypatch):
+    """A bird failure should be a distinct nonzero live-search error."""
+    import twag.cli.search as cli_mod
+
+    monkeypatch.setattr(cli_mod, "get_connection", _fake_connection)
+    monkeypatch.setattr(cli_mod, "search_tweets", lambda conn, query, **kwargs: [])
+
+    def _failed_refresh(*args, **kwargs):
+        raise cli_mod.LiveSearchError("live bird search failed within 30s")
+
+    monkeypatch.setattr(cli_mod, "refresh_search_cache", _failed_refresh)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["search", "NVIDIA", "--live", "--time", "1h"])
+
+    assert result.exit_code != 0
+    assert "live bird search failed within 30s" in result.output
+    assert "No cached results" not in result.output
 
 
 def test_default_order_score_without_query(monkeypatch):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -869,6 +869,17 @@ class TestFetchFunctions:
         with pytest.raises(RuntimeError, match=r"bird (thread|replies) failed"):
             fetch("123")
 
+    def test_fetch_search_can_skip_hydration_and_bound_timeout(self, mock_run_bird, single_tweet_json):
+        """Live search can avoid sequential retweet reads and cap the bird call."""
+        mock_run_bird.return_value = (json.dumps([single_tweet_json]), "", 0)
+
+        with patch("twag.fetcher.bird_cli._hydrate_truncated_retweets") as hydrate:
+            tweets = fetch_search("query", hydrate_retweets=False, timeout=30)
+
+        assert len(tweets) == 1
+        hydrate.assert_not_called()
+        assert mock_run_bird.call_args.kwargs["timeout"] == 30
+
     def test_fetch_bookmarks_success(self, mock_run_bird, single_tweet_json):
         """Successful bookmarks fetch."""
         mock_run_bird.return_value = (json.dumps([single_tweet_json]), "", 0)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -96,6 +96,62 @@ def test_process_unprocessed_expands_links_and_persists_before_triage(monkeypatc
         assert row["links_expanded_at"] is not None
 
 
+def test_process_unprocessed_triage_only_skips_context_enrichment(monkeypatch, tmp_path) -> None:
+    """Live-search triage should not expand dependencies, links, or enrichment."""
+    db_path = tmp_path / "twag_process_triage_only.db"
+    init_db(db_path)
+
+    with get_connection(db_path) as conn:
+        insert_tweet(
+            conn,
+            tweet_id="live-1",
+            author_handle="live_user",
+            content="Fresh result https://t.co/ext",
+            created_at=_FIXED_TS,
+            source="search",
+            has_link=True,
+            links=[{"url": "https://t.co/ext", "expanded_url": "https://t.co/ext"}],
+        )
+        conn.commit()
+
+    monkeypatch.setattr(pipeline_mod, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(
+        pipeline_mod,
+        "load_config",
+        lambda: {
+            "scoring": {"batch_size": 10, "high_signal_threshold": 7, "min_score_for_media": 3},
+            "fetch": {"quote_depth": 3, "quote_delay": 1.0},
+            "processing": {"max_concurrency_url_expansion": 4},
+        },
+    )
+    monkeypatch.setattr(
+        pipeline_mod,
+        "_expand_unprocessed_with_dependencies",
+        lambda *args, **kwargs: pytest.fail("dependency expansion should be skipped"),
+    )
+    monkeypatch.setattr(
+        pipeline_mod,
+        "_expand_links_for_rows",
+        lambda *args, **kwargs: pytest.fail("link expansion should be skipped"),
+    )
+
+    captured = {}
+
+    def _fake_triage_rows(_conn, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(pipeline_mod, "_triage_rows", _fake_triage_rows)
+
+    results = pipeline_mod.process_unprocessed(limit=10, triage_only=True)
+
+    assert results == []
+    assert captured["update_stats"] is False
+    assert captured["allow_summarize"] is False
+    assert captured["media_min_score"] is None
+    assert captured["enrich_results"] is False
+
+
 def test_process_unprocessed_skips_already_expanded_links(monkeypatch, tmp_path) -> None:
     db_path = tmp_path / "twag_process_skip_expanded_links.db"
     init_db(db_path)

--- a/tests/test_search_live.py
+++ b/tests/test_search_live.py
@@ -1,0 +1,100 @@
+"""Regression tests for live search cache refreshes and cashtag queries."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from twag.db import get_connection, init_db, insert_tweet, search_tweets
+from twag.search_live import LiveSearchError, _classify_with_timeout, refresh_search_cache
+
+
+def test_cashtag_query_is_normalized_for_fts(tmp_path):
+    """A shell-safe cashtag query should not crash SQLite FTS5."""
+    db_path = tmp_path / "cashtag.db"
+    init_db(db_path)
+    with get_connection(db_path) as conn:
+        insert_tweet(
+            conn,
+            tweet_id="blnd-1",
+            author_handle="marketwatcher",
+            content="Blend Labs $BLND announced a new partnership",
+            created_at=datetime.now(timezone.utc),
+            source="test",
+        )
+        conn.commit()
+
+    with get_connection(db_path, readonly=True) as conn:
+        results = search_tweets(conn, '$BLND OR "Blend Labs"')
+
+    assert [result.id for result in results] == ["blnd-1"]
+
+
+def test_live_refresh_filters_time_stores_and_classifies(monkeypatch):
+    """Only in-window live results should enter the scoring pipeline."""
+    import twag.search_live as live_mod
+
+    now = datetime.now(timezone.utc)
+    old = SimpleNamespace(id="old", created_at=now - timedelta(hours=2))
+    recent = SimpleNamespace(id="recent", created_at=now - timedelta(minutes=5))
+    stored = []
+    classified = []
+
+    def _fake_fetch(query, count, *, hydrate_retweets, timeout):
+        assert hydrate_retweets is False
+        assert timeout == 30
+        return [old, recent]
+
+    monkeypatch.setattr(live_mod, "fetch_search", _fake_fetch)
+
+    def _fake_store(tweets, **kwargs):
+        stored.extend(tweets)
+        assert kwargs["source"] == "search"
+        assert kwargs["quote_depth"] == 0
+        return len(tweets), len(tweets)
+
+    monkeypatch.setattr(live_mod, "store_fetched_tweets", _fake_store)
+    monkeypatch.setattr(
+        live_mod,
+        "_classify_with_timeout",
+        lambda ids, timeout: classified.append((ids, timeout)),
+    )
+
+    ids = refresh_search_cache(
+        "NVIDIA",
+        count=20,
+        since=now - timedelta(hours=1),
+        until=None,
+        classify=True,
+        classification_timeout=45,
+    )
+
+    assert ids == {"recent"}
+    assert [tweet.id for tweet in stored] == ["recent"]
+    assert classified == [({"recent"}, 45)]
+
+
+def test_classification_timeout_terminates_worker(monkeypatch):
+    """A stuck classification worker should be terminated at the overall deadline."""
+    import twag.search_live as live_mod
+
+    class _Process:
+        returncode = None
+        pid = 123
+
+        def communicate(self, *, input, timeout):
+            raise live_mod.subprocess.TimeoutExpired("worker", timeout)
+
+    process = _Process()
+    terminated = []
+    monkeypatch.setattr(live_mod.subprocess, "Popen", lambda *args, **kwargs: process)
+
+    def _record_termination(value):
+        terminated.append(value)
+
+    monkeypatch.setattr(live_mod, "_terminate_process", _record_termination)
+
+    with pytest.raises(LiveSearchError, match="timed out after 12s"):
+        _classify_with_timeout({"tweet-1"}, 12)
+
+    assert terminated == [process]

--- a/twag/cli/search.py
+++ b/twag/cli/search.py
@@ -1,6 +1,7 @@
 """Search command."""
 
 import json
+import sqlite3
 
 import rich_click as click
 
@@ -13,6 +14,7 @@ from ..db import (
     query_suggests_equity_context,
     search_tweets,
 )
+from ..search_live import LiveSearchError, refresh_search_cache
 from ._console import console
 
 
@@ -28,6 +30,19 @@ from ._console import console
 @click.option("--until", help="End time (YYYY-MM-DD)")
 @click.option("--today", is_flag=True, help="Since previous market close (4pm ET)")
 @click.option("--time", "time_range", help="Time range shorthand (today, 7d, etc.)")
+@click.option(
+    "--live/--cached",
+    default=False,
+    show_default=True,
+    help="Query fresh public X results with bird instead of only the local cache",
+)
+@click.option(
+    "--classification-timeout",
+    type=click.IntRange(min=1, max=600),
+    default=120,
+    show_default=True,
+    help="Overall timeout in seconds for optional live-result classification",
+)
 @click.option("--limit", "-n", type=int, default=20, help="Max results (default: 20)")
 @click.option(
     "--order",
@@ -56,6 +71,8 @@ def search(
     until: str | None,
     today: bool,
     time_range: str | None,
+    live: bool,
+    classification_timeout: int,
     limit: int,
     order: str | None,
     fmt: str,
@@ -72,12 +89,14 @@ def search(
       Simple:    inflation fed
       Phrases:   "rate hike"
       Boolean:   inflation AND fed, fed NOT fomc
+      Cashtags:  $BLND OR "Blend Labs" (single-quote in the shell)
       Prefix:    infla*
       Column:    author_handle:zerohedge
 
     \b
     EXAMPLES:
       twag search "inflation" --today
+      twag search "NVIDIA" --live --time 1h
       twag search "fed rate" -c fed_policy -s 7
       twag search "NVDA" -a zerohedge --time 7d
       twag search "earnings" --ticker AAPL
@@ -101,8 +120,8 @@ def search(
     if today:
         time_range = "today"
 
-    # Parse time_range into datetimes for browse mode
-    if time_range and not query:
+    # Parse time_range into concrete bounds for both cached and live paths.
+    if time_range:
         parsed_since, parsed_until = parse_time_range(time_range)
         if parsed_since and since_dt is None:
             since_dt = parsed_since
@@ -113,27 +132,47 @@ def search(
         # FTS search mode
         effective_order = order or "rank"
 
+        if live and bookmarks:
+            raise click.UsageError("--live cannot be combined with --bookmarks")
+
         # Auto-detect equity context for smart defaults (only if no time specified)
         if not time_range and since_dt is None and query_suggests_equity_context(query):
             click.echo("(auto-detected equity context, defaulting to --today)", err=True)
             time_range = "today"
+            parsed_since, parsed_until = parse_time_range(time_range)
+            since_dt = parsed_since
+            until_dt = parsed_until
 
-        with get_connection(readonly=True) as conn:
-            results = search_tweets(
-                conn,
-                query,
-                category=category,
-                author=author,
-                min_score=min_score,
-                signal_tier=tier,
-                ticker=ticker,
-                bookmarked_only=bookmarks,
-                since=since_dt,
-                until=until_dt,
-                time_range=time_range,
-                limit=limit,
-                order_by=effective_order,
-            )
+        search_kwargs = {
+            "category": category,
+            "author": author,
+            "min_score": min_score,
+            "signal_tier": tier,
+            "ticker": ticker,
+            "bookmarked_only": bookmarks,
+            "since": since_dt,
+            "until": until_dt,
+            "limit": limit,
+            "order_by": effective_order,
+        }
+        if live:
+            click.echo("Searching fresh public X results with bird...", err=True)
+            classify = any((category, min_score is not None, tier, ticker, effective_order == "score"))
+            fetch_count = min(max(limit * 2, 20), 100)
+            try:
+                live_tweet_ids = refresh_search_cache(
+                    query,
+                    count=fetch_count,
+                    since=since_dt,
+                    until=until_dt,
+                    classify=classify,
+                    classification_timeout=classification_timeout,
+                )
+            except LiveSearchError as exc:
+                raise click.ClickException(str(exc)) from exc
+            search_kwargs["tweet_ids"] = live_tweet_ids
+
+        results = _search_cached(query, search_kwargs)
     else:
         # Browse mode — no FTS query
         if order == "rank":
@@ -171,7 +210,17 @@ def search(
         results = [_feed_tweet_to_search_result(ft) for ft in feed_results]
 
     if not results:
-        console.print("No results found.")
+        if query and live:
+            message = "No live X results matched the requested query and filters."
+        elif query:
+            message = "No cached results found. Re-run with --live to query fresh public X results."
+        else:
+            message = "No results found."
+        if fmt == "json":
+            click.echo(message, err=True)
+            click.echo("[]")
+        else:
+            console.print(message)
         return
 
     if fmt == "json":
@@ -180,6 +229,19 @@ def search(
         _output_full(results)
     else:
         _output_brief(results)
+
+
+def _search_cached(query: str, kwargs: dict) -> list[SearchResult]:
+    """Run the local FTS query and turn parser failures into concise usage errors."""
+    try:
+        with get_connection(readonly=True) as conn:
+            return search_tweets(conn, query, **kwargs)
+    except sqlite3.OperationalError as exc:
+        if "fts5" not in str(exc).lower():
+            raise
+        raise click.UsageError(
+            "Invalid search query. Use FTS5 terms, quoted phrases, AND/OR/NOT, prefixes, or shell-quoted cashtags.",
+        ) from exc
 
 
 def _feed_tweet_to_search_result(ft: FeedTweet) -> SearchResult:

--- a/twag/db/search.py
+++ b/twag/db/search.py
@@ -1,6 +1,7 @@
 """Search and feed query operations."""
 
 import json
+import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
@@ -93,6 +94,13 @@ EQUITY_KEYWORDS = {
     "report",
 }
 
+_CASHTAG_PATTERN = re.compile(r"(?<![\w$])\$([A-Za-z][A-Za-z0-9_]*)")
+
+
+def normalize_fts_query(query: str) -> str:
+    """Normalize shell-safe X cashtags into tokens accepted by SQLite FTS5."""
+    return _CASHTAG_PATTERN.sub(r"\1", query)
+
 
 def query_suggests_equity_context(query: str) -> bool:
     """Check if a search query suggests equity-relevant context."""
@@ -113,6 +121,7 @@ def search_tweets(
     since: datetime | None = None,
     until: datetime | None = None,
     time_range: str | None = None,
+    tweet_ids: set[str] | None = None,
     limit: int = 50,
     offset: int = 0,
     order_by: str = "rank",
@@ -131,6 +140,7 @@ def search_tweets(
         since: Start time (UTC datetime)
         until: End time (UTC datetime)
         time_range: Time range spec ("today", "7d", "2025-01-15", etc.)
+        tweet_ids: Restrict results to a specific set of fetched tweet IDs
         limit: Maximum results to return
         offset: Offset for pagination
         order_by: Sort order - "rank" (BM25), "score" (relevance), "time" (created_at)
@@ -152,7 +162,7 @@ def search_tweets(
 
     # FTS match
     conditions.append("tweets_fts MATCH ?")
-    params.append(query)
+    params.append(normalize_fts_query(query))
 
     if category:
         # Match category in JSON array (e.g., '["fed_policy", "rates_fx"]')
@@ -181,6 +191,14 @@ def search_tweets(
 
     if bookmarked_only:
         conditions.append("t.bookmarked = 1")
+
+    if tweet_ids is not None:
+        if not tweet_ids:
+            conditions.append("1 = 0")
+        else:
+            placeholders = ",".join("?" for _ in tweet_ids)
+            conditions.append(f"t.id IN ({placeholders})")
+            params.extend(sorted(tweet_ids))
 
     if since:
         conditions.append("t.created_at >= ?")

--- a/twag/fetcher/bird_cli.py
+++ b/twag/fetcher/bird_cli.py
@@ -366,15 +366,21 @@ def fetch_user_tweets(handle: str, count: int = 50) -> list[Tweet]:
     return _hydrate_truncated_retweets(tweets)
 
 
-def fetch_search(query: str, count: int = 30) -> list[Tweet]:
+def fetch_search(
+    query: str,
+    count: int = 30,
+    *,
+    hydrate_retweets: bool = True,
+    timeout: int = 60,
+) -> list[Tweet]:
     """Search for tweets matching a query."""
-    stdout, stderr, code = run_bird(["search", query, "-n", str(count), "--json"])
+    stdout, stderr, code = run_bird(["search", query, "-n", str(count), "--json"], timeout=timeout)
 
     if code != 0:
         raise RuntimeError(f"bird search failed (exit {code}): {stderr.strip()}")
 
     tweets = _parse_bird_output(stdout)
-    return _hydrate_truncated_retweets(tweets)
+    return _hydrate_truncated_retweets(tweets) if hydrate_retweets else tweets
 
 
 def fetch_thread(tweet_url_or_id: str, *, all_pages: bool = False, max_pages: int | None = None) -> list[Tweet]:

--- a/twag/processor/pipeline.py
+++ b/twag/processor/pipeline.py
@@ -44,6 +44,7 @@ def process_unprocessed(
     status_cb: Callable[[str], None] | None = None,
     total_cb: Callable[[int], None] | None = None,
     force_refresh: bool = False,
+    triage_only: bool = False,
 ) -> list[TriageResult]:
     """Process tweets that haven't been scored yet."""
     from ..metrics import get_collector
@@ -67,7 +68,7 @@ def process_unprocessed(
         if not unprocessed:
             return []
 
-        if quote_depth > 0:
+        if not triage_only and quote_depth > 0:
             if status_cb:
                 status_cb("Expanding dependency tweets")
             unprocessed = _expand_unprocessed_with_dependencies(
@@ -80,7 +81,7 @@ def process_unprocessed(
                 total_cb=total_cb,
             )
 
-        if not dry_run:
+        if not dry_run and not triage_only:
             unprocessed = _expand_links_for_rows(
                 conn,
                 unprocessed,
@@ -135,12 +136,13 @@ def process_unprocessed(
             enrich_model=enrich_model,
             high_threshold=high_threshold,
             tier1_handles=tier1_handles,
-            update_stats=True,
-            allow_summarize=True,
-            media_min_score=media_min_score,
+            update_stats=not triage_only,
+            allow_summarize=not triage_only,
+            media_min_score=None if triage_only else media_min_score,
             progress_cb=progress_cb,
             status_cb=status_cb,
             force_refresh=force_refresh,
+            enrich_results=not triage_only,
         )
 
         conn.commit()

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -397,6 +397,7 @@ def _triage_rows(
     progress_cb: Callable[[int], None] | None = None,
     status_cb: Callable[[str], None] | None = None,
     force_refresh: bool = False,
+    enrich_results: bool = True,
 ) -> list[TriageResult]:
     """Run triage on provided rows and persist results."""
     from ..metrics import get_collector
@@ -677,7 +678,7 @@ def _triage_rows(
                     is_high_signal=result.score >= high_threshold,
                 )
 
-            if media_min_score is not None and result.score >= media_min_score:
+            if enrich_results and media_min_score is not None and result.score >= media_min_score:
                 media_items = parse_media_items(tweet_row["media_items"])
                 if media_items:
                     if not _needs_media_analysis(media_items):
@@ -717,7 +718,8 @@ def _triage_rows(
                         )
 
             needs_analysis = (
-                analysis_min_score is not None
+                enrich_results
+                and analysis_min_score is not None
                 and result.score >= analysis_min_score
                 and tweet_row is not None
                 and (force_refresh or not tweet_row["analysis_json"])
@@ -726,7 +728,8 @@ def _triage_rows(
                 task_count += 1
 
             needs_article = (
-                tweet_row is not None
+                enrich_results
+                and tweet_row is not None
                 and bool(tweet_row["is_x_article"])
                 and (force_refresh or not tweet_row["article_processed_at"])
                 and result.score >= article_min_score

--- a/twag/search_classify_worker.py
+++ b/twag/search_classify_worker.py
@@ -1,0 +1,28 @@
+"""Bounded subprocess worker for live-search triage."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from .db import get_connection, get_tweets_by_ids
+from .processor import process_unprocessed
+
+
+def main() -> int:
+    """Classify the tweet IDs supplied on stdin without emitting secrets."""
+    try:
+        payload = json.load(sys.stdin)
+        tweet_ids = {str(tweet_id) for tweet_id in payload if tweet_id}
+        with get_connection(readonly=True) as conn:
+            rows_by_id = get_tweets_by_ids(conn, tweet_ids)
+        rows = [row for row in rows_by_id.values() if row["processed_at"] is None]
+        if rows:
+            process_unprocessed(limit=len(rows), rows=rows, triage_only=True)
+    except BaseException:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/twag/search_live.py
+++ b/twag/search_live.py
@@ -1,0 +1,129 @@
+"""Live X search fallback for cache misses."""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+from .fetcher import fetch_search
+from .processor import store_fetched_tweets
+
+_BIRD_LIVE_SEARCH_TIMEOUT_SECONDS = 30
+
+
+class LiveSearchError(RuntimeError):
+    """A safe, user-facing live search failure."""
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime for reliable range comparisons."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _tweet_is_in_range(tweet, since: datetime | None, until: datetime | None) -> bool:
+    """Check a fetched tweet against optional half-open UTC bounds."""
+    if since is None and until is None:
+        return True
+    if tweet.created_at is None:
+        return False
+
+    created_at = _as_utc(tweet.created_at)
+    if since is not None and created_at < _as_utc(since):
+        return False
+    return until is None or created_at < _as_utc(until)
+
+
+def refresh_search_cache(
+    query: str,
+    *,
+    count: int,
+    since: datetime | None,
+    until: datetime | None,
+    classify: bool,
+    classification_timeout: int,
+) -> set[str]:
+    """Fetch a live X query, persist in-range tweets, and optionally classify them.
+
+    Returns the IDs of fetched tweets inside the requested time range. Error
+    messages deliberately omit backend stderr so cookie values cannot leak.
+    """
+    try:
+        tweets = fetch_search(
+            query=query,
+            count=count,
+            hydrate_retweets=False,
+            timeout=_BIRD_LIVE_SEARCH_TIMEOUT_SECONDS,
+        )
+    except RuntimeError as exc:
+        raise LiveSearchError(
+            "live bird search failed within 30s; verify X authentication with `bird whoami`",
+        ) from exc
+
+    in_range = [tweet for tweet in tweets if _tweet_is_in_range(tweet, since, until)]
+    if not in_range:
+        return set()
+
+    try:
+        store_fetched_tweets(
+            in_range,
+            source="search",
+            query_params={"query": query, "count": count, "live_fallback": True},
+            quote_depth=0,
+        )
+    except Exception as exc:
+        raise LiveSearchError("live search results could not be stored") from exc
+
+    if not classify:
+        return {tweet.id for tweet in in_range if tweet.id}
+
+    tweet_ids = {tweet.id for tweet in in_range if tweet.id}
+    _classify_with_timeout(tweet_ids, classification_timeout)
+
+    return tweet_ids
+
+
+def _classify_with_timeout(tweet_ids: set[str], timeout: int) -> None:
+    """Run triage-only classification in a killable, bounded child process."""
+    if not tweet_ids:
+        return
+
+    process = subprocess.Popen(
+        [sys.executable, "-m", "twag.search_classify_worker"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        start_new_session=os.name == "posix",
+    )
+    try:
+        process.communicate(input=json.dumps(sorted(tweet_ids)), timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        _terminate_process(process)
+        raise LiveSearchError(f"live result classification timed out after {timeout}s") from exc
+
+    if process.returncode != 0:
+        raise LiveSearchError("live result classification failed")
+
+
+def _terminate_process(process: subprocess.Popen) -> None:
+    """Terminate a timed-out worker and escalate if it does not exit."""
+    if process.poll() is not None:
+        return
+    if os.name == "posix":
+        os.killpg(process.pid, signal.SIGTERM)
+    else:
+        process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+        process.wait()


### PR DESCRIPTION
## Summary

- add an explicit `twag search --live` mode backed by the existing authenticated bird path while keeping cached FTS5 search as the default
- constrain live output to the current bird result IDs and requested time window
- normalize shell-preserved cashtags for FTS5, including `'$BLND OR "Blend Labs"'`
- run optional score/category/ticker classification in a triage-only subprocess with a killable overall timeout
- distinguish cached-empty, live-empty, bird failure, and classification timeout/failure
- document local and live query syntax in README and SKILL

## Root cause

`twag search` was intentionally local-only. The installed CLI, database, and FTS index were healthy, and bird auth returned fresh NVIDIA and BLND posts, but those posts were outside or absent from the locally ingested corpus. A literal cashtag also reached SQLite unchanged and raised `fts5: syntax error near "$"`.

The first live prototype reused the full processing pipeline and stalled before triage while expanding dependencies and links. Live scoring now skips dependency hydration, URL expansion, media/article analysis, and enrichment; bird is capped at 30 seconds and classification defaults to a killable 120-second overall timeout.

## Validation

- `uv run ruff format twag tests`
- `uv run ruff check twag tests`
- `uv run ty check`
- `uv run pytest -q` (all tests pass)
- unscored live NVIDIA: 10 results in 1.9s
- scored live NVIDIA (`1h`, score >= 4): 7 results, scores 4-8
- scored live BLND (`30d`, score >= 4): 10 results, scores 4-7
- literal live cashtag `'$BLND OR "Blend Labs"'`: 20 results with `$BLND` preserved
- reinstalled `/home/clifton/.local/bin/twag` at `0.1.38.dev1+gd14a361e5`; original cached NVIDIA and BLND commands now return 10 results each

## Note

The machine-local commit hook invokes unpinned `uvx ty` 0.0.59 and flags five pre-existing stale `ty: ignore` comments outside this diff. The repository-pinned `uv run ty` 0.0.15 passes; unrelated ignores were intentionally left untouched.
