### PR TITLE
Enable high reasoning for DeepSeek Flash triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,9 @@ twag config set scoring.min_score_for_analysis 6
 twag config set scoring.max_article_summary_chars 20000
 ```
 
-New configurations default triage to `deepseek-v4-flash` with reasoning high; enrichment settings are unchanged.
+New configurations default triage to `deepseek-v4-flash` with reasoning high and `triage_max_tokens` 16384.
+DeepSeek reasoning calls enforce the same 16384-token floor so stale lower values cannot exhaust the response budget;
+enrichment settings are unchanged.
 
 ### charts vision provider
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ twag config set scoring.min_score_for_analysis 6
 twag config set scoring.max_article_summary_chars 20000
 ```
 
-New configurations default triage to `deepseek-v4-flash` with reasoning disabled; enrichment settings are unchanged.
+New configurations default triage to `deepseek-v4-flash` with reasoning high; enrichment settings are unchanged.
 
 ### charts vision provider
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,3 +9,4 @@ def test_default_triage_uses_deepseek_v4_flash() -> None:
     assert llm_config["triage_model"] == "deepseek-v4-flash"
     assert llm_config["triage_provider"] == "deepseek"
     assert llm_config["triage_reasoning"] == "high"
+    assert llm_config["triage_max_tokens"] == 16_384

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,4 +8,4 @@ def test_default_triage_uses_deepseek_v4_flash() -> None:
 
     assert llm_config["triage_model"] == "deepseek-v4-flash"
     assert llm_config["triage_provider"] == "deepseek"
-    assert llm_config["triage_reasoning"] == "disabled"
+    assert llm_config["triage_reasoning"] == "high"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -4,6 +4,8 @@ import httpx
 import pytest
 
 from twag.scorer import llm_client
+from twag.scorer.prompts import BATCH_TRIAGE_PROMPT
+from twag.scorer.scoring import TRIAGE_BATCH_SCHEMA
 
 
 class _FakeDeepSeekResponse:
@@ -183,6 +185,65 @@ def test_call_deepseek_uses_json_mode_for_schema_with_reasoning(monkeypatch) -> 
     assert seen["json"]["response_format"] == {"type": "json_object"}
     assert seen["json"]["thinking"] == {"type": "enabled"}
     assert seen["json"]["reasoning_effort"] == "high"
+
+
+def test_call_deepseek_uses_json_mode_for_high_reasoning_triage(monkeypatch) -> None:
+    seen: dict = {}
+    completed: dict = {}
+
+    class TriageJsonResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "choices": [{"message": {"content": '{"items":[]}'}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": 800,
+                    "completion_tokens": 180,
+                    "total_tokens": 980,
+                    "completion_tokens_details": {"reasoning_tokens": 169},
+                },
+            }
+
+    def fake_post(url, *, headers, json, timeout):
+        seen.update(url=url, payload=json, timeout=timeout)
+        return TriageJsonResponse()
+
+    monkeypatch.setattr(llm_client, "get_deepseek_api_key", lambda: "test-key")
+    monkeypatch.setattr(llm_client, "load_config", lambda: {"llm": {}})
+    monkeypatch.setattr(httpx, "post", fake_post)
+    monkeypatch.setattr(llm_client, "begin_llm_usage_attempt", lambda **kwargs: 123)
+    monkeypatch.setattr(
+        llm_client,
+        "complete_llm_usage_attempt",
+        lambda attempt_id, **kwargs: completed.update({"attempt_id": attempt_id, **kwargs}),
+    )
+
+    result = llm_client._call_deepseek(
+        "deepseek-v4-flash",
+        BATCH_TRIAGE_PROMPT,
+        max_tokens=4096,
+        reasoning="high",
+        component="triage",
+        json_schema=TRIAGE_BATCH_SCHEMA,
+        json_tool_name="emit_triage_batch",
+    )
+
+    assert result == '{"items":[]}'
+    assert seen["url"] == "https://api.deepseek.com/chat/completions"
+    assert seen["payload"]["model"] == "deepseek-v4-flash"
+    assert seen["payload"]["messages"] == [{"role": "user", "content": BATCH_TRIAGE_PROMPT}]
+    assert seen["payload"]["max_tokens"] == 4096
+    assert seen["payload"]["thinking"] == {"type": "enabled"}
+    assert seen["payload"]["reasoning_effort"] == "high"
+    assert seen["payload"]["response_format"] == {"type": "json_object"}
+    assert "tools" not in seen["payload"]
+    assert "tool_choice" not in seen["payload"]
+    assert completed["component"] == "triage"
+    assert completed["model"] == "deepseek-v4-flash"
+    assert completed["reasoning_tokens"] == 169
+    assert completed["success"] is True
 
 
 def test_call_deepseek_treats_low_reasoning_as_non_thinking(monkeypatch) -> None:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -3,6 +3,7 @@
 import httpx
 import pytest
 
