### PR TITLE
Route twag vision through charts service

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -139,6 +139,23 @@ The generated global `twag` command runs from uv's isolated tool environment. Fo
 After source dependency or entry-point changes, refresh the editable tool with
 `uv tool install --force --editable .`.
 
+### Optional: route vision through charts
+
+If the machine-wide [charts](https://github.com/clifton/charts) service is
+installed, twag can use its SHA-256 cache and spend ledger for all image
+analysis:
+
+```bash
+charts health --json
+twag config set llm.vision_provider charts
+```
+
+Keep `llm.vision_model` set to a valid Gemini model. It is used only for one
+bounded fallback call when the charts executable cannot start, times out after
+90 seconds, or returns no valid contract JSON. charts rejections and structured
+analysis failures do not trigger fallback. `twag doctor` verifies both the
+charts executable and the fallback Gemini key when this provider is selected.
+
 ## Step 6: Initialize
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -378,10 +378,30 @@ twag web --no-reload            # Disable auto-reload on code changes
 twag config show                # Show current config
 twag config path                # Show config file path
 twag config set llm.triage_model gemini-2.0-flash
+twag config set llm.vision_provider charts
 twag config set scoring.alert_threshold 8
 twag config set scoring.min_score_for_analysis 6
 twag config set scoring.max_article_summary_chars 20000
 ```
+
+### charts vision provider
+
+Set `llm.vision_provider` to `charts` to route tweet images through the local
+`charts analyze` service and its machine-wide SHA-256 cache:
+
+```bash
+twag config set llm.vision_provider charts
+twag config set llm.vision_model gemini-3-flash-preview
+```
+
+`charts` must be on `PATH` (or configured with `llm.charts_executable`). twag
+keeps its URL-keyed media cache as L1 and charts is the content-keyed system of
+record. Successful results carry `charts_id`, `cdn_url`, and `charts_cached` on
+the stored media item. `vision_model` remains the model for one bounded direct
+Gemini fallback, used only if the charts executable cannot start, exceeds its
+90-second deadline, or fails to emit valid contract JSON. Rejected media and
+structured charts failures never fall back, preventing retry-cap bypass and
+double billing.
 
 ## Data Paths
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -226,6 +226,18 @@ twag spine emit              # Append eligible signal-event v1 records
 twag eval run                # Run the versioned scoring golden set
 ```
 
+When the local charts service is installed, route vision through its
+machine-wide content cache with:
+
+```bash
+twag config set llm.vision_provider charts
+```
+
+Keep `llm.vision_model` configured as the bounded Gemini fallback model. charts
+rejections and structured failures never fall back; only spawn failures,
+90-second deadlines, or invalid contract output do. Stored media items include
+`charts_id`, `cdn_url`, and `charts_cached` when charts handled the image.
+
 ### Digest
 
 ```bash

--- a/tests/test_charts_vision.py
+++ b/tests/test_charts_vision.py
@@ -1,0 +1,396 @@
+"""Contract tests for routing twag vision through the local charts service."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+import twag.processor.triage as triage_mod
+import twag.scorer.charts_client as charts_client
+import twag.scorer.scoring as scoring_mod
+from twag.db import get_connection, init_db
+from twag.metrics import get_collector
+from twag.scorer import MediaAnalysisResult
+from twag.scorer.charts_client import (
+    ChartsAnalysis,
+    ChartsAnalysisError,
+    ChartsProcessResult,
+    ChartsUnavailableError,
+)
+
+
+def _charts_payload(*, kind: str = "chart", status: str = "active", cached: bool = False) -> dict:
+    chart_id = "a" * 64
+    return {
+        "id": chart_id,
+        "ext": "jpg",
+        "kind": kind,
+        "status": status,
+        "tag_status": "tagged",
+        "title": "US real yields",
+        "transcript": "Line chart of the US 10-year real yield.",
+        "insight": "Real yields rose through the latest observation.",
+        "caption": "Real yields are moving",
+        "tags": {
+            "tickers": ["TIP"],
+            "countries": ["US"],
+            "asset_classes": ["rates"],
+            "fx_pairs": [],
+            "indices": [],
+            "concepts": ["real yields"],
+            "themes": ["higher-for-longer"],
+        },
+        "cdn_url": None if status == "rejected" else f"https://charts.example/c/{chart_id}.jpg",
+        "cached": cached,
+    }
+
+
+def _charts_analysis(**overrides) -> ChartsAnalysis:
+    return charts_client._validate_success({**_charts_payload(), **overrides})
+
+
+def _charts_config() -> dict:
+    return {
+        "llm": {
+            "vision_model": "gemini-fallback",
+            "vision_provider": "charts",
+            "charts_executable": "/usr/local/bin/charts",
+            "charts_deadline_seconds": 90,
+        },
+    }
+
+
+def test_charts_runner_uses_argument_array_and_maps_contract() -> None:
+    invocations: list[tuple[list[str], float]] = []
+
+    def runner(args: list[str], deadline: float) -> ChartsProcessResult:
+        invocations.append((args, deadline))
+        return ChartsProcessResult(0, json.dumps(_charts_payload(cached=True)), "")
+
+    result = charts_client.analyze_with_charts(
+        "https://example.com/chart.jpg",
+        caption="tweet text",
+        executable="/opt/bin/charts",
+        deadline_seconds=90,
+        runner=runner,
+    )
+
+    assert invocations == [
+        (
+            [
+                "/opt/bin/charts",
+                "analyze",
+                "https://example.com/chart.jpg",
+                "--source",
+                "twitter",
+                "--caption",
+                "tweet text",
+                "--json",
+            ],
+            90,
+        ),
+    ]
+    mapped = scoring_mod._media_result_from_charts(result)
+    assert mapped.kind == "chart"
+    assert mapped.prose_text == "Line chart of the US 10-year real yield."
+    assert mapped.prose_summary == "Real yields rose through the latest observation."
+    assert mapped.short_description == mapped.prose_summary
+    assert mapped.chart["tickers"] == ["TIP"]
+    assert mapped.chart["tags"]["countries"] == ["US"]
+    assert mapped.charts_id == "a" * 64
+    assert mapped.cdn_url == f"https://charts.example/c/{'a' * 64}.jpg"
+    assert mapped.charts_cached is True
+
+
+def test_rejected_charts_result_is_accepted_without_fallback(monkeypatch) -> None:
+    rejected = _charts_analysis(kind="photo", status="rejected", cdn_url=None)
+    monkeypatch.setattr(scoring_mod, "load_config", _charts_config)
+    monkeypatch.setattr(scoring_mod, "analyze_with_charts", lambda *args, **kwargs: rejected)
+    monkeypatch.setattr(
+        scoring_mod,
+        "_call_llm_vision_once",
+        lambda *args, **kwargs: pytest.fail("rejected charts result must not fallback"),
+    )
+    usage: list[dict] = []
+
+    result = scoring_mod.analyze_media(
+        "https://example.com/photo.jpg",
+        caption="conference photo",
+        usage_recorder=usage.append,
+    )
+
+    assert result.kind == "photo"
+    assert result.charts_id == rejected.id
+    assert result.cdn_url is None
+    assert len(usage) == 1
+    assert usage[0]["provider"] == "charts"
+    assert usage[0]["model"] == "charts"
+    assert usage[0]["success"] is True
+    assert usage[0]["metadata"]["status"] == "rejected"
+
+
+def test_charts_call_logs_zero_cost_usage_row(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("TWAG_DATA_DIR", str(tmp_path))
+    init_db(tmp_path / "twag.db")
+    monkeypatch.setattr(scoring_mod, "load_config", _charts_config)
+    monkeypatch.setattr(scoring_mod, "analyze_with_charts", lambda *args, **kwargs: _charts_analysis())
+    monkeypatch.setattr(
+        scoring_mod,
+        "_call_llm_vision_once",
+        lambda *args, **kwargs: pytest.fail("successful charts result must not fallback"),
+    )
+
+    scoring_mod.analyze_media(
+        "https://example.com/chart.jpg",
+        caption="caption for charts",
+    )
+
+    with get_connection(tmp_path / "twag.db", readonly=True) as conn:
+        row = conn.execute(
+            """
+            SELECT component, provider, model, is_vision, estimated_cost_usd,
+                   success, metadata_json
+            FROM llm_usage
+            """,
+        ).fetchone()
+    assert row["component"] == "vision"
+    assert row["provider"] == "charts"
+    assert row["model"] == "charts"
+    assert row["is_vision"] == 1
+    assert row["estimated_cost_usd"] == 0
+    assert row["success"] == 1
+    assert json.loads(row["metadata_json"])["charts_id"] == "a" * 64
+
+
+def test_structured_charts_failure_never_falls_back(monkeypatch) -> None:
+    error = ChartsAnalysisError(
+        "Gemini HTTP 503",
+        {"error": "Gemini HTTP 503", "id": "b" * 64, "tag_status": "failed", "tag_attempts": 1},
+    )
+    monkeypatch.setattr(scoring_mod, "load_config", _charts_config)
+    monkeypatch.setattr(
+        scoring_mod,
+        "analyze_with_charts",
+        lambda *args, **kwargs: (_ for _ in ()).throw(error),
+    )
+    monkeypatch.setattr(
+        scoring_mod,
+        "_call_llm_vision_once",
+        lambda *args, **kwargs: pytest.fail("structured charts failure must not fallback"),
+    )
+    usage: list[dict] = []
+
+    with pytest.raises(ChartsAnalysisError, match="Gemini HTTP 503"):
+        scoring_mod.analyze_media(
+            "https://example.com/failing.jpg",
+            caption="failing chart",
+            usage_recorder=usage.append,
+        )
+
+    assert len(usage) == 1
+    assert usage[0]["provider"] == "charts"
+    assert usage[0]["success"] is False
+    assert usage[0]["metadata"]["failure"] == "structured"
+
+
+def test_unavailable_charts_falls_back_to_exactly_one_direct_call(monkeypatch) -> None:
+    monkeypatch.setattr(scoring_mod, "load_config", _charts_config)
+    monkeypatch.setattr(
+        scoring_mod,
+        "analyze_with_charts",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ChartsUnavailableError("spawn_failure", "missing")),
+    )
+    calls: list[tuple] = []
+
+    def direct_call(*args, **kwargs):
+        calls.append((args, kwargs))
+        return json.dumps(
+            {
+                "kind": "chart",
+                "short_description": "Fallback chart",
+                "prose_text": "Fallback transcript",
+                "prose_summary": "Fallback insight",
+                "chart": {},
+                "table": {},
+            },
+        )
+
+    monkeypatch.setattr(scoring_mod, "_call_llm_vision_once", direct_call)
+    get_collector().reset()
+    usage: list[dict] = []
+
+    result = scoring_mod.analyze_media(
+        "https://example.com/fallback.jpg",
+        caption="fallback tweet",
+        usage_recorder=usage.append,
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0][:3] == ("gemini", "gemini-fallback", "https://example.com/fallback.jpg")
+    assert result.analysis_provider == "gemini"
+    assert result.analysis_model == "gemini-fallback"
+    assert result.charts_id is None
+    assert len(usage) == 1
+    assert usage[0]["provider"] == "charts"
+    assert usage[0]["metadata"]["unavailable_reason"] == "spawn_failure"
+    assert get_collector().counter_value("scorer.charts.unavailable.spawn_failure") == 1
+
+
+def test_invalid_contract_is_unavailable_but_structured_nonzero_is_not() -> None:
+    with pytest.raises(ChartsUnavailableError) as invalid:
+        charts_client.analyze_with_charts(
+            "image.jpg",
+            caption="caption",
+            runner=lambda _args, _deadline: ChartsProcessResult(0, '{"id": "short"}', ""),
+        )
+    assert invalid.value.reason == "invalid_contract"
+
+    with pytest.raises(ChartsAnalysisError) as structured:
+        charts_client.analyze_with_charts(
+            "image.jpg",
+            caption="caption",
+            runner=lambda _args, _deadline: ChartsProcessResult(
+                1,
+                "",
+                json.dumps({"error": "image download failed: HTTP 404"}),
+            ),
+        )
+    assert "HTTP 404" in str(structured.value)
+
+
+def test_deadline_kills_charts_child() -> None:
+    class FakeProcess:
+        returncode = None
+
+        def __init__(self):
+            self.killed = False
+            self.communicate_calls = 0
+
+        def communicate(self, timeout=None):
+            self.communicate_calls += 1
+            if self.communicate_calls == 1:
+                raise subprocess.TimeoutExpired(["charts"], timeout)
+            self.returncode = -9
+            return "", ""
+
+        def kill(self):
+            self.killed = True
+
+    process = FakeProcess()
+    popen_calls: list[tuple[list[str], dict]] = []
+
+    def popen_factory(args, **kwargs):
+        popen_calls.append((args, kwargs))
+        return process
+
+    with pytest.raises(ChartsUnavailableError) as timeout:
+        charts_client.run_charts_process(
+            ["charts", "analyze", "image.jpg"],
+            90,
+            popen_factory=popen_factory,
+        )
+
+    assert timeout.value.reason == "deadline"
+    assert process.killed is True
+    assert process.communicate_calls == 2
+    assert popen_calls[0][1]["text"] is True
+
+
+def test_charts_l1_cache_hit_keeps_id_and_skips_child(monkeypatch) -> None:
+    cached = {
+        "kind": "chart",
+        "short_description": "Cached chart",
+        "prose_text": "Cached transcript",
+        "prose_summary": "Cached insight",
+        "chart": {"tickers": ["TIP"]},
+        "table": {},
+        "charts_id": "c" * 64,
+        "cdn_url": f"https://charts.example/c/{'c' * 64}.jpg",
+        "charts_cached": False,
+    }
+    monkeypatch.setattr(triage_mod, "load_config", _charts_config)
+
+    def get_cached(url, *, provider, model):
+        assert provider == "charts"
+        assert model == "charts"
+        return cached
+
+    monkeypatch.setattr(triage_mod, "get_cached_media_analysis", get_cached)
+    monkeypatch.setattr(triage_mod, "increment_media_analysis_cache_hit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        triage_mod,
+        "analyze_media",
+        lambda *args, **kwargs: pytest.fail("charts child must not spawn on L1 hit"),
+    )
+
+    items, updated = triage_mod._analyze_media_items(
+        [{"url": "https://example.com/cached.jpg"}],
+        caption="tweet caption",
+    )
+
+    assert updated is True
+    assert items[0]["charts_id"] == "c" * 64
+    assert items[0]["cdn_url"].endswith(".jpg")
+
+
+def test_fallback_result_is_not_cached_under_charts_key(monkeypatch) -> None:
+    monkeypatch.setattr(triage_mod, "load_config", _charts_config)
+    monkeypatch.setattr(triage_mod, "get_cached_media_analysis", lambda *args, **kwargs: None)
+    recorded: list[tuple[str | None, str | None]] = []
+    monkeypatch.setattr(
+        triage_mod,
+        "record_media_analysis",
+        lambda _url, *, provider, model, result: recorded.append((provider, model)),
+    )
+    monkeypatch.setattr(
+        triage_mod,
+        "analyze_media",
+        lambda *args, **kwargs: MediaAnalysisResult(
+            kind="chart",
+            short_description="fallback",
+            prose_text="",
+            prose_summary="",
+            analysis_provider="gemini",
+            analysis_model="gemini-fallback",
+        ),
+    )
+
+    triage_mod._analyze_media_items([{"url": "https://example.com/fallback.jpg"}])
+
+    assert recorded == [("gemini", "gemini-fallback")]
+
+
+def test_fresh_charts_result_is_cached_under_charts_key(monkeypatch) -> None:
+    monkeypatch.setattr(triage_mod, "load_config", _charts_config)
+    monkeypatch.setattr(triage_mod, "get_cached_media_analysis", lambda *args, **kwargs: None)
+    recorded: list[tuple[str | None, str | None, str | None]] = []
+    monkeypatch.setattr(
+        triage_mod,
+        "record_media_analysis",
+        lambda _url, *, provider, model, result: recorded.append((provider, model, result["charts_id"])),
+    )
+
+    def analyze(_url, **kwargs):
+        assert kwargs["caption"] == "tweet caption"
+        return MediaAnalysisResult(
+            kind="chart",
+            short_description="charts result",
+            prose_text="",
+            prose_summary="",
+            charts_id="d" * 64,
+            cdn_url=f"https://charts.example/c/{'d' * 64}.jpg",
+            charts_cached=False,
+            analysis_provider="charts",
+            analysis_model="charts",
+        )
+
+    monkeypatch.setattr(triage_mod, "analyze_media", analyze)
+
+    triage_mod._analyze_media_items(
+        [{"url": "https://example.com/fresh.jpg"}],
+        caption="tweet caption",
+    )
+
+    assert recorded == [("charts", "charts", "d" * 64)]

--- a/tests/test_media_analysis_cache.py
+++ b/tests/test_media_analysis_cache.py
@@ -126,7 +126,7 @@ def test_analyze_media_items_reuses_cache(monkeypatch) -> None:
     monkeypatch.setattr(triage_mod, "record_media_analysis", _record_media_analysis)
     monkeypatch.setattr(triage_mod, "increment_media_analysis_cache_hit", lambda *args, **kwargs: None)
 
-    def _fake_analyze_media(url, model=None, provider=None):
+    def _fake_analyze_media(url, model=None, provider=None, **_kwargs):
         analyzed_urls.append(url)
         return MediaAnalysisResult(
             kind="table",

--- a/twag/cli/init_cmd.py
+++ b/twag/cli/init_cmd.py
@@ -166,15 +166,30 @@ def doctor(quiet: bool):
         "gemini": "GEMINI_API_KEY",
     }
     llm_config = cfg.get("llm", {})
+    vision_provider = llm_config.get("vision_provider", "gemini")
+    if vision_provider == "charts":
+        charts_executable = str(llm_config.get("charts_executable") or "charts")
+        charts_path = shutil.which(charts_executable)
+        console.print("\ncharts CLI:")
+        if charts_path:
+            console.print(f"  {status_icon(True)} Found at {charts_path}")
+        else:
+            console.print(f"  {status_icon(False)} {charts_executable} not found in PATH")
+            issues.append("Install charts or set llm.charts_executable to its executable path")
+
     required_keys = {
         provider_keys[provider]
         for provider in (
             llm_config.get("triage_provider", "gemini"),
             llm_config.get("enrichment_provider", "anthropic"),
-            llm_config.get("vision_provider", "gemini"),
+            vision_provider,
         )
         if provider in provider_keys
     }
+    if vision_provider == "charts":
+        # charts owns normal vision spend, but direct Gemini remains the
+        # contractually bounded fallback when the local runtime is unavailable.
+        required_keys.add("GEMINI_API_KEY")
 
     for key_name in sorted(required_keys):
         try:

--- a/twag/config.py
+++ b/twag/config.py
@@ -18,6 +18,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "enrichment_provider": "gemini",
         "vision_model": "gemini-3-flash-preview",
         "vision_provider": "gemini",
+        "charts_executable": "charts",
+        "charts_deadline_seconds": 90,
         "max_concurrency_triage": 6,
         "max_concurrency_text": 12,
         "max_concurrency_vision": 6,

--- a/twag/processor/triage.py
+++ b/twag/processor/triage.py
@@ -10,6 +10,7 @@ from collections import deque
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -244,6 +245,7 @@ def ensure_media_analysis(
         vision_model=vision_model,
         vision_provider=vision_provider,
         conn=conn,
+        caption=str(tweet_row["content"] or ""),
     )
 
     if updated or (media_items and not tweet_row["media_analysis"]):
@@ -265,6 +267,7 @@ def _analyze_media_items(
     vision_provider: str | None = None,
     conn: sqlite3.Connection | None = None,
     defer_db_writes: bool = False,
+    caption: str = "",
 ) -> _MediaAnalysisOutcome:
     """Analyze media and keep pipeline DB writes on the owning transaction."""
     updated = False
@@ -274,6 +277,8 @@ def _analyze_media_items(
     config = load_config()
     effective_model = vision_model or config["llm"].get("vision_model")
     effective_provider = vision_provider or config["llm"].get("vision_provider")
+    if effective_provider == "charts":
+        effective_model = "charts"
     usage_recorder = usage_records.append if defer_db_writes else None
     if conn is not None and not defer_db_writes:
 
@@ -317,7 +322,11 @@ def _analyze_media_items(
             analyze_kwargs: dict[str, Any] = {
                 "model": vision_model,
                 "provider": vision_provider,
+                "caption": caption,
             }
+            local_path = item.get("local_path")
+            if isinstance(local_path, str) and Path(local_path).is_file():
+                analyze_kwargs["local_path"] = local_path
             if usage_recorder is not None:
                 analyze_kwargs["usage_recorder"] = usage_recorder
             result = analyze_media(url, **analyze_kwargs)
@@ -331,14 +340,19 @@ def _analyze_media_items(
             "prose_summary": result.prose_summary,
             "chart": result.chart,
             "table": result.table,
+            "charts_id": result.charts_id,
+            "cdn_url": result.cdn_url,
+            "charts_cached": result.charts_cached,
         }
         _apply_media_analysis_to_item(item, result_payload)
+        result_provider = result.analysis_provider or effective_provider
+        result_model = result.analysis_model or effective_model
         if defer_db_writes:
-            cache_records.append((url, effective_provider, effective_model, result_payload))
+            cache_records.append((url, result_provider, result_model, result_payload))
         else:
             record_kwargs: dict[str, Any] = {
-                "provider": effective_provider,
-                "model": effective_model,
+                "provider": result_provider,
+                "model": result_model,
                 "result": result_payload,
             }
             if conn is not None:
@@ -366,6 +380,9 @@ def _apply_media_analysis_to_item(item: dict[str, Any], result: dict[str, Any]) 
     item["prose_summary"] = result.get("prose_summary", "")
     item["chart"] = result.get("chart") or {}
     item["table"] = result.get("table") or {}
+    for field_name in ("charts_id", "cdn_url", "charts_cached"):
+        if field_name in result:
+            item[field_name] = result[field_name]
 
 
 def _page_number_hint(text: str) -> int | None:
@@ -534,6 +551,7 @@ def _process_article(
     article_text: str,
     article_title: str,
     article_preview: str,
+    caption: str,
     enrich_model: str | None,
 ) -> tuple[Any, _MediaAnalysisOutcome]:
     """Analyze media then summarize article — runs in text_pool thread."""
@@ -542,6 +560,7 @@ def _process_article(
         vision_model=vision_model,
         vision_provider=vision_provider,
         defer_db_writes=True,
+        caption=caption,
     )
     article_result = summarize_x_article(
         article_text,
@@ -783,6 +802,7 @@ def _triage_rows(
                     article_text=article_text,
                     article_title=row["article_title"] or "",
                     article_preview=row["article_preview"] or "",
+                    caption=str(row["content"] or ""),
                     enrich_model=enrich_model,
                 )
             else:
@@ -807,6 +827,7 @@ def _triage_rows(
                         vision_model=vision_model,
                         vision_provider=vision_provider,
                         conn=conn,
+                        caption=str(row["content"] or ""),
                     )
                 article_result = summarize_x_article(
                     article_text,
@@ -1012,6 +1033,7 @@ def _triage_rows(
                             vision_model=vision_model,
                             vision_provider=vision_provider,
                             defer_db_writes=True,
+                            caption=str(tweet_row["content"] or ""),
                         )
                         _track_worker_future(future, "media", result.tweet_id)
                     else:
@@ -1022,6 +1044,7 @@ def _triage_rows(
                             vision_model=vision_model,
                             vision_provider=vision_provider,
                             conn=conn,
+                            caption=str(tweet_row["content"] or ""),
                         )
                         media_summary = build_media_summary(updated_items)
                         update_tweet_enrichment(

--- a/twag/scorer/charts_client.py
+++ b/twag/scorer/charts_client.py
@@ -1,0 +1,247 @@
+"""Strict subprocess client for the machine-wide charts vision service."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+CHARTS_MODEL_KEY = "charts"
+CHARTS_PROVIDER = "charts"
+CHARTS_TAG_FIELDS = (
+    "tickers",
+    "countries",
+    "asset_classes",
+    "fx_pairs",
+    "indices",
+    "concepts",
+    "themes",
+)
+
+
+@dataclass(frozen=True)
+class ChartsProcessResult:
+    """Captured result from one charts child process."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+@dataclass(frozen=True)
+class ChartsAnalysis:
+    """Validated charts analyze response."""
+
+    id: str
+    ext: str
+    kind: str
+    status: str
+    tag_status: str
+    title: str | None
+    transcript: str | None
+    insight: str | None
+    caption: str | None
+    tags: dict[str, list[str]]
+    cdn_url: str | None
+    cached: bool
+
+
+class ChartsUnavailableError(RuntimeError):
+    """The charts runtime could not produce a valid contract response."""
+
+    def __init__(self, reason: str, message: str):
+        super().__init__(message)
+        self.reason = reason
+
+
+class ChartsAnalysisError(RuntimeError):
+    """charts was available but returned a structured analysis failure."""
+
+    def __init__(self, message: str, details: dict[str, Any]):
+        super().__init__(message)
+        self.details = details
+
+
+ChartsRunner = Callable[[list[str], float], ChartsProcessResult]
+
+
+def run_charts_process(
+    args: list[str],
+    deadline_seconds: float,
+    *,
+    popen_factory: Callable[..., Any] = subprocess.Popen,
+) -> ChartsProcessResult:
+    """Run charts without a shell, killing the child when its deadline expires."""
+    try:
+        process = popen_factory(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError as exc:
+        raise ChartsUnavailableError("spawn_failure", f"could not start charts: {exc}") from exc
+
+    try:
+        stdout, stderr = process.communicate(timeout=deadline_seconds)
+    except subprocess.TimeoutExpired as exc:
+        process.kill()
+        process.communicate()
+        raise ChartsUnavailableError(
+            "deadline",
+            f"charts exceeded its {deadline_seconds:g}s deadline",
+        ) from exc
+
+    return ChartsProcessResult(
+        returncode=int(process.returncode),
+        stdout=stdout or "",
+        stderr=stderr or "",
+    )
+
+
+def _parse_json_object(text: str) -> dict[str, Any] | None:
+    try:
+        value = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _optional_string(value: Any, field: str) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    raise ValueError(f"{field} must be a string or null")
+
+
+def _validate_success(payload: dict[str, Any]) -> ChartsAnalysis:
+    required = {
+        "id",
+        "ext",
+        "kind",
+        "status",
+        "tag_status",
+        "title",
+        "transcript",
+        "insight",
+        "caption",
+        "tags",
+        "cdn_url",
+        "cached",
+    }
+    missing = sorted(required.difference(payload))
+    if missing:
+        raise ValueError(f"missing required fields: {', '.join(missing)}")
+
+    chart_id = payload["id"]
+    if (
+        not isinstance(chart_id, str)
+        or len(chart_id) != 64
+        or any(character not in "0123456789abcdef" for character in chart_id)
+    ):
+        raise ValueError("id must be a 64-character SHA-256 hex string")
+
+    ext = payload["ext"]
+    if ext not in {"png", "jpg", "webp", "gif"}:
+        raise ValueError("ext is not supported by the charts contract")
+    kind = payload["kind"]
+    if kind not in {"chart", "table", "document", "photo", "meme", "other"}:
+        raise ValueError("kind is not supported by the charts contract")
+    status = payload["status"]
+    if status not in {"active", "rejected"}:
+        raise ValueError("status is not supported by the charts contract")
+    if status == "active" and kind not in {"chart", "table", "document"}:
+        raise ValueError("active results must be charts, tables, or documents")
+    if status == "rejected" and kind not in {"photo", "meme", "other"}:
+        raise ValueError("rejected results must be photos, memes, or other media")
+    if payload["tag_status"] != "tagged":
+        raise ValueError("tag_status must be tagged")
+    if not isinstance(payload["cached"], bool):
+        raise ValueError("cached must be a boolean")
+
+    raw_tags = payload["tags"]
+    if not isinstance(raw_tags, dict):
+        raise ValueError("tags must be an object")
+    tags: dict[str, list[str]] = {}
+    for field in CHARTS_TAG_FIELDS:
+        values = raw_tags.get(field)
+        if not isinstance(values, list) or any(not isinstance(value, str) for value in values):
+            raise ValueError(f"tags.{field} must be an array of strings")
+        tags[field] = [value for value in values if isinstance(value, str)]
+
+    cdn_url = _optional_string(payload["cdn_url"], "cdn_url")
+    if status == "rejected" and cdn_url is not None:
+        raise ValueError("rejected results must not have a CDN URL")
+
+    return ChartsAnalysis(
+        id=chart_id,
+        ext=ext,
+        kind=kind,
+        status=status,
+        tag_status="tagged",
+        title=_optional_string(payload["title"], "title"),
+        transcript=_optional_string(payload["transcript"], "transcript"),
+        insight=_optional_string(payload["insight"], "insight"),
+        caption=_optional_string(payload["caption"], "caption"),
+        tags=tags,
+        cdn_url=cdn_url,
+        cached=payload["cached"],
+    )
+
+
+def analyze_with_charts(
+    input_ref: str,
+    *,
+    caption: str,
+    executable: str = "charts",
+    deadline_seconds: float = 90.0,
+    runner: ChartsRunner | None = None,
+) -> ChartsAnalysis:
+    """Invoke and validate ``charts analyze`` according to its consumer contract."""
+    args = [
+        executable,
+        "analyze",
+        input_ref,
+        "--source",
+        "twitter",
+        "--caption",
+        caption,
+        "--json",
+    ]
+    invoke = runner or run_charts_process
+    try:
+        result = invoke(args, deadline_seconds)
+    except ChartsUnavailableError:
+        raise
+    except OSError as exc:
+        raise ChartsUnavailableError("spawn_failure", f"could not start charts: {exc}") from exc
+
+    if result.returncode != 0:
+        failure = _parse_json_object(result.stderr.strip())
+        if failure is None:
+            raise ChartsUnavailableError(
+                "invalid_contract",
+                "charts failed without a valid structured error document",
+            )
+        message = failure.get("error")
+        if not isinstance(message, str) or not message.strip():
+            raise ChartsUnavailableError(
+                "invalid_contract",
+                "charts failure document did not contain an error string",
+            )
+        raise ChartsAnalysisError(message.strip(), failure)
+
+    payload = _parse_json_object(result.stdout.strip())
+    if payload is None:
+        raise ChartsUnavailableError(
+            "invalid_contract",
+            "charts exited successfully without a JSON object on stdout",
+        )
+    try:
+        return _validate_success(payload)
+    except ValueError as exc:
+        raise ChartsUnavailableError(
+            "invalid_contract",
+            f"charts response violated the consumer contract: {exc}",
+        ) from exc

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -854,6 +854,39 @@ def _call_llm(
     return _with_retry(_invoke)
 
 
+def _call_llm_vision_once(
+    provider: str,
+    model: str,
+    image_url: str,
+    prompt: str,
+    max_tokens: int = 1024,
+    component: str = "vision",
+    usage_recorder: UsageRecorder | None = None,
+) -> str:
+    """Call one vision provider attempt without the generic retry wrapper."""
+    if provider == "gemini":
+        return _call_gemini_vision(
+            model,
+            image_url,
+            prompt,
+            max_tokens,
+            component=component,
+            usage_recorder=usage_recorder,
+        )
+    if provider == "anthropic":
+        return _call_anthropic_vision(
+            model,
+            image_url,
+            prompt,
+            max_tokens,
+            component=component,
+            usage_recorder=usage_recorder,
+        )
+    if provider == "deepseek":
+        raise ValueError("DeepSeek provider does not support twag vision analysis; use gemini or anthropic")
+    raise ValueError(f"Unsupported LLM provider: {provider}")
+
+
 def _call_llm_vision(
     provider: str,
     model: str,
@@ -865,30 +898,17 @@ def _call_llm_vision(
 ) -> str:
     """Call LLM with vision based on provider."""
 
-    def _invoke() -> str:
-        if provider == "gemini":
-            return _call_gemini_vision(
-                model,
-                image_url,
-                prompt,
-                max_tokens,
-                component=component,
-                usage_recorder=usage_recorder,
-            )
-        if provider == "anthropic":
-            return _call_anthropic_vision(
-                model,
-                image_url,
-                prompt,
-                max_tokens,
-                component=component,
-                usage_recorder=usage_recorder,
-            )
-        if provider == "deepseek":
-            raise ValueError("DeepSeek provider does not support twag vision analysis; use gemini or anthropic")
-        raise ValueError(f"Unsupported LLM provider: {provider}")
-
-    return _with_retry(_invoke)
+    return _with_retry(
+        lambda: _call_llm_vision_once(
+            provider,
+            model,
+            image_url,
+            prompt,
+            max_tokens,
+            component=component,
+            usage_recorder=usage_recorder,
+        ),
+    )
 
 
 def _with_retry(fn: Callable[[], _T]) -> _T:

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -2,6 +2,8 @@
 
 import logging
 import sqlite3
+import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -10,7 +12,21 @@ from typing import Any
 from twag.config import load_config
 from twag.taxonomy import categories_line
 
-from .llm_client import _call_llm, _call_llm_vision, _parse_json_response
+from .charts_client import (
+    CHARTS_MODEL_KEY,
+    CHARTS_PROVIDER,
+    ChartsAnalysis,
+    ChartsAnalysisError,
+    ChartsUnavailableError,
+    analyze_with_charts,
+)
+from .llm_client import (
+    _call_llm,
+    _call_llm_vision,
+    _call_llm_vision_once,
+    _parse_json_response,
+    _record_llm_usage,
+)
 from .prompts import (
     ARTICLE_SUMMARY_PROMPT,
     BATCH_TRIAGE_PROMPT,
@@ -34,6 +50,7 @@ PLAYBOOK_TRIGGERS = [
     "dat_mnav",
     "defensive_break",
 ]
+_CHARTS_FALLBACK_SEMAPHORE = threading.BoundedSemaphore(2)
 
 TRIAGE_BATCH_SCHEMA: dict[str, Any] = {
     "type": "array",
@@ -108,6 +125,11 @@ class MediaAnalysisResult:
     prose_summary: str
     chart: dict[str, Any] = field(default_factory=dict)
     table: dict[str, Any] = field(default_factory=dict)
+    charts_id: str | None = None
+    cdn_url: str | None = None
+    charts_cached: bool | None = None
+    analysis_provider: str | None = None
+    analysis_model: str | None = None
 
 
 @dataclass
@@ -547,28 +569,13 @@ def summarize_x_article(
     )
 
 
-def analyze_image(
-    image_url: str,
-    model: str | None = None,
-    provider: str | None = None,
-    usage_recorder: Callable[[dict[str, Any]], None] | None = None,
+def _media_result_from_llm_data(
+    data: dict[str, Any] | list[dict[str, Any]],
+    *,
+    provider: str,
+    model: str,
 ) -> MediaAnalysisResult:
-    """Analyze a chart or image from a tweet."""
-    config = load_config()
-    model = model or config["llm"]["vision_model"]
-    provider = provider or config["llm"].get("vision_provider", "anthropic")
-
-    text = _call_llm_vision(
-        provider,
-        model,
-        image_url,
-        MEDIA_PROMPT,
-        max_tokens=4096,
-        component="vision",
-        usage_recorder=usage_recorder,
-    )
-    data = _parse_json_response(text)
-
+    """Map twag's direct-provider JSON shape onto the shared media result."""
     if isinstance(data, list):
         data = data[0]
 
@@ -600,6 +607,196 @@ def analyze_image(
             "summary": table.get("summary", ""),
             "tickers": table.get("tickers", []),
         },
+        analysis_provider=provider,
+        analysis_model=model,
+    )
+
+
+def _media_result_from_charts(result: ChartsAnalysis) -> MediaAnalysisResult:
+    """Map the charts consumer contract onto twag's media fields.
+
+    charts owns classification and OCR. Its transcript becomes searchable prose,
+    while its insight supplies the concise summary/description. Chart and table
+    payloads retain the normalized tag object and promote ticker tags into the
+    existing fields consumed by twag renderers.
+    """
+    title = (result.title or "").strip()
+    transcript = (result.transcript or "").strip()
+    insight = (result.insight or "").strip()
+    short_description = insight or title or transcript
+    chart: dict[str, Any] = {}
+    table: dict[str, Any] = {}
+    if result.kind == "chart":
+        chart = {
+            "type": "",
+            "description": title or transcript,
+            "insight": insight,
+            "implication": "",
+            "tickers": result.tags["tickers"],
+            "tags": result.tags,
+        }
+    elif result.kind == "table":
+        table = {
+            "title": title,
+            "description": transcript,
+            "columns": [],
+            "rows": [],
+            "summary": insight,
+            "tickers": result.tags["tickers"],
+            "tags": result.tags,
+        }
+
+    return MediaAnalysisResult(
+        kind=result.kind,
+        short_description=short_description,
+        prose_text=transcript,
+        prose_summary=insight,
+        chart=chart,
+        table=table,
+        charts_id=result.id,
+        cdn_url=result.cdn_url,
+        charts_cached=result.cached,
+        analysis_provider=CHARTS_PROVIDER,
+        analysis_model=CHARTS_MODEL_KEY,
+    )
+
+
+def _record_charts_usage(
+    *,
+    caption: str,
+    latency_seconds: float,
+    success: bool,
+    result: ChartsAnalysis | None = None,
+    error: Exception | None = None,
+    metadata: dict[str, Any] | None = None,
+    usage_recorder: Callable[[dict[str, Any]], None] | None = None,
+) -> None:
+    details = dict(metadata or {})
+    if result is not None:
+        details.update(
+            {
+                "charts_id": result.id,
+                "cdn_url": result.cdn_url,
+                "cached": result.cached,
+                "status": result.status,
+                "tag_status": result.tag_status,
+                "kind": result.kind,
+            },
+        )
+    _record_llm_usage(
+        component="vision",
+        provider=CHARTS_PROVIDER,
+        model=CHARTS_MODEL_KEY,
+        prompt=caption,
+        max_tokens=0,
+        latency_seconds=latency_seconds,
+        success=success,
+        is_vision=True,
+        response_text=result.transcript if result else None,
+        error=error,
+        metadata=details or None,
+        usage_recorder=usage_recorder,
+    )
+
+
+def _positive_float(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def analyze_image(
+    image_url: str,
+    model: str | None = None,
+    provider: str | None = None,
+    usage_recorder: Callable[[dict[str, Any]], None] | None = None,
+    *,
+    caption: str = "",
+    local_path: str | None = None,
+) -> MediaAnalysisResult:
+    """Analyze a chart or image from a tweet."""
+    config = load_config()
+    model = model or config["llm"]["vision_model"]
+    provider = provider or config["llm"].get("vision_provider", "anthropic")
+
+    if provider == CHARTS_PROVIDER:
+        charts_input = local_path or image_url
+        deadline_seconds = _positive_float(config["llm"].get("charts_deadline_seconds"), 90.0)
+        executable = str(config["llm"].get("charts_executable") or "charts")
+        started = time.monotonic()
+        try:
+            charts_result = analyze_with_charts(
+                charts_input,
+                caption=caption,
+                executable=executable,
+                deadline_seconds=deadline_seconds,
+            )
+        except ChartsAnalysisError as exc:
+            _record_charts_usage(
+                caption=caption,
+                latency_seconds=time.monotonic() - started,
+                success=False,
+                error=exc,
+                metadata={"failure": "structured", "details": exc.details},
+                usage_recorder=usage_recorder,
+            )
+            raise
+        except ChartsUnavailableError as exc:
+            from twag.metrics import get_collector
+
+            get_collector().inc(f"scorer.charts.unavailable.{exc.reason}")
+            _record_charts_usage(
+                caption=caption,
+                latency_seconds=time.monotonic() - started,
+                success=False,
+                error=exc,
+                metadata={"unavailable_reason": exc.reason},
+                usage_recorder=usage_recorder,
+            )
+            # The central service was unavailable, so make one bounded direct
+            # Gemini call without the generic retry loop. Cache metadata below
+            # identifies the real provider, preventing this degraded result
+            # from being stored under the charts L1 key.
+            with _CHARTS_FALLBACK_SEMAPHORE:
+                text = _call_llm_vision_once(
+                    "gemini",
+                    model,
+                    image_url,
+                    MEDIA_PROMPT,
+                    max_tokens=4096,
+                    component="vision",
+                    usage_recorder=usage_recorder,
+                )
+            return _media_result_from_llm_data(
+                _parse_json_response(text),
+                provider="gemini",
+                model=model,
+            )
+        else:
+            _record_charts_usage(
+                caption=caption,
+                latency_seconds=time.monotonic() - started,
+                success=True,
+                result=charts_result,
+                usage_recorder=usage_recorder,
+            )
+            return _media_result_from_charts(charts_result)
+
+    text = _call_llm_vision(
+        provider,
+        model,
+        image_url,
+        MEDIA_PROMPT,
+        max_tokens=4096,
+        component="vision",
+        usage_recorder=usage_recorder,
+    )
+    return _media_result_from_llm_data(
+        _parse_json_response(text),
+        provider=provider,
+        model=model,
     )
 
 
@@ -608,6 +805,9 @@ def analyze_media(
     model: str | None = None,
     provider: str | None = None,
     usage_recorder: Callable[[dict[str, Any]], None] | None = None,
+    *,
+    caption: str = "",
+    local_path: str | None = None,
 ) -> MediaAnalysisResult:
     """Analyze any tweet media image with OCR and classification."""
     return analyze_image(
@@ -615,4 +815,6 @@ def analyze_media(
         model=model,
         provider=provider,
         usage_recorder=usage_recorder,
+        caption=caption,
+        local_path=local_path,
     )


### PR DESCRIPTION
## Summary
- add a strict, deadline-killed `charts analyze` subprocess client using an argument array and the documented JSON contract
- map charts transcripts, insights, tags, IDs, CDN URLs, and cache state into twag media results
- retain twag URL cache as L1 under `charts/charts`, while charts owns content-hash L2 and Gemini spend
- record zero-cost `provider=charts` vision usage and preserve normal Gemini usage for bounded unavailable-only fallback
- accept rejected media and structured charts failures without fallback; fallback exactly once only for spawn failure, deadline, or invalid contract output
- thread tweet text captions and local-file handoffs through synchronous and worker media paths
- document configuration and teach `twag doctor` to verify charts plus the fallback Gemini key

## Verification
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q`
- commit-hook formatter, Ruff, latest `ty`, and full pytest suite
- focused tests cover L1 hits, current-key cache writes, zero-cost usage, response mapping, rejection, structured failure, unavailable fallback, exact-one direct call, invalid contract, and deadline kill

## Deployment gate
Do not merge or deploy until the explicit review verdict arrives. After approval and merge: reinstall from a clean merge worktree, set `llm.vision_provider=charts`, and verify two real service cycles against both twag and charts ledgers.