### PR TITLE
Use uv for twag installation and development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ metadata:
 ### Setup
 
 ```bash
-pip install -e ".[dev]"
+uv sync --group dev
+uv run twag --version
 ```
 
 ### Lint & Format

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,9 +4,16 @@ Step-by-step instructions for installing twag and its dependencies.
 
 ## Prerequisites
 
-- Python 3.10+ with pip
+- [uv](https://docs.astral.sh/uv/) (manages the Python 3.10+ tool environment)
 - Node.js 18+ with npm (for bird CLI)
 - A Twitter/X account
+
+Install and verify uv first:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv --version
+```
 
 ## Step 1: Install bird CLI
 
@@ -109,25 +116,28 @@ export DEEPSEEK_API_KEY="your_deepseek_key"
 
 ## Step 5: Install twag
 
-### From PyPI
+### Global CLI from PyPI (Recommended)
 
 ```bash
-pip install twag
+uv tool install twag
 ```
+
+If `twag` is not on `PATH`, run `uv tool update-shell` and restart the shell. Upgrade later with
+`uv tool upgrade twag`.
 
 ### From Source
 
 ```bash
 git clone https://github.com/clifton/twag.git
 cd twag
-pip install -e .
+uv tool install --editable .
 ```
 
-### Using uv
+The generated global `twag` command runs from uv's isolated tool environment. For development inside the checkout, use
+`uv sync --group dev` once and invoke the local environment with `uv run twag ...`.
 
-```bash
-uv pip install twag
-```
+After source dependency or entry-point changes, refresh the editable tool with
+`uv tool install --force --editable .`.
 
 ## Step 6: Initialize
 
@@ -198,7 +208,7 @@ Description=TWAG Twitter Aggregator
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 'source ~/.env && twag fetch && twag process'
+ExecStart=/bin/bash -lc 'source %h/.env && %h/.local/bin/twag fetch && %h/.local/bin/twag process'
 ```
 
 Create `~/.config/systemd/user/twag.timer`:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Example telegram notification. Chart emojis are links to tweets that have charts
 
 ## Prerequisites
 
+### uv (Required)
+
+twag uses [uv](https://docs.astral.sh/uv/) for installation and development environments. Install uv, then verify it is
+available:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv --version
+```
+
 ### bird CLI (Required)
 
 twag uses [bird](https://github.com/steipete/bird) to access Twitter/X. Install it first:
@@ -91,27 +101,28 @@ export DEEPSEEK_API_KEY="your_deepseek_key"    # optional
 
 ## Installation
 
-### From PyPI (Recommended)
+### Global CLI from PyPI (Recommended)
 
 ```bash
-pip install twag
+uv tool install twag
 ```
+
+If `twag` is not on `PATH`, run `uv tool update-shell` and restart the shell. Upgrade later with
+`uv tool upgrade twag`.
 
 ### From Source
 
 ```bash
 git clone https://github.com/clifton/twag.git
 cd twag
-pip install -e .
+uv tool install --editable .
 ```
 
-### Using uv
+`uv tool install` creates the global `twag` launcher in uv's tool environment, so normal user and automation commands
+remain `twag ...` while dependency and Python management stay with uv. Inside a source checkout, use `uv run twag ...`
+when you want the checkout's locked development environment instead of the global tool.
 
-```bash
-uv pip install twag
-# or from source
-uv pip install -e .
-```
+Reinstall an editable source tool after dependency or entry-point changes with `uv tool install --force --editable .`.
 
 ## Quick Start
 
@@ -406,7 +417,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=%h/.local/bin/twag fetch && %h/.local/bin/twag process
+ExecStart=/bin/bash -lc '%h/.local/bin/twag fetch && %h/.local/bin/twag process'
 WorkingDirectory=%h
 EnvironmentFile=%h/.env
 ```
@@ -550,15 +561,18 @@ twag db restore backup.sql --force
 ## Development
 
 ```bash
-# Install dev dependencies
-pip install -e ".[dev]"
+# Install the locked project and dev dependencies
+uv sync --group dev
+
+# Run the checkout's CLI
+uv run twag --version
 
 # Run tests
-pytest
+uv run pytest
 
 # Lint and format
-ruff check .
-ruff format .
+uv run ruff check .
+uv run ruff format .
 
 # Frontend development
 cd twag/web/frontend

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,11 +15,11 @@ metadata:
       bins: ["twag", "bird"]
       env: ["GEMINI_API_KEY", "AUTH_TOKEN", "CT0"]
     install:
-      - id: pip
-        kind: pip
+      - id: uv
+        kind: uv
         package: twag
         bins: ["twag"]
-        label: "Install twag (pip)"
+        label: "Install twag (uv tool)"
       - id: bird-npm
         kind: node
         package: "@steipete/bird"
@@ -75,15 +75,18 @@ Verify auth: `bird whoami`
 ### Step 3: Install twag
 
 ```bash
-pip install twag
+uv tool install twag
 ```
 
 Or from source:
 
 ```bash
 git clone https://github.com/clifton/twag.git
-cd twag && pip install -e .
+cd twag && uv tool install --editable .
 ```
+
+The global `twag` launcher is managed by uv. Inside a development checkout, use `uv run twag ...` to run against the
+checkout and its locked environment.
 
 ### Step 4: Initialize and verify
 

--- a/scripts/cron-runner.sh
+++ b/scripts/cron-runner.sh
@@ -28,7 +28,7 @@ export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 
 # Validate twag is available
 if ! command -v twag >/dev/null 2>&1; then
-    echo "$(date '+%Y-%m-%d %H:%M:%S') [twag] ERROR: twag not found in PATH" >&2
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [twag] ERROR: twag not found in PATH; install with 'uv tool install twag'" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- make `uv tool install twag` the supported global CLI installation path
- use OpenClaw supported `kind: uv` installer metadata
- document `uv run twag` for checkout-aware development and `uv tool upgrade`/forced editable refreshes
- keep normal `twag ...` commands and automation on the launcher generated by uv
- fix the systemd examples to execute multi-command pipelines through a shell

## Design
The Python CLI does not invoke uv itself. A uv-installed console script is already isolated and managed by uv; invoking uv from inside `twag` would recurse and add per-command project sync overhead.

## Validation
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` (395 passed)
- `bash -n scripts/cron-runner.sh`
- `uv run twag --version`
- `uv tool run --from twag==0.1.39 twag --version`