### PR TITLE
Tolerate missing tier-1 users during fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ twag fetch --stagger 5          # Only fetch 5 least-recent tier-1 accounts
 twag fetch --delay 5.0          # 5s delay between tier-1 fetches (default: 3s)
 ```
 
+Tier-1 accounts that Bird reports as not found are logged as warnings and skipped
+without failing the fetch. Transient Bird failures keep their normal retry and
+error behavior.
+
 ### Process Commands
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -212,6 +212,9 @@ twag fetch --source search -q "query"  # Search tweets
 twag fetch --stagger 5        # Rotate: fetch 5 least-recent tier-1
 twag fetch --delay 5.0        # Pacing between tier-1 fetches (default: 3s)
 
+Missing tier-1 users are warned and skipped without failing the fetch; transient
+Bird errors still retry and fail normally.
+
 twag process                  # Score unprocessed (no alerts by default)
 twag process -n 100           # Limit batch
 twag process --dry-run        # Preview

--- a/tests/test_cli_fetch_tier1.py
+++ b/tests/test_cli_fetch_tier1.py
@@ -1,0 +1,78 @@
+"""CLI tests for tier-1 account fetch behavior."""
+
+import json
+import logging
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+from twag.cli import cli
+from twag.metrics import get_collector
+
+
+def test_tier1_missing_user_warns_and_healthy_account_succeeds(monkeypatch, caplog):
+    """A missing tier-1 user must not discard healthy accounts or fail the fetch."""
+    import twag.cli.fetch as cli_mod
+    import twag.config as config_mod
+    import twag.db as db_mod
+    import twag.fetcher as fetcher_mod
+    import twag.fetcher.bird_cli as bird_cli_mod
+    import twag.processor as processor_mod
+
+    accounts = [{"handle": "missing"}, {"handle": "healthy"}]
+    runner_calls: list[str] = []
+    stored: list[tuple[list, str, dict]] = []
+    marked_fetched: list[str] = []
+
+    def bird_runner(args: list[str]) -> tuple[str, str, int]:
+        handle = args[1]
+        runner_calls.append(handle)
+        if handle == "@missing":
+            return "", "User @missing not found", 1
+        return (
+            json.dumps([{"id": "healthy-1", "author": {"username": "healthy"}, "text": "still here"}]),
+            "",
+            0,
+        )
+
+    def fetch_user_tweets(handle: str, count: int):
+        return bird_cli_mod.fetch_user_tweets(handle, count, bird_runner=bird_runner)
+
+    def store_fetched_tweets(tweets, source, query_params=None, **_kwargs):
+        stored.append((tweets, source, query_params or {}))
+        return len(tweets), len(tweets)
+
+    @contextmanager
+    def get_connection():
+        yield MagicMock()
+
+    monkeypatch.setattr(cli_mod, "init_db", lambda: None)
+    monkeypatch.setattr(cli_mod, "get_accounts", lambda *_args, **_kwargs: accounts)
+    monkeypatch.setattr(cli_mod, "get_connection", get_connection)
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"fetch": {"tier1_stagger": None}})
+    monkeypatch.setattr(fetcher_mod, "fetch_home_timeline", lambda count: [])
+    monkeypatch.setattr(fetcher_mod, "fetch_user_tweets", fetch_user_tweets)
+    monkeypatch.setattr(processor_mod, "store_fetched_tweets", store_fetched_tweets)
+    monkeypatch.setattr(
+        db_mod,
+        "update_account_last_fetched",
+        lambda _conn, handle: marked_fetched.append(handle),
+    )
+
+    metrics = get_collector()
+    not_found_before = metrics.counter_value("fetch.accounts.not_found")
+    caplog.set_level(logging.WARNING, logger="twag.cli.fetch")
+
+    result = CliRunner().invoke(cli, ["fetch", "--no-bookmarks", "--delay", "0"])
+
+    assert result.exit_code == 0
+    assert runner_calls == ["@missing", "@healthy"]
+    assert len(stored) == 1
+    assert stored[0][0][0].id == "healthy-1"
+    assert stored[0][1:] == ("user", {"handle": "healthy", "count": 20})
+    assert marked_fetched == ["missing", "healthy"]
+    assert "tier-1 account @missing not found; skipping" in caplog.text
+    assert metrics.counter_value("fetch.accounts.not_found") == not_found_before + 1
+    assert "account(s) failed" not in result.output
+    assert "error(s) during fetch" not in result.output

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -736,7 +736,11 @@ class TestRunBird:
 
     def test_run_bird_does_not_retry_not_found(self, mock_subprocess, mock_auth_env):
         """Unavailable users should not be retried as transient failures."""
+        from twag.metrics import get_collector
+
         mock_subprocess.return_value = MagicMock(stderr="User @missing not found", returncode=1)
+        metrics = get_collector()
+        errors_before = metrics.counter_value("fetcher.errors")
 
         stdout, stderr, code = run_bird(["user-tweets", "@missing", "-n", "1", "--json"])
 
@@ -744,6 +748,7 @@ class TestRunBird:
         assert stderr == "User @missing not found"
         assert code == 1
         mock_subprocess.assert_called_once()
+        assert metrics.counter_value("fetcher.errors") == errors_before
 
 
 # ============================================================================

--- a/twag/cli/fetch.py
+++ b/twag/cli/fetch.py
@@ -1,5 +1,6 @@
 """Fetch command."""
 
+import logging
 import sys
 
 import rich_click as click
@@ -8,6 +9,8 @@ from ..db import get_accounts, get_connection, init_db
 from ._console import console
 from ._helpers import _normalize_status_id_or_url
 from ._progress import RichProgressReporter, create_progress, make_callbacks
+
+log = logging.getLogger(__name__)
 
 
 @click.command()
@@ -37,7 +40,14 @@ def fetch(
     stagger: int | None,
 ):
     """Fetch tweets from Twitter/X."""
-    from ..fetcher import fetch_bookmarks, fetch_home_timeline, fetch_search, fetch_user_tweets, read_tweet
+    from ..fetcher import (
+        UserNotFoundError,
+        fetch_bookmarks,
+        fetch_home_timeline,
+        fetch_search,
+        fetch_user_tweets,
+        read_tweet,
+    )
     from ..processor import auto_promote_bookmarked_authors, store_bookmarked_tweets, store_fetched_tweets
 
     init_db()
@@ -180,6 +190,12 @@ def fetch(
                             update_account_last_fetched(conn, account["handle"])
                             conn.commit()
 
+                    except UserNotFoundError:
+                        log.warning("tier-1 account %s not found; skipping", handle_label)
+                        console.print(f"[yellow]  Warning: {handle_label} not found; skipping[/yellow]")
+                        with get_connection() as conn:
+                            update_account_last_fetched(conn, account["handle"])
+                            conn.commit()
                     except RuntimeError as e:
                         console.print(f"[red]  @{account['handle']}: {e}[/red]")
                         tier1_errors += 1

--- a/twag/fetcher/__init__.py
+++ b/twag/fetcher/__init__.py
@@ -1,6 +1,7 @@
 """Bird CLI wrapper for fetching tweets."""
 
 from .bird_cli import (
+    UserNotFoundError,
     _parse_bird_output,
     fetch_bookmarks,
     fetch_home_timeline,
@@ -17,6 +18,7 @@ from .extractors import Tweet
 
 __all__ = [
     "Tweet",
+    "UserNotFoundError",
     "_parse_bird_output",
     "fetch_bookmarks",
     "fetch_home_timeline",

--- a/twag/fetcher/bird_cli.py
+++ b/twag/fetcher/bird_cli.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 import threading
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -62,9 +63,22 @@ class ReadTweetResult:
     failure: ReadTweetFailure | None = None
 
 
+class UserNotFoundError(RuntimeError):
+    """Raised when ``bird user-tweets`` reports a permanently unavailable user."""
+
+    def __init__(self, handle: str):
+        self.handle = handle
+        super().__init__(f"bird user-tweets failed for {handle}: user not found")
+
+
 def _is_rate_limited(stderr: str) -> bool:
     """Check if bird CLI stderr indicates a 429 rate limit."""
     return "429" in stderr or "Rate limit" in stderr or "rate limit" in stderr
+
+
+def _is_user_not_found(stderr: str) -> bool:
+    """Identify Bird's terminal missing-user response without matching a missing CLI."""
+    return re.search(r"\buser\b[^\n]*\bnot found\b", stderr, flags=re.IGNORECASE) is not None
 
 
 def _is_retryable_bird_failure(stderr: str) -> bool:
@@ -128,13 +142,14 @@ def _run_bird_once(
             )
             tmp.seek(0)
             stdout = tmp.read()
+        user_not_found = args[:1] == ["user-tweets"] and _is_user_not_found(result.stderr)
         if result.stderr.strip():
             lines = result.stderr.strip().splitlines()
             meaningful = [ln for ln in lines if not ln.strip().startswith("\u2139")]
             if meaningful and log_failures:
-                level = logging.WARNING if result.returncode == 0 else logging.ERROR
+                level = logging.WARNING if result.returncode == 0 or user_not_found else logging.ERROR
                 log.log(level, "bird %s stderr: %s", args[0] if args else "?", _redact_stderr("\n".join(meaningful)))
-        if result.returncode != 0 and log_failures:
+        if result.returncode != 0 and log_failures and not user_not_found:
             log.error("bird %s exited with code %d", args[0] if args else "?", result.returncode)
         return stdout, result.stderr, result.returncode
     except subprocess.TimeoutExpired:
@@ -181,7 +196,8 @@ def run_bird(args: list[str], timeout: int = 60, *, log_failures: bool = True) -
 
         if returncode == 0 or not _is_retryable_bird_failure(stderr):
             m.observe("fetcher.latency_seconds", time.monotonic() - t0)
-            if returncode != 0:
+            user_not_found = args[:1] == ["user-tweets"] and _is_user_not_found(stderr)
+            if returncode != 0 and not user_not_found:
                 m.inc("fetcher.errors")
             return stdout, stderr, returncode
 
@@ -379,15 +395,26 @@ def fetch_home_timeline(count: int = 100) -> list[Tweet]:
     return _hydrate_truncated_retweets(tweets)
 
 
-def fetch_user_tweets(handle: str, count: int = 50) -> list[Tweet]:
+def fetch_user_tweets(
+    handle: str,
+    count: int = 50,
+    *,
+    bird_runner: Callable[[list[str]], tuple[str, str, int]] | None = None,
+) -> list[Tweet]:
     """Fetch tweets from a specific user."""
     # Normalize handle
     if not handle.startswith("@"):
         handle = f"@{handle}"
 
-    stdout, stderr, code = run_bird(["user-tweets", handle, "-n", str(count), "--json"])
+    runner = bird_runner or run_bird
+    stdout, stderr, code = runner(["user-tweets", handle, "-n", str(count), "--json"])
 
     if code != 0:
+        if _is_user_not_found(stderr):
+            from twag.metrics import get_collector
+
+            get_collector().inc("fetch.accounts.not_found")
+            raise UserNotFoundError(handle)
         raise RuntimeError(f"bird user-tweets failed for {handle} (exit {code}): {stderr.strip()}")
 
     tweets = _parse_bird_output(stdout)


### PR DESCRIPTION
## Summary

- classify `bird user-tweets` user-not-found responses separately from transient and operational failures
- warn with the missing handle, increment `fetch.accounts.not_found`, and continue the tier-1 batch without contributing to the fetch exit code
- mark the attempted account as fetched so staggered rotation can continue to healthy accounts
- preserve existing retry and error behavior for transient Bird failures
- document the behavior in the README and OpenClaw skill reference

## Root cause

A renamed or suspended tier-1 account returns a terminal `User ... not found` response from Bird. The tier-1 loop previously treated every `RuntimeError` as a fetch error, making the full fetch command exit 1 and causing repeated OpenClaw failure alerts even though other accounts fetched successfully.

## Validation

- `uv run ruff format .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q`

The new injected-runner test covers one missing account followed by one healthy account and verifies successful exit, healthy tweet storage, warning capture, metric increment, and no generic fetch error.