+from twag.metrics import get_collector
 from twag.scorer import llm_client
 from twag.scorer.prompts import BATCH_TRIAGE_PROMPT
 from twag.scorer.scoring import TRIAGE_BATCH_SCHEMA
@@ -234,7 +235,7 @@ def test_call_deepseek_uses_json_mode_for_high_reasoning_triage(monkeypatch) -> 
     assert seen["url"] == "https://api.deepseek.com/chat/completions"
     assert seen["payload"]["model"] == "deepseek-v4-flash"
     assert seen["payload"]["messages"] == [{"role": "user", "content": BATCH_TRIAGE_PROMPT}]
-    assert seen["payload"]["max_tokens"] == 4096
+    assert seen["payload"]["max_tokens"] == 16_384
     assert seen["payload"]["thinking"] == {"type": "enabled"}
     assert seen["payload"]["reasoning_effort"] == "high"
     assert seen["payload"]["response_format"] == {"type": "json_object"}
@@ -242,8 +243,65 @@ def test_call_deepseek_uses_json_mode_for_high_reasoning_triage(monkeypatch) -> 
     assert "tool_choice" not in seen["payload"]
     assert completed["component"] == "triage"
     assert completed["model"] == "deepseek-v4-flash"
+    assert completed["max_tokens"] == 16_384
     assert completed["reasoning_tokens"] == 169
     assert completed["success"] is True
+
+
+def test_call_deepseek_empty_content_reports_budget_diagnostics(monkeypatch) -> None:
+    completed: dict = {}
+
+    class EmptyContentResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "choices": [{"message": {"content": ""}, "finish_reason": "length"}],
+                "usage": {
+                    "prompt_tokens": 800,
+                    "completion_tokens": 16_384,
+                    "total_tokens": 17_184,
+                    "completion_tokens_details": {"reasoning_tokens": 16_384},
+                },
+            }
+
+    monkeypatch.setattr(llm_client, "get_deepseek_api_key", lambda: "test-key")
+    monkeypatch.setattr(llm_client, "load_config", lambda: {"llm": {}})
+    monkeypatch.setattr(httpx, "post", lambda *args, **kwargs: EmptyContentResponse())
+    monkeypatch.setattr(llm_client, "begin_llm_usage_attempt", lambda **kwargs: 123)
+    monkeypatch.setattr(
+        llm_client,
+        "complete_llm_usage_attempt",
+        lambda attempt_id, **kwargs: completed.update({"attempt_id": attempt_id, **kwargs}),
+    )
+    metrics = get_collector()
+    empty_content_before = metrics.counter_value("scorer.deepseek.empty_content")
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"finish_reason=length, completion_tokens=16384, "
+            r"reasoning_tokens=16384, max_tokens=16384"
+        ),
+    ):
+        llm_client._call_deepseek(
+            "deepseek-v4-flash",
+            BATCH_TRIAGE_PROMPT,
+            max_tokens=4096,
+            reasoning="high",
+            component="triage",
+            json_schema=TRIAGE_BATCH_SCHEMA,
+        )
+
+    assert metrics.counter_value("scorer.deepseek.empty_content") == empty_content_before + 1
+    assert metrics.histogram_stats("scorer.deepseek.empty_content.completion_tokens")["max"] == 16_384
+    assert metrics.histogram_stats("scorer.deepseek.empty_content.reasoning_tokens")["max"] == 16_384
+    assert completed["component"] == "triage"
+    assert completed["max_tokens"] == 16_384
+    assert completed["success"] is False
+    assert completed["metadata"]["finish_reason"] == "length"
+    assert "finish_reason=length" in completed["error_message"]
 
 
 def test_call_deepseek_treats_low_reasoning_as_non_thinking(monkeypatch) -> None:

