### PR TITLE
Make DeepSeek V4 Flash the default triage model

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,12 +381,14 @@ twag web --no-reload            # Disable auto-reload on code changes
 ```bash
 twag config show                # Show current config
 twag config path                # Show config file path
-twag config set llm.triage_model gemini-2.0-flash
+twag config set llm.triage_model deepseek-v4-flash
 twag config set llm.vision_provider charts
 twag config set scoring.alert_threshold 8
 twag config set scoring.min_score_for_analysis 6
 twag config set scoring.max_article_summary_chars 20000
 ```
+
+New configurations default triage to `deepseek-v4-flash` with reasoning disabled; enrichment settings are unchanged.
 
 ### charts vision provider
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+"""Tests for default configuration."""
+
+from twag.config import load_config
+
+
+def test_default_triage_uses_deepseek_v4_flash() -> None:
+    llm_config = load_config()["llm"]
+
+    assert llm_config["triage_model"] == "deepseek-v4-flash"
+    assert llm_config["triage_provider"] == "deepseek"
+    assert llm_config["triage_reasoning"] == "disabled"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -255,10 +255,12 @@ def test_call_deepseek_uses_strict_beta_tool_for_json_schema(monkeypatch) -> Non
 
     assert result == '[{"id": "1"}]'
     assert seen["url"] == "https://api.deepseek.com/beta/chat/completions"
+    assert seen["payload"]["model"] == "deepseek-v4-flash"
     assert seen["payload"]["thinking"] == {"type": "disabled"}
     assert "reasoning_effort" not in seen["payload"]
     assert seen["payload"]["tools"][0]["function"]["strict"] is True
     assert seen["payload"]["tools"][0]["function"]["parameters"]["properties"]["result"] == schema
+    assert seen["payload"]["tool_choice"] == {"type": "function", "function": {"name": "emit_result"}}
 
 
 def test_call_gemini_uses_standard_response_json_schema(monkeypatch) -> None:

--- a/twag/config.py
+++ b/twag/config.py
@@ -12,8 +12,9 @@ APP_NAME = "twag"
 # Default configuration
 DEFAULT_CONFIG: dict[str, Any] = {
     "llm": {
-        "triage_model": "gemini-3-flash-preview",
-        "triage_provider": "gemini",
+        "triage_model": "deepseek-v4-flash",
+        "triage_provider": "deepseek",
+        "triage_reasoning": "disabled",
         "enrichment_model": "gemini-3.1-pro-preview",
         "enrichment_provider": "gemini",
         "vision_model": "gemini-3-flash-preview",


### PR DESCRIPTION
## Summary

- make new twag configurations use `deepseek-v4-flash` for triage with the DeepSeek provider and reasoning disabled
- leave enrichment configuration unchanged
- document the default and add regression coverage for the default plus the Flash strict-tool request shape

## Why

The deployed triage configuration already used DeepSeek Pro with reasoning disabled, but the repository default had drifted back to Gemini. DeepSeek V4 Flash is now the preferred low-latency triage model, so fresh configurations need a valid DeepSeek/Flash/disabled trio.

DeepSeek's current pricing page still lists Flash at $0.14/M uncached input tokens, $0.28/M output tokens, and $0.0028/M cache-hit input tokens, matching the existing `MODEL_PRICES` row; no pricing code change was needed.

## Impact

Only triage defaults change. Enrichment model, provider, and reasoning settings are untouched. Existing user config remains unchanged until explicitly updated during deployment.

## Checks

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q`