--- a/tests/test_scoring_prompt.py
+++ b/tests/test_scoring_prompt.py
@@ -69,7 +69,7 @@ def test_high_reasoning_triage_prompt_embeds_complete_json_shape(monkeypatch):
     assert captured["model"] == "deepseek-v4-flash"
     assert captured["kwargs"]["reasoning"] == "high"
     assert captured["kwargs"]["component"] == "triage"
-    assert captured["kwargs"]["max_tokens"] == 4096
+    assert captured["kwargs"]["max_tokens"] == 16_384
     assert captured["kwargs"]["json_schema"] is TRIAGE_BATCH_SCHEMA
     assert "Return a JSON array with one object per tweet, in order:" in captured["prompt"]
     for field in TRIAGE_BATCH_SCHEMA["items"]["required"]:

--- a/tests/test_scoring_prompt.py
+++ b/tests/test_scoring_prompt.py
@@ -47,6 +47,37 @@ def test_prompt_contains_author_context_fund_context_and_categories(monkeypatch)
     assert results[0].catalyst_status is None
 
 
+def test_high_reasoning_triage_prompt_embeds_complete_json_shape(monkeypatch):
+    captured = {}
+
+    def fake_call(provider, model, prompt, **kwargs):
+        captured.update(provider=provider, model=model, prompt=prompt, kwargs=kwargs)
+        return (
+            '[{"id":"1","score":7,"surprise":1,"is_stale_repeat":false,'
+            '"categories":["macro_data"],"themes":["ai-memory"],"playbook_trigger":"none",'
+            '"catalyst":"none","direction":"long","tickers":["MU"],"summary":"fact"}]'
+        )
+
+    monkeypatch.setattr("twag.scorer.scoring._call_llm", fake_call)
+
+    results = triage_tweets_batch(
+        [{"id": "1", "handle": "source", "text": "new print"}],
+        fund_context="LIVE THEMES: ai-memory",
+    )
+
+    assert captured["provider"] == "deepseek"
+    assert captured["model"] == "deepseek-v4-flash"
+    assert captured["kwargs"]["reasoning"] == "high"
+    assert captured["kwargs"]["component"] == "triage"
+    assert captured["kwargs"]["max_tokens"] == 4096
+    assert captured["kwargs"]["json_schema"] is TRIAGE_BATCH_SCHEMA
+    assert "Return a JSON array with one object per tweet, in order:" in captured["prompt"]
+    for field in TRIAGE_BATCH_SCHEMA["items"]["required"]:
+        assert f'"{field}"' in captured["prompt"]
+    assert results[0].tweet_id == "1"
+    assert results[0].summary == "fact"
+
+
 def test_parser_tolerates_old_missing_fields(monkeypatch):
     monkeypatch.setattr(
         "twag.scorer.scoring._call_llm",

--- a/twag/config.py
+++ b/twag/config.py
@@ -15,6 +15,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "triage_model": "deepseek-v4-flash",
         "triage_provider": "deepseek",
         "triage_reasoning": "high",
+        "triage_max_tokens": 16_384,
         "enrichment_model": "gemini-3.1-pro-preview",
         "enrichment_provider": "gemini",
         "vision_model": "gemini-3-flash-preview",

--- a/twag/config.py
+++ b/twag/config.py
@@ -14,7 +14,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "llm": {
         "triage_model": "deepseek-v4-flash",
         "triage_provider": "deepseek",
-        "triage_reasoning": "disabled",
+        "triage_reasoning": "high",
         "enrichment_model": "gemini-3.1-pro-preview",
         "enrichment_provider": "gemini",
         "vision_model": "gemini-3-flash-preview",

--- a/twag/scorer/llm_client.py
+++ b/twag/scorer/llm_client.py
@@ -15,6 +15,7 @@ from twag.db.inference import record_llm_usage as record_llm_usage
 
 _T = TypeVar("_T")
 UsageRecorder = Callable[[dict[str, Any]], None]
+_DEEPSEEK_REASONING_MIN_MAX_TOKENS = 16_384
 
 _NON_RETRYABLE_ERROR_PATTERNS = (
     "api key",
@@ -465,8 +466,11 @@ def _call_deepseek(
     total_tokens = 0
     reasoning_tokens = 0
     cached_tokens = 0
+    finish_reason: str | None = None
     try:
         effort = _normalize_deepseek_reasoning(reasoning)
+        if effort:
+            max_tokens = max(max_tokens, _DEEPSEEK_REASONING_MIN_MAX_TOKENS)
         request_timeout = _configured_llm_timeout_seconds()
         api_key = get_deepseek_api_key()
         payload: dict[str, Any] = {
@@ -567,6 +571,9 @@ def _call_deepseek(
             if isinstance(choices, list) and choices:
                 first_choice = choices[0]
                 if isinstance(first_choice, dict):
+                    raw_finish_reason = first_choice.get("finish_reason")
+                    if isinstance(raw_finish_reason, str):
+                        finish_reason = raw_finish_reason
                     message = first_choice.get("message")
                     if isinstance(message, dict):
                         tool_calls = message.get("tool_calls")
@@ -621,7 +628,14 @@ def _call_deepseek(
                             )
                             return content
 
-        raise RuntimeError("DeepSeek response did not contain message content")
+        m.inc("scorer.deepseek.empty_content")
+        m.observe("scorer.deepseek.empty_content.completion_tokens", output_tokens)
+        m.observe("scorer.deepseek.empty_content.reasoning_tokens", reasoning_tokens)
+        raise RuntimeError(
+            "DeepSeek response did not contain message content "
+            f"(finish_reason={finish_reason or 'unknown'}, completion_tokens={output_tokens}, "
+            f"reasoning_tokens={reasoning_tokens}, max_tokens={max_tokens})",
+        )
     except Exception as exc:
         m.inc("scorer.deepseek.errors")
         _record_llm_usage(
@@ -639,7 +653,11 @@ def _call_deepseek(
             cached_input_tokens=cached_tokens,
             total_tokens=total_tokens,
             error=exc,
-            metadata={"usage": usage} if usage else None,
+            metadata={
+                **({"usage": usage} if usage else {}),
+                **({"finish_reason": finish_reason} if finish_reason else {}),
+            }
+            or None,
         )
         raise
 

--- a/twag/scorer/scoring.py
+++ b/twag/scorer/scoring.py
@@ -288,7 +288,7 @@ def triage_tweets_batch(
     config = load_config()
     model = model or config["llm"]["triage_model"]
     provider = provider or config["llm"].get("triage_provider", "anthropic")
-    max_tokens = int(config["llm"].get("triage_max_tokens") or 4096)
+    max_tokens = int(config["llm"].get("triage_max_tokens") or 16_384)
     reasoning = config["llm"].get("triage_reasoning")
     if provider != "deepseek":
         reasoning = None


### PR DESCRIPTION
## Summary

- change the default DeepSeek V4 Flash triage reasoning from `disabled` to `high`
- set the default `triage_max_tokens` to 16384 and enforce that floor for every reasoning-enabled DeepSeek call
- make empty-content failures report finish reason and token-budget diagnostics in the error ledger and dedicated metrics
- update the README and add prompt, request-shape, budget-floor, and failure-diagnostic regressions

## JSON-mode fidelity

With reasoning enabled, DeepSeek does not receive twag's strict tool schema. The built-in triage prompt already embeds a complete JSON example containing every required `TRIAGE_BATCH_SCHEMA` item field, and the triage parser accepts the documented array response.

The regressions prove both sides of that contract:

- the rendered default triage prompt exposes every required field and parses the response under the Flash/high configuration
- the exact client request sends `thinking: enabled`, `reasoning_effort: high`, `response_format: json_object`, and `max_tokens: 16384`, with no `tools` or `tool_choice`

## Budget safety and diagnostics

The default budget is now 16384. `_call_deepseek` also raises any smaller `max_tokens` value to 16384 whenever reasoning effort is enabled, so a stale deployed value of 4096 cannot exhaust the response budget.

If DeepSeek still returns no content, the raised and persisted error includes `finish_reason`, completion tokens, reasoning tokens, and the effective max-token budget. A dedicated empty-content counter plus completion/reasoning token histograms make the failure distinguishable in process metrics.

Review integration evidence: a production-sized 12-tweet complex batch completed 12/12 with high reasoning at 16384 tokens in 52.6 seconds, versus roughly 6-9 seconds with reasoning disabled. That is within the configured request timeout for the production batch size of 10, but the latency increase is material and will be checked again during deployment.

## Impact

New configurations use high reasoning and a 16384-token budget for Flash triage. The triage model/provider and all enrichment settings remain unchanged. Existing deployed config is unchanged until the post-review deployment step.

## Checks

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q`
